### PR TITLE
v0.8.3: Improve crates.io publishing with better rate limit handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,12 +92,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          # Publish in dependency order with delays for indexing
+          # Publish in dependency order with delays for crates.io rate limiting
           CRATES=(
             "amari-core"
             "amari-tropical"
             "amari-dual"
             "amari-info-geom"
+            "amari-relativistic"
             "amari-enumerative"
             "amari-fusion"
             "amari-automata"
@@ -124,8 +125,8 @@ jobs:
             else
               echo "Publishing $crate version $TARGET_VERSION..."
               cargo publish --allow-dirty || echo "Failed to publish $crate, continuing..."
-              echo "Waiting for crates.io to index $crate..."
-              sleep 30
+              echo "Waiting for crates.io indexing and rate limit reset..."
+              sleep 90
             fi
 
             if [ "$crate" != "amari" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ keywords = ["mathematics", "geometric-algebra", "tropical-algebra", "automatic-d
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "amari-core", version = "0.8.1" }
-amari-tropical = { path = "amari-tropical", version = "0.8.1" }
-amari-dual = { path = "amari-dual", version = "0.8.1" }
-amari-fusion = { path = "amari-fusion", version = "0.8.1" }
-amari-info-geom = { path = "amari-info-geom", version = "0.8.1" }
-amari-automata = { path = "amari-automata", version = "0.8.1" }
-amari-enumerative = { path = "amari-enumerative", version = "0.8.1" }
-amari-relativistic = { path = "amari-relativistic", version = "0.8.1" }
-amari-gpu = { path = "amari-gpu", version = "0.8.1", optional = true }
+amari-core = { path = "amari-core", version = "0.8.3" }
+amari-tropical = { path = "amari-tropical", version = "0.8.3" }
+amari-dual = { path = "amari-dual", version = "0.8.3" }
+amari-fusion = { path = "amari-fusion", version = "0.8.3" }
+amari-info-geom = { path = "amari-info-geom", version = "0.8.3" }
+amari-automata = { path = "amari-automata", version = "0.8.3" }
+amari-enumerative = { path = "amari-enumerative", version = "0.8.3" }
+amari-relativistic = { path = "amari-relativistic", version = "0.8.3" }
+amari-gpu = { path = "amari-gpu", version = "0.8.3", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -41,7 +41,7 @@ members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tr
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.3"
 authors = ["Amari Contributors"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/amari-automata/Cargo.toml
+++ b/amari-automata/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["cellular-automata", "inverse-design", "self-assembly", "geometric-a
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
-amari-dual = { path = "../amari-dual", version = "0.8.1" }
-amari-tropical = { path = "../amari-tropical", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
+amari-dual = { path = "../amari-dual", version = "0.8.3" }
+amari-tropical = { path = "../amari-tropical", version = "0.8.3" }
 num-traits = { workspace = true }
 serde = { workspace = true, optional = true }
 

--- a/amari-dual/Cargo.toml
+++ b/amari-dual/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["automatic-differentiation", "dual-numbers", "calculus", "mathematic
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/amari-enumerative/Cargo.toml
+++ b/amari-enumerative/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["mathematics", "geometry", "enumerative", "intersection", "schubert"
 categories = ["mathematics", "science"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
 num-rational = "0.4"
 num-bigint = "0.4"
 num-traits = { workspace = true }

--- a/amari-fusion/Cargo.toml
+++ b/amari-fusion/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["fusion-system", "algebraic-structures", "mathematics", "composition
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
-amari-dual = { path = "../amari-dual", version = "0.8.1" }
-amari-tropical = { path = "../amari-tropical", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
+amari-dual = { path = "../amari-dual", version = "0.8.3" }
+amari-tropical = { path = "../amari-tropical", version = "0.8.3" }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/amari-gpu/Cargo.toml
+++ b/amari-gpu/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
 # Default to no high-precision for GPU (and WASM compatibility)
-amari-core = { path = "../amari-core", version = "0.8.1", default-features = false, features = ["std", "phantom-types"] }
-amari-info-geom = { path = "../amari-info-geom", version = "0.8.1", default-features = false, features = ["std"] }
-amari-relativistic = { path = "../amari-relativistic", version = "0.8.1", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.8.3", default-features = false, features = ["std", "phantom-types"] }
+amari-info-geom = { path = "../amari-info-geom", version = "0.8.3", default-features = false, features = ["std"] }
+amari-relativistic = { path = "../amari-relativistic", version = "0.8.3", default-features = false, features = ["std", "phantom-types"] }
 wgpu = "0.19"
 futures = "0.3"
 pollster = "0.3"

--- a/amari-info-geom/Cargo.toml
+++ b/amari-info-geom/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["information-geometry", "statistics", "manifolds", "fisher-metric", 
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
 approx = { workspace = true }

--- a/amari-relativistic/Cargo.toml
+++ b/amari-relativistic/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["relativistic-physics", "geometric-algebra", "spacetime", "general-r
 categories = ["mathematics", "science", "simulation", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
 nalgebra = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 num-traits = { workspace = true }

--- a/amari-tropical/Cargo.toml
+++ b/amari-tropical/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["tropical-algebra", "max-plus", "semiring", "mathematics", "optimiza
 categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
-amari-core = { path = "../amari-core", version = "0.8.1" }
+amari-core = { path = "../amari-core", version = "0.8.3" }
 num-traits = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/amari-wasm/Cargo.toml
+++ b/amari-wasm/Cargo.toml
@@ -25,7 +25,7 @@ nalgebra = { workspace = true }
 # Amari dependencies with high-precision explicitly disabled for WASM
 # Note: We must disable default features on ALL dependencies to prevent
 # any transitive enabling of high-precision through the dependency chain
-amari-core = { path = "../amari-core", version = "0.8.1", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.8.3", default-features = false, features = ["std", "phantom-types"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/examples/rust/computer-graphics/Cargo.toml
+++ b/examples/rust/computer-graphics/Cargo.toml
@@ -23,9 +23,9 @@ name = "ray_tracing"
 path = "src/raytracing.rs"
 
 [dependencies]
-amari = { path = "../../../", version = "0.8.1" }
-amari-core = { path = "../../../amari-core", version = "0.8.1" }
-amari-dual = { path = "../../../amari-dual", version = "0.8.1" }
+amari = { path = "../../../", version = "0.8.3" }
+amari-core = { path = "../../../amari-core", version = "0.8.3" }
+amari-dual = { path = "../../../amari-dual", version = "0.8.3" }
 plotters = "0.3"
 rand = "0.8"
 nalgebra = "0.33"

--- a/examples/rust/machine-learning/Cargo.toml
+++ b/examples/rust/machine-learning/Cargo.toml
@@ -23,9 +23,9 @@ name = "verified_learning"
 path = "src/verified_learning.rs"
 
 [dependencies]
-amari = { path = "../../../", version = "0.8.1" }
-amari-core = { path = "../../../amari-core", version = "0.8.1" }
-amari-dual = { path = "../../../amari-dual", version = "0.8.1" }
+amari = { path = "../../../", version = "0.8.3" }
+amari-core = { path = "../../../amari-core", version = "0.8.3" }
+amari-dual = { path = "../../../amari-dual", version = "0.8.3" }
 plotters = "0.3"
 rand = "0.8"
 nalgebra = "0.33"

--- a/examples/rust/physics-simulation/Cargo.toml
+++ b/examples/rust/physics-simulation/Cargo.toml
@@ -23,9 +23,9 @@ name = "quantum_mechanics"
 path = "src/quantum_mechanics.rs"
 
 [dependencies]
-amari = { path = "../../../", version = "0.8.1" }
-amari-core = { path = "../../../amari-core", version = "0.8.1" }
-amari-dual = { path = "../../../amari-dual", version = "0.8.1" }
+amari = { path = "../../../", version = "0.8.3" }
+amari-core = { path = "../../../amari-core", version = "0.8.3" }
+amari-dual = { path = "../../../amari-dual", version = "0.8.3" }
 plotters = "0.3"
 rand = "0.8"
 nalgebra = "0.33"


### PR DESCRIPTION
## Summary
- **Increase sleep time** from 30s to 90s between crate publishes for better rate limit handling
- **Add missing amari-relativistic** to the GitHub Actions publish workflow 
- **Version bump** to 0.8.3 across all workspace crates
- **Resolve publishing bottleneck** that caused only 6/10 crates to publish

## Background
The previous v0.8.2 release successfully published 6 out of 10 crates to crates.io, but hit rate limits that prevented the remaining 4 crates from publishing. This is a common issue with crates.io when publishing multiple crates in a workspace.

## Changes Made

### 1. **Enhanced Rate Limit Handling**
- Increased sleep time from 30 seconds to 90 seconds between publishes
- Updated workflow comments to clarify this is for rate limiting, not just indexing
- This should allow the full publishing pipeline to complete without hitting limits

### 2. **Complete Crate Coverage**  
- Added missing `amari-relativistic` to the CRATES array (was missing in original workflow)
- All 10 crates now included in proper dependency order

### 3. **Version Management**
- Updated workspace version to 0.8.3
- Updated all internal dependency references to 0.8.3
- Maintains consistency across the entire workspace

## Current Status
**✅ Published (6/10):** amari-core, amari-enumerative, amari-gpu, amari-info-geom, amari-relativistic, amari-tropical  
**❌ Pending (4/10):** amari (main), amari-dual, amari-fusion, amari-automata

## Expected Impact
With the 90-second delays, the workflow should successfully publish all remaining crates, bringing the total from 6/10 to 10/10 crates available on crates.io.

## Test Plan
- [x] All 800+ tests pass across workspace
- [x] Pre-commit hooks validate successfully  
- [x] Version references updated consistently
- [x] Workflow syntax validated
- [x] Publishing order maintains dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)