### PR TITLE
Add amari-rewrite foundational ARS/TRS crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,7 @@ jobs:
             "amari-topology"
             "amari-probabilistic"
             "amari-dynamics"
+            "amari-rewrite"
             "amari-gpu"
             "amari-optimization"
             "amari"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ path = "examples/networked_physics.rs"
 required-features = ["deterministic"]
 
 [workspace]
-members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal"]
+members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal", "amari-rewrite"]
 resolver = "2"
 
 [workspace.package]
@@ -104,6 +104,7 @@ amari-topology = { path = "amari-topology", version = "0.22.0" }
 amari-dynamics = { path = "amari-dynamics", version = "0.22.0" }
 amari-cgt = { path = "amari-cgt", version = "0.22.0" }
 amari-surreal = { path = "amari-surreal", version = "0.22.0" }
+amari-rewrite = { path = "amari-rewrite", version = "0.22.0" }
 amari-wasm = { path = "amari-wasm", version = "0.22.0" }
 
 # External dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ amari-topology = { workspace = true, optional = true }
 amari-dynamics = { workspace = true, optional = true }
 amari-cgt = { workspace = true, optional = true }
 amari-surreal = { workspace = true, optional = true }
+amari-rewrite = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -54,10 +55,11 @@ topology = ["dep:amari-topology"]
 dynamics = ["dep:amari-dynamics"]
 cgt = ["dep:amari-cgt", "amari-enumerative/cgt-bridge"]
 surreal = ["dep:amari-surreal", "cgt"]
+rewrite = ["dep:amari-rewrite"]
 # Deterministic mode for networked physics (~10-20% slower but bit-exact)
 deterministic = []
 # Enable all optional crates
-full = ["gpu", "optimization", "flynn", "measure", "calculus", "holographic", "probabilistic", "functional", "topology", "dynamics", "cgt", "surreal"]
+full = ["gpu", "optimization", "flynn", "measure", "calculus", "holographic", "probabilistic", "functional", "topology", "dynamics", "cgt", "surreal", "rewrite"]
 
 [[test]]
 name = "integration"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A unified mathematical computing library featuring geometric algebra, differenti
 - **Probabilistic Contracts**: SMT-LIB2 proof obligation generation, Monte Carlo statistical verification, probabilistic value tracking, and rare event classification
 - **Combinatorial Game Theory** *(v0.22.0 extension focus)*: Short normal-play games, canonical forms, outcome classes, nimbers, and small exact-layer generation via `amari-cgt`
 - **Short Surreal Numbers** *(v0.22.0 extension focus)*: Exact dyadic arithmetic, numeric-game validation, simplest-number construction, and game/value round trips via `amari-surreal`
+- **Rewrite Systems** *(v0.23.0 development focus)*: Abstract rewriting systems, term rewriting systems, bounded inverse search, and anti-unification/rule inference via `amari-rewrite`
 - **GPU Backend Stabilization** *(v0.20.0 baseline)*: Hardware-validated WebGPU acceleration with public API tests, CPU-baseline correctness checks, benchmark/crossover documentation, and explicit GPU-backed vs GPU-recommended guidance
 
 ### GPU Acceleration & Multi-GPU Infrastructure
@@ -145,6 +146,7 @@ amari-network = "0.22.0"
 amari-enumerative = "0.22.0"
 amari-cgt = "0.22.0"         # short combinatorial games + nimbers
 amari-surreal = "0.22.0"    # exact short surreal numbers over numeric games
+amari-rewrite = "0.22.0"    # ARS/TRS rewriting, inverse search, and rule inference
 
 # Probabilistic verification contracts (SMT-LIB2, Monte Carlo)
 amari-flynn = "0.22.0"
@@ -675,6 +677,7 @@ main();
 - `amari-enumerative`: Enumerative geometry, Schubert calculus, WDVV curve counting, matroids, CSM classes, equivariant localization, and stability
 - `amari-optimization`: Gradient-based optimization algorithms
 - `amari-flynn`: Probabilistic verification contracts
+- `amari-rewrite`: Abstract and term rewriting systems, inverse search, and rule inference
 
 **Integration Crates** (consume domain APIs):
 - `amari-gpu`: Multi-GPU acceleration with WebGPU

--- a/amari-probabilistic/src/monte_carlo/mod.rs
+++ b/amari-probabilistic/src/monte_carlo/mod.rs
@@ -159,16 +159,28 @@ where
     where
         F: Fn(&Multivector<P, Q, R>) -> f64,
     {
+        self.estimate_with_rng(f, num_samples, &mut rand::rng())
+    }
+
+    /// Estimate E_target[f(X)] using a caller-provided RNG (for deterministic tests).
+    pub fn estimate_with_rng<F, Rng: rand::Rng>(
+        &self,
+        f: F,
+        num_samples: usize,
+        rng: &mut Rng,
+    ) -> Result<f64>
+    where
+        F: Fn(&Multivector<P, Q, R>) -> f64,
+    {
         if num_samples == 0 {
             return Err(ProbabilisticError::insufficient_samples(1, 0));
         }
 
-        let mut rng = rand::rng();
         let mut weighted_sum = 0.0;
         let mut weight_sum = 0.0;
 
         for _ in 0..num_samples {
-            let x = self.proposal.sample(&mut rng);
+            let x = self.proposal.sample(rng);
 
             let log_target = self.target.log_prob(&x).unwrap_or(f64::NEG_INFINITY);
             let log_proposal = self.proposal.log_prob(&x).unwrap_or(f64::NEG_INFINITY);
@@ -266,13 +278,16 @@ mod tests {
 
     #[test]
     fn test_importance_sampling() {
+        use rand::SeedableRng;
+
         let target =
             GaussianMultivector::<2, 0, 0>::isotropic(Multivector::scalar(2.0), 1.0).unwrap();
         let proposal = GaussianMultivector::<2, 0, 0>::standard();
         let sampler = ImportanceSampler::new(&target, &proposal);
 
-        // Estimate E_target[scalar_part] - should be ~2
-        let estimate = sampler.estimate(|x| x.get(0), 10000).unwrap();
+        // Use a seeded RNG for deterministic results.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let estimate = sampler.estimate_with_rng(|x| x.get(0), 10000, &mut rng).unwrap();
         assert!((estimate - 2.0).abs() < 0.5);
     }
 }

--- a/amari-probabilistic/src/monte_carlo/mod.rs
+++ b/amari-probabilistic/src/monte_carlo/mod.rs
@@ -287,7 +287,9 @@ mod tests {
 
         // Use a seeded RNG for deterministic results.
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let estimate = sampler.estimate_with_rng(|x| x.get(0), 10000, &mut rng).unwrap();
+        let estimate = sampler
+            .estimate_with_rng(|x| x.get(0), 10000, &mut rng)
+            .unwrap();
         assert!((estimate - 2.0).abs() < 0.5);
     }
 }

--- a/amari-rewrite/Cargo.toml
+++ b/amari-rewrite/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "amari-rewrite"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Abstract and term rewriting systems for the Amari library"
+repository = "https://github.com/justinelliottcobb/Amari"
+homepage = "https://github.com/justinelliottcobb/Amari"
+keywords = ["mathematics", "rewriting", "trs", "rules", "synthesis"]
+categories = ["mathematics", "science", "algorithms"]
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true, optional = true }
+amari-network = { workspace = true, optional = true }
+
+[features]
+default = ["std"]
+std = []
+serialize = ["dep:serde"]
+macros = []
+smt = []
+neural = []
+network = ["dep:amari-network", "neural"]

--- a/amari-rewrite/README.md
+++ b/amari-rewrite/README.md
@@ -1,0 +1,27 @@
+# amari-rewrite
+
+Foundational abstract and term rewriting systems for the Amari library.
+
+`amari-rewrite` is a toolkit for building and exploring rewrite systems over
+Amari-owned or user-owned data structures. The 0.23.0 target is a stable
+symbolic core plus explicitly feature-gated experimental research surfaces.
+
+## Stability tiers
+
+Stable/default surface:
+
+- `rewritable`: path/subterm traversal for user-owned data
+- `ars`: abstract rewrite systems over arbitrary rewritable values
+- `trs`: first-order terms, variables, substitutions, matching, and rewrite rules
+- `inverse`: bounded predecessor/backward search
+- `synthesis`: anti-unification and basic rule inference from examples
+
+Experimental feature-gated surfaces:
+
+- `macros`: future derive/helper macro ergonomics
+- `smt`: solver-backed validation and synthesis interfaces
+- `neural`: differentiable/neural rewrite trait scaffolding
+- `network`: optional `amari-network` bridge for rewrite-search guidance
+
+The default crate intentionally avoids external e-graph, SMT, neural, and tensor
+framework dependencies.

--- a/amari-rewrite/README.md
+++ b/amari-rewrite/README.md
@@ -25,3 +25,36 @@ Experimental feature-gated surfaces:
 
 The default crate intentionally avoids external e-graph, SMT, neural, and tensor
 framework dependencies.
+
+
+## Quick start: TRS simplification
+
+```rust
+use amari_rewrite::{trs::{Rule, Term, TermSystem}, RewriteResult};
+
+fn main() -> RewriteResult<()> {
+    let system = TermSystem::new(vec![
+        Rule::new(
+            Term::sym("add", [Term::constant("0"), Term::var("X")]),
+            Term::var("X"),
+        )?,
+    ]);
+
+    let term = Term::sym("add", [Term::constant("0"), Term::constant("a")]);
+    assert_eq!(system.normalize_with_limit(&term, 4)?, Term::constant("a"));
+    Ok(())
+}
+```
+
+## Examples
+
+- `symbolic_simplification.rs`: implement `Rewritable` for a user-owned expression enum.
+- `peano_trs.rs`: normalize Peano-style terms with checked TRS rules.
+- `inverse_search.rs`: enumerate bounded predecessor terms.
+- `infer_rule_from_examples.rs`: infer a basic rewrite rule from positive examples.
+
+Run one with:
+
+```bash
+cargo run -p amari-rewrite --example peano_trs
+```

--- a/amari-rewrite/examples/infer_rule_from_examples.rs
+++ b/amari-rewrite/examples/infer_rule_from_examples.rs
@@ -7,7 +7,10 @@ fn main() -> RewriteResult<()> {
             Term::constant("a"),
         ),
         (
-            Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("a")])]),
+            Term::sym(
+                "add",
+                [Term::constant("0"), Term::sym("s", [Term::constant("a")])],
+            ),
             Term::sym("s", [Term::constant("a")]),
         ),
     ];

--- a/amari-rewrite/examples/infer_rule_from_examples.rs
+++ b/amari-rewrite/examples/infer_rule_from_examples.rs
@@ -1,0 +1,21 @@
+use amari_rewrite::{synthesis::infer_rule, trs::Term, RewriteResult};
+
+fn main() -> RewriteResult<()> {
+    let examples = vec![
+        (
+            Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+            Term::constant("a"),
+        ),
+        (
+            Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("a")])]),
+            Term::sym("s", [Term::constant("a")]),
+        ),
+    ];
+
+    let rule = infer_rule(&examples)?;
+    println!("inferred rule: {:?} -> {:?}", rule.lhs(), rule.rhs());
+
+    assert_eq!(rule.apply_root(&examples[0].0).unwrap(), examples[0].1);
+    assert_eq!(rule.apply_root(&examples[1].0).unwrap(), examples[1].1);
+    Ok(())
+}

--- a/amari-rewrite/examples/inverse_search.rs
+++ b/amari-rewrite/examples/inverse_search.rs
@@ -1,12 +1,14 @@
-use amari_rewrite::{inverse::BackwardSearch, trs::{Rule, Term, TermSystem}, RewriteResult};
+use amari_rewrite::{
+    inverse::BackwardSearch,
+    trs::{Rule, Term, TermSystem},
+    RewriteResult,
+};
 
 fn main() -> RewriteResult<()> {
-    let system = TermSystem::new(vec![
-        Rule::new(
-            Term::sym("add", [Term::constant("0"), Term::var("X")]),
-            Term::var("X"),
-        )?,
-    ]);
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    )?]);
 
     let target = Term::constant("a");
     let predecessors: Vec<_> = BackwardSearch::new(&system, target.clone())
@@ -15,6 +17,9 @@ fn main() -> RewriteResult<()> {
         .collect();
 
     println!("predecessors of {target:?}: {predecessors:?}");
-    assert!(predecessors.contains(&Term::sym("add", [Term::constant("0"), Term::constant("a")])));
+    assert!(predecessors.contains(&Term::sym(
+        "add",
+        [Term::constant("0"), Term::constant("a")]
+    )));
     Ok(())
 }

--- a/amari-rewrite/examples/inverse_search.rs
+++ b/amari-rewrite/examples/inverse_search.rs
@@ -1,0 +1,20 @@
+use amari_rewrite::{inverse::BackwardSearch, trs::{Rule, Term, TermSystem}, RewriteResult};
+
+fn main() -> RewriteResult<()> {
+    let system = TermSystem::new(vec![
+        Rule::new(
+            Term::sym("add", [Term::constant("0"), Term::var("X")]),
+            Term::var("X"),
+        )?,
+    ]);
+
+    let target = Term::constant("a");
+    let predecessors: Vec<_> = BackwardSearch::new(&system, target.clone())
+        .max_depth(1)
+        .max_nodes(16)
+        .collect();
+
+    println!("predecessors of {target:?}: {predecessors:?}");
+    assert!(predecessors.contains(&Term::sym("add", [Term::constant("0"), Term::constant("a")])));
+    Ok(())
+}

--- a/amari-rewrite/examples/peano_trs.rs
+++ b/amari-rewrite/examples/peano_trs.rs
@@ -1,17 +1,24 @@
-use amari_rewrite::{trs::{Rule, Term, TermSystem}, RewriteResult};
+use amari_rewrite::{
+    trs::{Rule, Term, TermSystem},
+    RewriteResult,
+};
 
 fn main() -> RewriteResult<()> {
-    let system = TermSystem::new(vec![
-        Rule::new(
-            Term::sym("add", [Term::constant("0"), Term::var("X")]),
-            Term::var("X"),
-        )?,
-    ]);
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    )?]);
 
-    let term = Term::sym("add", [
-        Term::constant("0"),
-        Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]),
-    ]);
+    let term = Term::sym(
+        "add",
+        [
+            Term::constant("0"),
+            Term::sym(
+                "add",
+                [Term::constant("0"), Term::sym("s", [Term::constant("0")])],
+            ),
+        ],
+    );
 
     let normalized = system.normalize_with_limit(&term, 8)?;
     println!("{term:?} => {normalized:?}");

--- a/amari-rewrite/examples/peano_trs.rs
+++ b/amari-rewrite/examples/peano_trs.rs
@@ -1,0 +1,20 @@
+use amari_rewrite::{trs::{Rule, Term, TermSystem}, RewriteResult};
+
+fn main() -> RewriteResult<()> {
+    let system = TermSystem::new(vec![
+        Rule::new(
+            Term::sym("add", [Term::constant("0"), Term::var("X")]),
+            Term::var("X"),
+        )?,
+    ]);
+
+    let term = Term::sym("add", [
+        Term::constant("0"),
+        Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]),
+    ]);
+
+    let normalized = system.normalize_with_limit(&term, 8)?;
+    println!("{term:?} => {normalized:?}");
+    assert_eq!(normalized, Term::sym("s", [Term::constant("0")]));
+    Ok(())
+}

--- a/amari-rewrite/examples/symbolic_simplification.rs
+++ b/amari-rewrite/examples/symbolic_simplification.rs
@@ -1,4 +1,7 @@
-use amari_rewrite::{ars::{Rule, System}, Rewritable, RewriteError, RewriteResult};
+use amari_rewrite::{
+    ars::{Rule, System},
+    Rewritable, RewriteError, RewriteResult,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Expr {

--- a/amari-rewrite/examples/symbolic_simplification.rs
+++ b/amari-rewrite/examples/symbolic_simplification.rs
@@ -1,0 +1,52 @@
+use amari_rewrite::{ars::{Rule, System}, Rewritable, RewriteError, RewriteResult};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Expr {
+    Lit(i64),
+    Add(Box<Expr>, Box<Expr>),
+}
+
+impl Rewritable for Expr {
+    fn child_count(&self) -> usize {
+        match self {
+            Expr::Lit(_) => 0,
+            Expr::Add(_, _) => 2,
+        }
+    }
+
+    fn child(&self, index: usize) -> Option<&Self> {
+        match self {
+            Expr::Lit(_) => None,
+            Expr::Add(left, right) => match index {
+                0 => Some(left),
+                1 => Some(right),
+                _ => None,
+            },
+        }
+    }
+
+    fn replace_child(&self, index: usize, replacement: Self) -> RewriteResult<Self> {
+        match (self, index) {
+            (Expr::Add(_, right), 0) => Ok(Expr::Add(Box::new(replacement), right.clone())),
+            (Expr::Add(left, _), 1) => Ok(Expr::Add(left.clone(), Box::new(replacement))),
+            _ => Err(RewriteError::InvalidChildIndex { index }),
+        }
+    }
+}
+
+fn main() -> RewriteResult<()> {
+    let system = System::new(vec![Rule::new("add-zero-left", |expr: &Expr| match expr {
+        Expr::Add(left, right) if **left == Expr::Lit(0) => Some((**right).clone()),
+        _ => None,
+    })]);
+
+    let expr = Expr::Add(
+        Box::new(Expr::Lit(0)),
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(42)))),
+    );
+
+    let normalized = system.normalize_with_limit(&expr, 8)?;
+    println!("{expr:?} => {normalized:?}");
+    assert_eq!(normalized, Expr::Lit(42));
+    Ok(())
+}

--- a/amari-rewrite/src/ars/mod.rs
+++ b/amari-rewrite/src/ars/mod.rs
@@ -1,0 +1,184 @@
+//! Abstract rewriting systems over user-owned rewritable values.
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+
+use crate::{Path, Rewritable, RewriteError, RewriteResult};
+
+/// A single abstract rewrite rule over values of type `T`.
+pub struct Rule<T> {
+    name: String,
+    apply: Box<dyn Fn(&T) -> Option<T>>,
+}
+
+impl<T> Rule<T> {
+    /// Create a rule from a name and pure rewrite closure.
+    pub fn new(name: impl Into<String>, apply: impl Fn(&T) -> Option<T> + 'static) -> Self {
+        Self {
+            name: name.into(),
+            apply: Box::new(apply),
+        }
+    }
+
+    /// Rule name for diagnostics and traces.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Try to apply this rule at a root value.
+    pub fn try_apply(&self, term: &T) -> Option<T> {
+        (self.apply)(term)
+    }
+}
+
+/// Strategy used when selecting a single rewrite step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Strategy {
+    /// Try outer positions before inner positions.
+    OuterFirst,
+    /// Try inner positions before outer positions.
+    InnerFirst,
+    /// Try the first rule across positions using outer-first traversal.
+    FirstRule,
+    /// Enumerate all one-step successors rather than choosing one.
+    All,
+}
+
+impl Default for Strategy {
+    fn default() -> Self {
+        Self::OuterFirst
+    }
+}
+
+/// A concrete rewrite step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RewriteStep<T> {
+    /// Rule name that produced the step.
+    pub rule: String,
+    /// Position rewritten.
+    pub path: Path,
+    /// Resulting term.
+    pub result: T,
+}
+
+/// Abstract rewrite system over values of type `T`.
+pub struct System<T> {
+    rules: Vec<Rule<T>>,
+}
+
+impl<T> System<T> {
+    /// Create a system from a list of rules.
+    pub fn new(rules: Vec<Rule<T>>) -> Self {
+        Self { rules }
+    }
+
+    /// Borrow the rules.
+    pub fn rules(&self) -> &[Rule<T>] {
+        &self.rules
+    }
+}
+
+impl<T: Rewritable> System<T> {
+    /// Enumerate every one-step successor under every rule and position.
+    pub fn successors(&self, term: &T) -> RewriteResult<Vec<T>> {
+        let mut out = Vec::new();
+        for path in term.positions() {
+            let Some(subterm) = term.subterm(&path) else {
+                return Err(RewriteError::InvalidPath);
+            };
+            for rule in &self.rules {
+                if let Some(replacement) = rule.try_apply(subterm) {
+                    let rewritten = term.replace_at(&path, replacement)?;
+                    if rewritten != *term {
+                        out.push(rewritten);
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Enumerate detailed one-step successors.
+    pub fn steps(&self, term: &T) -> RewriteResult<Vec<RewriteStep<T>>> {
+        let mut out = Vec::new();
+        for path in term.positions() {
+            let Some(subterm) = term.subterm(&path) else {
+                return Err(RewriteError::InvalidPath);
+            };
+            for rule in &self.rules {
+                if let Some(replacement) = rule.try_apply(subterm) {
+                    let rewritten = term.replace_at(&path, replacement)?;
+                    if rewritten != *term {
+                        out.push(RewriteStep {
+                            rule: rule.name().into(),
+                            path: path.clone(),
+                            result: rewritten,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Apply one rewrite step using `strategy`.
+    pub fn apply_once(&self, term: &T, strategy: Strategy) -> RewriteResult<Option<T>> {
+        let mut positions = term.positions();
+        if matches!(strategy, Strategy::InnerFirst) {
+            positions.reverse();
+        }
+
+        if matches!(strategy, Strategy::FirstRule) {
+            for rule in &self.rules {
+                for path in &positions {
+                    let Some(subterm) = term.subterm(path) else {
+                        return Err(RewriteError::InvalidPath);
+                    };
+                    if let Some(replacement) = rule.try_apply(subterm) {
+                        let rewritten = term.replace_at(path, replacement)?;
+                        if rewritten != *term {
+                            return Ok(Some(rewritten));
+                        }
+                    }
+                }
+            }
+            return Ok(None);
+        }
+
+        for path in positions {
+            let Some(subterm) = term.subterm(&path) else {
+                return Err(RewriteError::InvalidPath);
+            };
+            for rule in &self.rules {
+                if let Some(replacement) = rule.try_apply(subterm) {
+                    let rewritten = term.replace_at(&path, replacement)?;
+                    if rewritten != *term {
+                        return Ok(Some(rewritten));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Normalize with the default outer-first strategy.
+    pub fn normalize(&self, term: &T) -> RewriteResult<T> {
+        self.normalize_with_limit(term, 1024)
+    }
+
+    /// Repeatedly rewrite until a fixed point is reached or the step limit is exhausted.
+    pub fn normalize_with_limit(&self, term: &T, max_steps: usize) -> RewriteResult<T> {
+        let mut current = term.clone();
+        for _ in 0..max_steps {
+            match self.apply_once(&current, Strategy::OuterFirst)? {
+                Some(next) => current = next,
+                None => return Ok(current),
+            }
+        }
+
+        if self.apply_once(&current, Strategy::OuterFirst)?.is_some() {
+            Err(RewriteError::StepLimitReached)
+        } else {
+            Ok(current)
+        }
+    }
+}

--- a/amari-rewrite/src/ars/mod.rs
+++ b/amari-rewrite/src/ars/mod.rs
@@ -4,10 +4,12 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 
 use crate::{Path, Rewritable, RewriteError, RewriteResult};
 
+type RuleFn<T> = dyn Fn(&T) -> Option<T>;
+
 /// A single abstract rewrite rule over values of type `T`.
 pub struct Rule<T> {
     name: String,
-    apply: Box<dyn Fn(&T) -> Option<T>>,
+    apply: Box<RuleFn<T>>,
 }
 
 impl<T> Rule<T> {
@@ -31,9 +33,10 @@ impl<T> Rule<T> {
 }
 
 /// Strategy used when selecting a single rewrite step.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Strategy {
     /// Try outer positions before inner positions.
+    #[default]
     OuterFirst,
     /// Try inner positions before outer positions.
     InnerFirst,
@@ -41,12 +44,6 @@ pub enum Strategy {
     FirstRule,
     /// Enumerate all one-step successors rather than choosing one.
     All,
-}
-
-impl Default for Strategy {
-    fn default() -> Self {
-        Self::OuterFirst
-    }
 }
 
 /// A concrete rewrite step.

--- a/amari-rewrite/src/error.rs
+++ b/amari-rewrite/src/error.rs
@@ -1,0 +1,25 @@
+use alloc::string::String;
+use thiserror::Error;
+
+/// Errors returned by rewrite operations.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum RewriteError {
+    /// A child index is outside the valid range for a node.
+    #[error("invalid child index {index}")]
+    InvalidChildIndex { index: usize },
+    /// A path does not identify a valid subterm.
+    #[error("invalid path")]
+    InvalidPath,
+    /// A rewrite or normalization step limit was reached.
+    #[error("rewrite step limit reached")]
+    StepLimitReached,
+    /// A bounded search node limit was reached.
+    #[error("node limit reached")]
+    NodeLimitReached,
+    /// A rewrite rule failed validation.
+    #[error("invalid rule: {message}")]
+    InvalidRule { message: String },
+}
+
+/// Result type used throughout `amari-rewrite`.
+pub type RewriteResult<T> = Result<T, RewriteError>;

--- a/amari-rewrite/src/inverse/mod.rs
+++ b/amari-rewrite/src/inverse/mod.rs
@@ -1,0 +1,104 @@
+//! Bounded inverse rewriting for term rewriting systems.
+//!
+//! Inverse rewriting is predecessor generation, not a true functional inverse.
+//! A rule `lhs -> rhs` is explored backward by matching `rhs` against a
+//! subterm and instantiating `lhs` with the same substitution.
+
+use alloc::collections::{BTreeSet, VecDeque};
+
+use crate::trs::{match_pattern, Term, TermSystem};
+
+/// Convenience helper returning all bounded predecessors as a vector.
+pub fn predecessors(system: &TermSystem, target: Term, max_depth: usize) -> alloc::vec::Vec<Term> {
+    BackwardSearch::new(system, target)
+        .max_depth(max_depth)
+        .collect()
+}
+
+/// Bounded breadth-first backward search over a `TermSystem`.
+pub struct BackwardSearch<'a> {
+    system: &'a TermSystem,
+    queue: VecDeque<(Term, usize)>,
+    visited: BTreeSet<Term>,
+    max_depth: usize,
+    max_nodes: usize,
+    emitted: usize,
+}
+
+impl<'a> BackwardSearch<'a> {
+    /// Create a search rooted at `target`.
+    pub fn new(system: &'a TermSystem, target: Term) -> Self {
+        let mut queue = VecDeque::new();
+        let mut visited = BTreeSet::new();
+        visited.insert(target.clone());
+        queue.push_back((target, 0));
+
+        Self {
+            system,
+            queue,
+            visited,
+            max_depth: 1,
+            max_nodes: 1024,
+            emitted: 0,
+        }
+    }
+
+    /// Set the maximum backward depth.
+    pub fn max_depth(mut self, max_depth: usize) -> Self {
+        self.max_depth = max_depth;
+        self
+    }
+
+    /// Set the maximum number of emitted predecessor nodes.
+    pub fn max_nodes(mut self, max_nodes: usize) -> Self {
+        self.max_nodes = max_nodes;
+        self
+    }
+
+    fn one_step_predecessors(&self, term: &Term) -> alloc::vec::Vec<Term> {
+        let mut out = alloc::vec::Vec::new();
+        for path in term.positions() {
+            let Some(subterm) = term.subterm(&path) else {
+                continue;
+            };
+
+            for rule in self.system.rules() {
+                if let Some(subst) = match_pattern(rule.rhs(), subterm) {
+                    let predecessor_subterm = subst.apply(rule.lhs());
+                    if let Ok(predecessor) = term.replace_at(&path, predecessor_subterm) {
+                        if predecessor != *term {
+                            out.push(predecessor);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+impl Iterator for BackwardSearch<'_> {
+    type Item = Term;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.emitted >= self.max_nodes {
+            return None;
+        }
+
+        while let Some((term, depth)) = self.queue.pop_front() {
+            if depth >= self.max_depth {
+                continue;
+            }
+
+            for predecessor in self.one_step_predecessors(&term) {
+                if self.visited.insert(predecessor.clone()) {
+                    self.queue.push_back((predecessor.clone(), depth + 1));
+                    self.emitted += 1;
+                    return Some(predecessor);
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate alloc;
 
+pub mod ars;
 pub mod error;
 pub mod prelude;
 pub mod rewritable;

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -18,3 +18,9 @@ pub mod trs;
 
 pub use error::{RewriteError, RewriteResult};
 pub use rewritable::{Path, Rewritable};
+
+#[cfg(feature = "neural")]
+pub mod neural;
+
+#[cfg(feature = "smt")]
+pub mod smt;

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -6,4 +6,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+pub mod error;
 pub mod prelude;
+pub mod rewritable;
+
+pub use error::{RewriteError, RewriteResult};
+pub use rewritable::{Path, Rewritable};

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod inverse;
 pub mod prelude;
 pub mod rewritable;
+pub mod synthesis;
 pub mod trs;
 
 pub use error::{RewriteError, RewriteResult};

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -1,0 +1,9 @@
+//! Abstract and term rewriting systems for Amari.
+//!
+//! `amari-rewrite` provides foundational rewriting tools: abstract rewriting
+//! systems (ARS), first-order term rewriting systems (TRS), bounded inverse
+//! rewriting, and lightweight rule synthesis via anti-unification.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod prelude;

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ars;
 pub mod error;
 pub mod prelude;
 pub mod rewritable;
+pub mod trs;
 
 pub use error::{RewriteError, RewriteResult};
 pub use rewritable::{Path, Rewritable};

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 pub mod ars;
 pub mod error;
+pub mod inverse;
 pub mod prelude;
 pub mod rewritable;
 pub mod trs;

--- a/amari-rewrite/src/lib.rs
+++ b/amari-rewrite/src/lib.rs
@@ -24,3 +24,6 @@ pub mod neural;
 
 #[cfg(feature = "smt")]
 pub mod smt;
+
+#[cfg(feature = "network")]
+pub mod network;

--- a/amari-rewrite/src/network/mod.rs
+++ b/amari-rewrite/src/network/mod.rs
@@ -1,0 +1,31 @@
+//! Experimental `amari-network` bridge for rewrite search guidance.
+//!
+//! Rewrite systems naturally form directed graphs: terms are nodes and rewrite
+//! steps are edges. In 0.23.0 this module only exposes lightweight summaries and
+//! keeps richer `GeometricNetwork` adapters as future experimental work.
+
+/// Summary of a rewrite trace as a graph path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RewriteGraphSummary {
+    /// Number of terms in the trace.
+    pub nodes: usize,
+    /// Number of rewrite transitions in the trace.
+    pub edges: usize,
+}
+
+impl RewriteGraphSummary {
+    /// Summarize a linear rewrite trace.
+    pub fn from_trace<T>(trace: &[T]) -> Self {
+        Self {
+            nodes: trace.len(),
+            edges: trace.len().saturating_sub(1),
+        }
+    }
+}
+
+/// Marker proving this module was compiled with the optional `amari-network`
+/// dependency available.
+pub fn network_bridge_enabled() -> bool {
+    let _ = core::mem::size_of::<Option<amari_network::NodeMetadata>>();
+    true
+}

--- a/amari-rewrite/src/neural/mod.rs
+++ b/amari-rewrite/src/neural/mod.rs
@@ -1,0 +1,21 @@
+//! Experimental neural and differentiable rewrite traits.
+//!
+//! This module is intentionally trait-only in 0.23.0. It keeps the rewrite
+//! architecture open for learned rules and neural inverse rewriting without
+//! choosing a tensor framework or adding heavy default dependencies.
+
+/// A differentiable or learned rewrite rule over a state representation.
+pub trait DifferentiableRule<State> {
+    /// Rule parameters, if any.
+    type Parameters;
+    /// Gradient representation, if any.
+    type Gradient;
+    /// Rule evaluation error.
+    type Error;
+
+    /// Apply the rule forward.
+    fn forward(&self, state: &State) -> Result<State, Self::Error>;
+
+    /// Compute a scalar loss between a prediction and a target.
+    fn loss(&self, predicted: &State, target: &State) -> Result<f64, Self::Error>;
+}

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -1,9 +1,9 @@
 //! Common imports for `amari-rewrite`.
 
-pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
+pub use crate::{Path, Rewritable, RewriteError, RewriteResult};
 
 pub use crate::ars::{Rule, Strategy, System};
-pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};
 pub use crate::inverse::BackwardSearch;
 pub use crate::synthesis::{anti_unify, anti_unify_all};
 pub use crate::synthesis::{infer_rule, infer_rules};
+pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -1,0 +1,1 @@
+//! Common imports for `amari-rewrite`.

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -1,1 +1,3 @@
 //! Common imports for `amari-rewrite`.
+
+pub use crate::{Path, RewriteError, RewriteResult, Rewritable};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -3,3 +3,4 @@
 pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
 
 pub use crate::ars::{Rule, Strategy, System};
+pub use crate::trs::{Substitution, Term};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -6,3 +6,4 @@ pub use crate::ars::{Rule, Strategy, System};
 pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};
 pub use crate::inverse::BackwardSearch;
 pub use crate::synthesis::{anti_unify, anti_unify_all};
+pub use crate::synthesis::{infer_rule, infer_rules};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -1,3 +1,5 @@
 //! Common imports for `amari-rewrite`.
 
 pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
+
+pub use crate::ars::{Rule, Strategy, System};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -5,3 +5,4 @@ pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
 pub use crate::ars::{Rule, Strategy, System};
 pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};
 pub use crate::inverse::BackwardSearch;
+pub use crate::synthesis::{anti_unify, anti_unify_all};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -4,3 +4,4 @@ pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
 
 pub use crate::ars::{Rule, Strategy, System};
 pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};
+pub use crate::inverse::BackwardSearch;

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -3,4 +3,4 @@
 pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
 
 pub use crate::ars::{Rule, Strategy, System};
-pub use crate::trs::{Rule as TrsRule, Substitution, Term};
+pub use crate::trs::{Rule as TrsRule, Substitution, Term, TermSystem};

--- a/amari-rewrite/src/prelude.rs
+++ b/amari-rewrite/src/prelude.rs
@@ -3,4 +3,4 @@
 pub use crate::{Path, RewriteError, RewriteResult, Rewritable};
 
 pub use crate::ars::{Rule, Strategy, System};
-pub use crate::trs::{Substitution, Term};
+pub use crate::trs::{Rule as TrsRule, Substitution, Term};

--- a/amari-rewrite/src/rewritable.rs
+++ b/amari-rewrite/src/rewritable.rs
@@ -1,0 +1,105 @@
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use crate::{RewriteError, RewriteResult};
+
+/// Path from a root term to one of its subterms.
+///
+/// The empty path is the root. Each component is a child index at the current
+/// node.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Path(Vec<usize>);
+
+impl Path {
+    /// Return the root path.
+    pub fn root() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Borrow the path components.
+    pub fn as_slice(&self) -> &[usize] {
+        &self.0
+    }
+
+    /// Return a path extended with one child index.
+    pub fn child(&self, index: usize) -> Self {
+        let mut next = self.0.clone();
+        next.push(index);
+        Self(next)
+    }
+
+    /// Whether this path identifies the root term.
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<const N: usize> From<[usize; N]> for Path {
+    fn from(value: [usize; N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Vec<usize>> for Path {
+    fn from(value: Vec<usize>) -> Self {
+        Self(value)
+    }
+}
+
+/// A recursive value that can be traversed and rebuilt at subterm paths.
+///
+/// Implement this trait for user-owned ASTs or state trees to make them usable
+/// by the abstract rewriting-system layer.
+pub trait Rewritable: Clone + PartialEq + Debug {
+    /// Number of immediate children.
+    fn child_count(&self) -> usize;
+
+    /// Return an immediate child by index.
+    fn child(&self, index: usize) -> Option<&Self>;
+
+    /// Return a new value with one immediate child replaced.
+    fn replace_child(&self, index: usize, replacement: Self) -> RewriteResult<Self>;
+
+    /// Borrow a subterm by path.
+    fn subterm(&self, path: &Path) -> Option<&Self> {
+        let mut current = self;
+        for &index in path.as_slice() {
+            current = current.child(index)?;
+        }
+        Some(current)
+    }
+
+    /// Return a new value with the subterm at `path` replaced.
+    fn replace_at(&self, path: &Path, replacement: Self) -> RewriteResult<Self> {
+        self.replace_at_slice(path.as_slice(), replacement)
+    }
+
+    /// Return all valid positions in preorder, including the root.
+    fn positions(&self) -> Vec<Path> {
+        fn walk<T: Rewritable>(term: &T, path: Path, out: &mut Vec<Path>) {
+            out.push(path.clone());
+            for index in 0..term.child_count() {
+                if let Some(child) = term.child(index) {
+                    walk(child, path.child(index), out);
+                }
+            }
+        }
+
+        let mut out = Vec::new();
+        walk(self, Path::root(), &mut out);
+        out
+    }
+
+    fn replace_at_slice(&self, path: &[usize], replacement: Self) -> RewriteResult<Self> {
+        match path.split_first() {
+            None => Ok(replacement),
+            Some((&index, rest)) => {
+                let child = self
+                    .child(index)
+                    .ok_or(RewriteError::InvalidChildIndex { index })?;
+                let replaced_child = child.replace_at_slice(rest, replacement)?;
+                self.replace_child(index, replaced_child)
+            }
+        }
+    }
+}

--- a/amari-rewrite/src/smt/mod.rs
+++ b/amari-rewrite/src/smt/mod.rs
@@ -1,0 +1,22 @@
+//! Experimental SMT/solver integration traits.
+//!
+//! This module defines solver-facing interfaces without committing 0.23.0 to a
+//! concrete SMT backend. Future implementations can use these traits for
+//! equivalence proofs, rule validation, or solver-backed synthesis.
+
+/// Interface for solver-backed rewrite validation.
+pub trait RewriteSolver {
+    /// Solver term representation.
+    type Term;
+    /// Proof or validation certificate.
+    type Certificate;
+    /// Solver error.
+    type Error;
+
+    /// Prove or validate equivalence of two terms.
+    fn prove_equivalent(
+        &self,
+        lhs: &Self::Term,
+        rhs: &Self::Term,
+    ) -> Result<Self::Certificate, Self::Error>;
+}

--- a/amari-rewrite/src/synthesis/anti_unify.rs
+++ b/amari-rewrite/src/synthesis/anti_unify.rs
@@ -1,0 +1,73 @@
+//! Anti-unification for first-order terms.
+//!
+//! Anti-unification computes a most-specific generalization of terms. Fresh
+//! variables mark positions where input terms disagree.
+
+use alloc::{format, vec::Vec};
+
+use crate::trs::Term;
+
+/// Fresh variable generator for anti-unification.
+#[derive(Clone, Debug, Default)]
+pub struct VarGen {
+    next: usize,
+}
+
+impl VarGen {
+    /// Create a new generator.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a fresh generated variable term.
+    pub fn fresh(&mut self) -> Term {
+        let name = format!("_G{}", self.next);
+        self.next += 1;
+        Term::var(name)
+    }
+
+    /// Anti-unify two terms using this generator.
+    pub fn anti_unify(&mut self, left: &Term, right: &Term) -> Term {
+        if left == right {
+            return left.clone();
+        }
+
+        match (left, right) {
+            (Term::Sym(left_symbol, left_args), Term::Sym(right_symbol, right_args))
+                if left_symbol == right_symbol && left_args.len() == right_args.len() =>
+            {
+                Term::Sym(
+                    left_symbol.clone(),
+                    left_args
+                        .iter()
+                        .zip(right_args)
+                        .map(|(left_arg, right_arg)| self.anti_unify(left_arg, right_arg))
+                        .collect(),
+                )
+            }
+            _ => self.fresh(),
+        }
+    }
+}
+
+/// Anti-unify two terms.
+pub fn anti_unify(left: &Term, right: &Term) -> Term {
+    VarGen::new().anti_unify(left, right)
+}
+
+/// Anti-unify a non-empty slice of terms.
+pub fn anti_unify_all(terms: &[Term]) -> Option<Term> {
+    let mut iter = terms.iter();
+    let mut current = iter.next()?.clone();
+    let mut var_gen = VarGen::new();
+    for term in iter {
+        current = var_gen.anti_unify(&current, term);
+    }
+    Some(current)
+}
+
+/// Anti-unify all terms from an iterator by collecting them first.
+pub fn anti_unify_iter(terms: impl IntoIterator<Item = Term>) -> Option<Term> {
+    let terms: Vec<Term> = terms.into_iter().collect();
+    anti_unify_all(&terms)
+}

--- a/amari-rewrite/src/synthesis/inference.rs
+++ b/amari-rewrite/src/synthesis/inference.rs
@@ -2,7 +2,10 @@
 
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use crate::{trs::{Rule, Term, Variable}, RewriteError, RewriteResult};
+use crate::{
+    trs::{Rule, Term, Variable},
+    RewriteError, RewriteResult,
+};
 
 /// Infer a single checked TRS rule from positive `(before, after)` examples.
 ///
@@ -21,8 +24,12 @@ pub fn infer_rule(examples: &[(Term, Term)]) -> RewriteResult<Rule> {
     let mut generalizer = PairGeneralizer::new();
     let lhs_terms: Vec<Term> = examples.iter().map(|(lhs, _)| lhs.clone()).collect();
     let rhs_terms: Vec<Term> = examples.iter().map(|(_, rhs)| rhs.clone()).collect();
-    let lhs = generalizer.anti_unify_all(&lhs_terms).expect("non-empty lhs terms");
-    let rhs = generalizer.anti_unify_all(&rhs_terms).expect("non-empty rhs terms");
+    let lhs = generalizer
+        .anti_unify_all(&lhs_terms)
+        .expect("non-empty lhs terms");
+    let rhs = generalizer
+        .anti_unify_all(&rhs_terms)
+        .expect("non-empty rhs terms");
 
     Rule::new(lhs, rhs)
 }

--- a/amari-rewrite/src/synthesis/inference.rs
+++ b/amari-rewrite/src/synthesis/inference.rs
@@ -1,0 +1,116 @@
+//! Rule inference from example rewrite steps.
+
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+use crate::{trs::{Rule, Term, Variable}, RewriteError, RewriteResult};
+
+/// Infer a single checked TRS rule from positive `(before, after)` examples.
+///
+/// This lightweight 0.23.0 inference path anti-unifies the before terms and
+/// the after terms with a shared disagreement table. Shared concrete
+/// disagreements across the left and right side therefore receive the same
+/// generated variable, which is enough for common algebraic identities such as
+/// `add(0, X) -> X`.
+pub fn infer_rule(examples: &[(Term, Term)]) -> RewriteResult<Rule> {
+    if examples.is_empty() {
+        return Err(RewriteError::InvalidRule {
+            message: String::from("cannot infer a rule from empty examples"),
+        });
+    }
+
+    let mut generalizer = PairGeneralizer::new();
+    let lhs_terms: Vec<Term> = examples.iter().map(|(lhs, _)| lhs.clone()).collect();
+    let rhs_terms: Vec<Term> = examples.iter().map(|(_, rhs)| rhs.clone()).collect();
+    let lhs = generalizer.anti_unify_all(&lhs_terms).expect("non-empty lhs terms");
+    let rhs = generalizer.anti_unify_all(&rhs_terms).expect("non-empty rhs terms");
+
+    Rule::new(lhs, rhs)
+}
+
+/// Infer one or more rules from positive and negative examples.
+///
+/// The first 0.23.0 implementation returns the positive-example rule when it
+/// does not reproduce any negative example. More complete specialization is
+/// intentionally deferred.
+pub fn infer_rules(
+    positives: &[(Term, Term)],
+    negatives: &[(Term, Term)],
+) -> RewriteResult<Vec<Rule>> {
+    let rule = infer_rule(positives)?;
+    let covers_negative = negatives.iter().any(|(lhs, rhs)| {
+        rule.apply_root(lhs)
+            .map(|produced| produced == *rhs)
+            .unwrap_or(false)
+    });
+
+    if covers_negative {
+        return Err(RewriteError::InvalidRule {
+            message: String::from("inferred rule covers a negative example"),
+        });
+    }
+
+    Ok(vec![rule])
+}
+
+#[derive(Clone, Debug, Default)]
+struct PairGeneralizer {
+    next: usize,
+    disagreements: BTreeMap<(Term, Term), Variable>,
+}
+
+impl PairGeneralizer {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn anti_unify_all(&mut self, terms: &[Term]) -> Option<Term> {
+        let mut iter = terms.iter();
+        let mut current = iter.next()?.clone();
+        for term in iter {
+            current = self.anti_unify(&current, term);
+        }
+        Some(current)
+    }
+
+    fn anti_unify(&mut self, left: &Term, right: &Term) -> Term {
+        if left == right {
+            return left.clone();
+        }
+
+        match (left, right) {
+            (Term::Sym(left_symbol, left_args), Term::Sym(right_symbol, right_args))
+                if left_symbol == right_symbol && left_args.len() == right_args.len() =>
+            {
+                Term::Sym(
+                    left_symbol.clone(),
+                    left_args
+                        .iter()
+                        .zip(right_args)
+                        .map(|(left_arg, right_arg)| self.anti_unify(left_arg, right_arg))
+                        .collect(),
+                )
+            }
+            _ => Term::Var(self.variable_for(left, right)),
+        }
+    }
+
+    fn variable_for(&mut self, left: &Term, right: &Term) -> Variable {
+        let key = (left.clone(), right.clone());
+        if let Some(var) = self.disagreements.get(&key) {
+            return var.clone();
+        }
+
+        let var = Variable::new(format_alloc("_I", self.next));
+        self.next += 1;
+        self.disagreements.insert(key, var.clone());
+        var
+    }
+}
+
+fn format_alloc(prefix: &str, index: usize) -> String {
+    let mut out = String::from(prefix);
+    // Avoid requiring std formatting machinery in this small no_std-friendly helper.
+    let digits = index.to_string();
+    out.push_str(&digits);
+    out
+}

--- a/amari-rewrite/src/synthesis/mod.rs
+++ b/amari-rewrite/src/synthesis/mod.rs
@@ -1,0 +1,5 @@
+//! Lightweight rule synthesis helpers.
+
+mod anti_unify;
+
+pub use anti_unify::{anti_unify, anti_unify_all, anti_unify_iter, VarGen};

--- a/amari-rewrite/src/synthesis/mod.rs
+++ b/amari-rewrite/src/synthesis/mod.rs
@@ -1,5 +1,7 @@
 //! Lightweight rule synthesis helpers.
 
 mod anti_unify;
+mod inference;
 
 pub use anti_unify::{anti_unify, anti_unify_all, anti_unify_iter, VarGen};
+pub use inference::{infer_rule, infer_rules};

--- a/amari-rewrite/src/trs/matching.rs
+++ b/amari-rewrite/src/trs/matching.rs
@@ -1,0 +1,33 @@
+//! Pattern matching for first-order terms.
+
+use super::{Substitution, Term};
+
+/// Match a pattern against a term, returning a consistent substitution.
+///
+/// Variables in `pattern` may bind to arbitrary subterms in `term`. Repeated
+/// occurrences of a variable must bind to the same term.
+pub fn match_pattern(pattern: &Term, term: &Term) -> Option<Substitution> {
+    let mut subst = Substitution::new();
+    match_into(pattern, term, &mut subst).then_some(subst)
+}
+
+fn match_into(pattern: &Term, term: &Term, subst: &mut Substitution) -> bool {
+    match (pattern, term) {
+        (Term::Var(var), _) => match subst.get_var(var) {
+            Some(existing) => existing == term,
+            None => {
+                subst.insert(var.clone(), term.clone());
+                true
+            }
+        },
+        (Term::Sym(pattern_symbol, pattern_args), Term::Sym(term_symbol, term_args)) => {
+            pattern_symbol == term_symbol
+                && pattern_args.len() == term_args.len()
+                && pattern_args
+                    .iter()
+                    .zip(term_args)
+                    .all(|(pattern_arg, term_arg)| match_into(pattern_arg, term_arg, subst))
+        }
+        _ => false,
+    }
+}

--- a/amari-rewrite/src/trs/mod.rs
+++ b/amari-rewrite/src/trs/mod.rs
@@ -1,7 +1,11 @@
 //! Term rewriting systems.
 
+mod matching;
+mod rule;
 mod substitution;
 mod term;
 
+pub use matching::match_pattern;
+pub use rule::Rule;
 pub use substitution::Substitution;
 pub use term::{Symbol, Term, Variable};

--- a/amari-rewrite/src/trs/mod.rs
+++ b/amari-rewrite/src/trs/mod.rs
@@ -3,9 +3,11 @@
 mod matching;
 mod rule;
 mod substitution;
+mod system;
 mod term;
 
 pub use matching::match_pattern;
 pub use rule::Rule;
 pub use substitution::Substitution;
+pub use system::TermSystem;
 pub use term::{Symbol, Term, Variable};

--- a/amari-rewrite/src/trs/mod.rs
+++ b/amari-rewrite/src/trs/mod.rs
@@ -1,0 +1,7 @@
+//! Term rewriting systems.
+
+mod substitution;
+mod term;
+
+pub use substitution::Substitution;
+pub use term::{Symbol, Term, Variable};

--- a/amari-rewrite/src/trs/rule.rs
+++ b/amari-rewrite/src/trs/rule.rs
@@ -1,0 +1,64 @@
+//! Term rewrite rules.
+
+use alloc::{collections::BTreeSet, string::String};
+
+use crate::{RewriteError, RewriteResult};
+
+use super::{match_pattern, Substitution, Term, Variable};
+
+/// A first-order term rewrite rule `lhs -> rhs`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Rule {
+    lhs: Term,
+    rhs: Term,
+}
+
+impl Rule {
+    /// Create a checked rule.
+    ///
+    /// All variables in the RHS must occur in the LHS.
+    pub fn new(lhs: Term, rhs: Term) -> RewriteResult<Self> {
+        let lhs_vars: BTreeSet<Variable> = lhs.variables().into_iter().collect();
+        let rhs_vars = rhs.variables();
+        if let Some(missing) = rhs_vars.iter().find(|var| !lhs_vars.contains(*var)) {
+            return Err(RewriteError::InvalidRule {
+                message: format_alloc("rhs variable ", missing.as_str(), " does not occur in lhs"),
+            });
+        }
+        Ok(Self { lhs, rhs })
+    }
+
+    /// Create a rule without RHS variable validation.
+    pub fn new_unchecked(lhs: Term, rhs: Term) -> Self {
+        Self { lhs, rhs }
+    }
+
+    /// Borrow the left-hand side pattern.
+    pub fn lhs(&self) -> &Term {
+        &self.lhs
+    }
+
+    /// Borrow the right-hand side template.
+    pub fn rhs(&self) -> &Term {
+        &self.rhs
+    }
+
+    /// Match the LHS against `term`.
+    pub fn matches(&self, term: &Term) -> Option<Substitution> {
+        match_pattern(&self.lhs, term)
+    }
+
+    /// Apply this rule at the root of `term`.
+    pub fn apply_root(&self, term: &Term) -> Option<Term> {
+        let subst = self.matches(term)?;
+        Some(subst.apply(&self.rhs))
+    }
+}
+
+fn format_alloc(prefix: &str, value: &str, suffix: &str) -> String {
+    let mut out = String::new();
+    out.push_str(prefix);
+    out.push_str(value);
+    out.push_str(suffix);
+    out
+}

--- a/amari-rewrite/src/trs/substitution.rs
+++ b/amari-rewrite/src/trs/substitution.rs
@@ -45,14 +45,11 @@ impl Substitution {
     /// Apply this substitution recursively to `term`.
     pub fn apply(&self, term: &Term) -> Term {
         match term {
-            Term::Var(var) => self
-                .map
-                .get(var)
-                .cloned()
-                .unwrap_or_else(|| term.clone()),
-            Term::Sym(symbol, args) => {
-                Term::Sym(symbol.clone(), args.iter().map(|arg| self.apply(arg)).collect())
-            }
+            Term::Var(var) => self.map.get(var).cloned().unwrap_or_else(|| term.clone()),
+            Term::Sym(symbol, args) => Term::Sym(
+                symbol.clone(),
+                args.iter().map(|arg| self.apply(arg)).collect(),
+            ),
         }
     }
 }

--- a/amari-rewrite/src/trs/substitution.rs
+++ b/amari-rewrite/src/trs/substitution.rs
@@ -1,0 +1,58 @@
+//! Substitutions for first-order terms.
+
+use alloc::{collections::BTreeMap, string::String};
+
+use super::{Term, Variable};
+
+/// A variable-to-term substitution.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Substitution {
+    map: BTreeMap<Variable, Term>,
+}
+
+impl Substitution {
+    /// Create an empty substitution.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a binding, returning the updated substitution.
+    pub fn with(mut self, variable: impl Into<Variable>, term: Term) -> Self {
+        self.insert(variable, term);
+        self
+    }
+
+    /// Insert or replace a binding.
+    pub fn insert(&mut self, variable: impl Into<Variable>, term: Term) -> Option<Term> {
+        self.map.insert(variable.into(), term)
+    }
+
+    /// Borrow a binding by variable.
+    pub fn get(&self, variable: &str) -> Option<&Term> {
+        self.map.get(&Variable::new(String::from(variable)))
+    }
+
+    /// Borrow a binding by typed variable.
+    pub fn get_var(&self, variable: &Variable) -> Option<&Term> {
+        self.map.get(variable)
+    }
+
+    /// Iterate bindings.
+    pub fn iter(&self) -> impl Iterator<Item = (&Variable, &Term)> {
+        self.map.iter()
+    }
+
+    /// Apply this substitution recursively to `term`.
+    pub fn apply(&self, term: &Term) -> Term {
+        match term {
+            Term::Var(var) => self
+                .map
+                .get(var)
+                .cloned()
+                .unwrap_or_else(|| term.clone()),
+            Term::Sym(symbol, args) => {
+                Term::Sym(symbol.clone(), args.iter().map(|arg| self.apply(arg)).collect())
+            }
+        }
+    }
+}

--- a/amari-rewrite/src/trs/system.rs
+++ b/amari-rewrite/src/trs/system.rs
@@ -1,0 +1,92 @@
+//! Term rewriting-system normalization.
+
+use alloc::vec::Vec;
+
+use crate::{Path, RewriteError, RewriteResult};
+
+use super::{Rule, Term};
+
+/// A first-order term rewriting system.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TermSystem {
+    rules: Vec<Rule>,
+}
+
+impl TermSystem {
+    /// Create a term system from checked TRS rules.
+    pub fn new(rules: Vec<Rule>) -> Self {
+        Self { rules }
+    }
+
+    /// Borrow the rules.
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
+    }
+
+    /// Enumerate one-step successors for every rule at every position.
+    pub fn successors(&self, term: &Term) -> RewriteResult<Vec<Term>> {
+        let mut out = Vec::new();
+        for path in term.positions() {
+            let Some(subterm) = term.subterm(&path) else {
+                return Err(RewriteError::InvalidPath);
+            };
+            for rule in &self.rules {
+                if let Some(replacement) = rule.apply_root(subterm) {
+                    let rewritten = term.replace_at(&path, replacement)?;
+                    if rewritten != *term {
+                        out.push(rewritten);
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Apply the first outermost one-step rewrite.
+    pub fn apply_once(&self, term: &Term) -> RewriteResult<Option<Term>> {
+        for path in term.positions() {
+            if let Some(next) = self.apply_once_at(term, &path)? {
+                return Ok(Some(next));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Apply the first matching rule at a specific path.
+    pub fn apply_once_at(&self, term: &Term, path: &Path) -> RewriteResult<Option<Term>> {
+        let Some(subterm) = term.subterm(path) else {
+            return Err(RewriteError::InvalidPath);
+        };
+        for rule in &self.rules {
+            if let Some(replacement) = rule.apply_root(subterm) {
+                let rewritten = term.replace_at(path, replacement)?;
+                if rewritten != *term {
+                    return Ok(Some(rewritten));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Normalize with a conservative default step limit.
+    pub fn normalize(&self, term: &Term) -> RewriteResult<Term> {
+        self.normalize_with_limit(term, 1024)
+    }
+
+    /// Normalize until fixed point or step limit.
+    pub fn normalize_with_limit(&self, term: &Term, max_steps: usize) -> RewriteResult<Term> {
+        let mut current = term.clone();
+        for _ in 0..max_steps {
+            match self.apply_once(&current)? {
+                Some(next) => current = next,
+                None => return Ok(current),
+            }
+        }
+
+        if self.apply_once(&current)?.is_some() {
+            Err(RewriteError::StepLimitReached)
+        } else {
+            Ok(current)
+        }
+    }
+}

--- a/amari-rewrite/src/trs/term.rs
+++ b/amari-rewrite/src/trs/term.rs
@@ -1,0 +1,175 @@
+//! First-order terms for term rewriting systems.
+
+use alloc::{string::String, vec::Vec};
+use core::fmt;
+
+use crate::{Path, Rewritable, RewriteError, RewriteResult};
+
+/// A first-order pattern variable.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Variable(String);
+
+impl Variable {
+    /// Create a variable from a name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Borrow the variable name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Variable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for Variable {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for Variable {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// A first-order function or constant symbol.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Symbol(String);
+
+impl Symbol {
+    /// Create a symbol from a name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Borrow the symbol name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for Symbol {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for Symbol {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// A first-order term.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Term {
+    /// Pattern variable.
+    Var(Variable),
+    /// Function symbol with zero or more arguments.
+    Sym(Symbol, Vec<Term>),
+}
+
+impl Term {
+    /// Construct a variable term.
+    pub fn var(name: impl Into<Variable>) -> Self {
+        Self::Var(name.into())
+    }
+
+    /// Construct a constant symbol.
+    pub fn constant(name: impl Into<Symbol>) -> Self {
+        Self::Sym(name.into(), Vec::new())
+    }
+
+    /// Construct a symbol with arguments.
+    pub fn sym(name: impl Into<Symbol>, args: impl IntoIterator<Item = Term>) -> Self {
+        Self::Sym(name.into(), args.into_iter().collect())
+    }
+
+    /// Return true for variables.
+    pub fn is_var(&self) -> bool {
+        matches!(self, Self::Var(_))
+    }
+
+    /// Number of immediate arguments.
+    pub fn arity(&self) -> usize {
+        match self {
+            Self::Var(_) => 0,
+            Self::Sym(_, args) => args.len(),
+        }
+    }
+
+    /// Borrow all valid positions in preorder.
+    pub fn positions(&self) -> Vec<Path> {
+        <Self as Rewritable>::positions(self)
+    }
+
+    /// Borrow a subterm by path.
+    pub fn subterm(&self, path: &Path) -> Option<&Self> {
+        <Self as Rewritable>::subterm(self, path)
+    }
+
+    /// Return a new term with a subterm replaced.
+    pub fn replace_at(&self, path: &Path, replacement: Self) -> RewriteResult<Self> {
+        <Self as Rewritable>::replace_at(self, path, replacement)
+    }
+
+    /// Collect variables occurring in this term.
+    pub fn variables(&self) -> Vec<Variable> {
+        let mut vars = Vec::new();
+        self.collect_variables(&mut vars);
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+
+    fn collect_variables(&self, vars: &mut Vec<Variable>) {
+        match self {
+            Self::Var(var) => vars.push(var.clone()),
+            Self::Sym(_, args) => {
+                for arg in args {
+                    arg.collect_variables(vars);
+                }
+            }
+        }
+    }
+}
+
+impl Rewritable for Term {
+    fn child_count(&self) -> usize {
+        self.arity()
+    }
+
+    fn child(&self, index: usize) -> Option<&Self> {
+        match self {
+            Self::Var(_) => None,
+            Self::Sym(_, args) => args.get(index),
+        }
+    }
+
+    fn replace_child(&self, index: usize, replacement: Self) -> RewriteResult<Self> {
+        match self {
+            Self::Var(_) => Err(RewriteError::InvalidChildIndex { index }),
+            Self::Sym(symbol, args) => {
+                if index >= args.len() {
+                    return Err(RewriteError::InvalidChildIndex { index });
+                }
+                let mut next = args.clone();
+                next[index] = replacement;
+                Ok(Self::Sym(symbol.clone(), next))
+            }
+        }
+    }
+}

--- a/amari-rewrite/tests/anti_unification.rs
+++ b/amari-rewrite/tests/anti_unification.rs
@@ -1,0 +1,27 @@
+use amari_rewrite::{synthesis::anti_unify, trs::{match_pattern, Term}};
+
+#[test]
+fn identical_terms_generalize_to_themselves() {
+    let zero = Term::constant("0");
+    assert_eq!(anti_unify(&zero, &zero), zero);
+}
+
+#[test]
+fn nested_terms_generalize_at_disagreement() {
+    let a = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
+    let b = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::sym("s", [Term::constant("0")])])]);
+
+    let generalized = anti_unify(&a, &b);
+
+    match &generalized {
+        Term::Sym(symbol, args) => {
+            assert_eq!(symbol.as_str(), "add");
+            assert_eq!(args[0], Term::constant("0"));
+            assert!(matches!(&args[1], Term::Sym(s, inner) if s.as_str() == "s" && matches!(inner[0], Term::Var(_))));
+        }
+        _ => panic!("expected symbolic generalization"),
+    }
+
+    assert!(match_pattern(&generalized, &a).is_some());
+    assert!(match_pattern(&generalized, &b).is_some());
+}

--- a/amari-rewrite/tests/anti_unification.rs
+++ b/amari-rewrite/tests/anti_unification.rs
@@ -1,4 +1,7 @@
-use amari_rewrite::{synthesis::anti_unify, trs::{match_pattern, Term}};
+use amari_rewrite::{
+    synthesis::anti_unify,
+    trs::{match_pattern, Term},
+};
 
 #[test]
 fn identical_terms_generalize_to_themselves() {
@@ -8,8 +11,17 @@ fn identical_terms_generalize_to_themselves() {
 
 #[test]
 fn nested_terms_generalize_at_disagreement() {
-    let a = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
-    let b = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::sym("s", [Term::constant("0")])])]);
+    let a = Term::sym(
+        "add",
+        [Term::constant("0"), Term::sym("s", [Term::constant("0")])],
+    );
+    let b = Term::sym(
+        "add",
+        [
+            Term::constant("0"),
+            Term::sym("s", [Term::sym("s", [Term::constant("0")])]),
+        ],
+    );
 
     let generalized = anti_unify(&a, &b);
 
@@ -17,7 +29,9 @@ fn nested_terms_generalize_at_disagreement() {
         Term::Sym(symbol, args) => {
             assert_eq!(symbol.as_str(), "add");
             assert_eq!(args[0], Term::constant("0"));
-            assert!(matches!(&args[1], Term::Sym(s, inner) if s.as_str() == "s" && matches!(inner[0], Term::Var(_))));
+            assert!(
+                matches!(&args[1], Term::Sym(s, inner) if s.as_str() == "s" && matches!(inner[0], Term::Var(_)))
+            );
         }
         _ => panic!("expected symbolic generalization"),
     }

--- a/amari-rewrite/tests/ars_system.rs
+++ b/amari-rewrite/tests/ars_system.rs
@@ -1,4 +1,7 @@
-use amari_rewrite::{ars::{Rule, System}, Rewritable};
+use amari_rewrite::{
+    ars::{Rule, System},
+    Rewritable,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Expr {

--- a/amari-rewrite/tests/ars_system.rs
+++ b/amari-rewrite/tests/ars_system.rs
@@ -1,0 +1,66 @@
+use amari_rewrite::{ars::{Rule, System}, Rewritable};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Expr {
+    Lit(i64),
+    Add(Box<Expr>, Box<Expr>),
+}
+
+impl Rewritable for Expr {
+    fn child_count(&self) -> usize {
+        match self {
+            Expr::Lit(_) => 0,
+            Expr::Add(_, _) => 2,
+        }
+    }
+
+    fn child(&self, index: usize) -> Option<&Self> {
+        match self {
+            Expr::Lit(_) => None,
+            Expr::Add(left, right) => match index {
+                0 => Some(left),
+                1 => Some(right),
+                _ => None,
+            },
+        }
+    }
+
+    fn replace_child(&self, index: usize, replacement: Self) -> amari_rewrite::RewriteResult<Self> {
+        match (self, index) {
+            (Expr::Add(_, right), 0) => Ok(Expr::Add(Box::new(replacement), right.clone())),
+            (Expr::Add(left, _), 1) => Ok(Expr::Add(left.clone(), Box::new(replacement))),
+            _ => Err(amari_rewrite::RewriteError::InvalidChildIndex { index }),
+        }
+    }
+}
+
+#[test]
+fn normalize_applies_rule_until_fixed_point() {
+    let system = System::new(vec![Rule::new("add-zero-left", |expr: &Expr| match expr {
+        Expr::Add(left, right) if **left == Expr::Lit(0) => Some((**right).clone()),
+        _ => None,
+    })]);
+
+    let expr = Expr::Add(
+        Box::new(Expr::Lit(0)),
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(5)))),
+    );
+
+    assert_eq!(system.normalize_with_limit(&expr, 8).unwrap(), Expr::Lit(5));
+}
+
+#[test]
+fn all_successors_returns_every_one_step_rewrite() {
+    let system = System::new(vec![Rule::new("add-zero-left", |expr: &Expr| match expr {
+        Expr::Add(left, right) if **left == Expr::Lit(0) => Some((**right).clone()),
+        _ => None,
+    })]);
+
+    let expr = Expr::Add(
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(1)))),
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(2)))),
+    );
+
+    let successors = system.successors(&expr).unwrap();
+    assert_eq!(successors.len(), 2);
+}

--- a/amari-rewrite/tests/experimental_features.rs
+++ b/amari-rewrite/tests/experimental_features.rs
@@ -11,7 +11,9 @@ fn differentiable_rule_trait_can_be_implemented() {
         type Gradient = ();
         type Error = core::convert::Infallible;
 
-        fn forward(&self, state: &f64) -> Result<f64, Self::Error> { Ok(*state) }
+        fn forward(&self, state: &f64) -> Result<f64, Self::Error> {
+            Ok(*state)
+        }
         fn loss(&self, predicted: &f64, target: &f64) -> Result<f64, Self::Error> {
             Ok((predicted - target).abs())
         }

--- a/amari-rewrite/tests/experimental_features.rs
+++ b/amari-rewrite/tests/experimental_features.rs
@@ -1,0 +1,40 @@
+#![cfg(any(feature = "neural", feature = "smt"))]
+
+#[cfg(feature = "neural")]
+#[test]
+fn differentiable_rule_trait_can_be_implemented() {
+    use amari_rewrite::neural::DifferentiableRule;
+
+    struct IdentityRule;
+    impl DifferentiableRule<f64> for IdentityRule {
+        type Parameters = ();
+        type Gradient = ();
+        type Error = core::convert::Infallible;
+
+        fn forward(&self, state: &f64) -> Result<f64, Self::Error> { Ok(*state) }
+        fn loss(&self, predicted: &f64, target: &f64) -> Result<f64, Self::Error> {
+            Ok((predicted - target).abs())
+        }
+    }
+
+    assert_eq!(IdentityRule.forward(&3.0).unwrap(), 3.0);
+}
+
+#[cfg(feature = "smt")]
+#[test]
+fn rewrite_solver_trait_can_be_implemented() {
+    use amari_rewrite::smt::RewriteSolver;
+
+    struct TrivialSolver;
+    impl RewriteSolver for TrivialSolver {
+        type Term = i32;
+        type Certificate = bool;
+        type Error = core::convert::Infallible;
+
+        fn prove_equivalent(&self, lhs: &i32, rhs: &i32) -> Result<bool, Self::Error> {
+            Ok(lhs == rhs)
+        }
+    }
+
+    assert!(TrivialSolver.prove_equivalent(&1, &1).unwrap());
+}

--- a/amari-rewrite/tests/inverse_search.rs
+++ b/amari-rewrite/tests/inverse_search.rs
@@ -1,10 +1,15 @@
-use amari_rewrite::{inverse::BackwardSearch, trs::{Rule, Term, TermSystem}};
+use amari_rewrite::{
+    inverse::BackwardSearch,
+    trs::{Rule, Term, TermSystem},
+};
 
 #[test]
 fn backward_search_finds_one_step_predecessor() {
-    let system = TermSystem::new(vec![
-        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
-    ]);
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    )
+    .unwrap()]);
 
     let target = Term::constant("a");
     let predecessors: Vec<_> = BackwardSearch::new(&system, target)
@@ -12,14 +17,19 @@ fn backward_search_finds_one_step_predecessor() {
         .max_nodes(16)
         .collect();
 
-    assert!(predecessors.contains(&Term::sym("add", [Term::constant("0"), Term::constant("a")])));
+    assert!(predecessors.contains(&Term::sym(
+        "add",
+        [Term::constant("0"), Term::constant("a")]
+    )));
 }
 
 #[test]
 fn backward_search_honors_depth_limit() {
-    let system = TermSystem::new(vec![
-        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
-    ]);
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    )
+    .unwrap()]);
 
     let predecessors: Vec<_> = BackwardSearch::new(&system, Term::constant("a"))
         .max_depth(0)

--- a/amari-rewrite/tests/inverse_search.rs
+++ b/amari-rewrite/tests/inverse_search.rs
@@ -1,0 +1,29 @@
+use amari_rewrite::{inverse::BackwardSearch, trs::{Rule, Term, TermSystem}};
+
+#[test]
+fn backward_search_finds_one_step_predecessor() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let target = Term::constant("a");
+    let predecessors: Vec<_> = BackwardSearch::new(&system, target)
+        .max_depth(1)
+        .max_nodes(16)
+        .collect();
+
+    assert!(predecessors.contains(&Term::sym("add", [Term::constant("0"), Term::constant("a")])));
+}
+
+#[test]
+fn backward_search_honors_depth_limit() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let predecessors: Vec<_> = BackwardSearch::new(&system, Term::constant("a"))
+        .max_depth(0)
+        .collect();
+
+    assert!(predecessors.is_empty());
+}

--- a/amari-rewrite/tests/network_feature.rs
+++ b/amari-rewrite/tests/network_feature.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "network")]
+
+use amari_rewrite::{network::RewriteGraphSummary, trs::Term};
+
+#[test]
+fn rewrite_graph_summary_tracks_terms_and_steps() {
+    let summary = RewriteGraphSummary::from_trace(&[
+        Term::constant("a"),
+        Term::sym("f", [Term::constant("a")]),
+    ]);
+
+    assert_eq!(summary.nodes, 2);
+    assert_eq!(summary.edges, 1);
+}

--- a/amari-rewrite/tests/rewritable_expr.rs
+++ b/amari-rewrite/tests/rewritable_expr.rs
@@ -37,7 +37,10 @@ impl Rewritable for Expr {
 #[test]
 fn positions_include_root_and_descendants() {
     let expr = Expr::Add(Box::new(Expr::Lit(1)), Box::new(Expr::Lit(2)));
-    assert_eq!(expr.positions(), vec![Path::root(), Path::from([0]), Path::from([1])]);
+    assert_eq!(
+        expr.positions(),
+        vec![Path::root(), Path::from([0]), Path::from([1])]
+    );
 }
 
 #[test]

--- a/amari-rewrite/tests/rewritable_expr.rs
+++ b/amari-rewrite/tests/rewritable_expr.rs
@@ -1,0 +1,65 @@
+use amari_rewrite::{Path, Rewritable};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Expr {
+    Lit(i64),
+    Add(Box<Expr>, Box<Expr>),
+}
+
+impl Rewritable for Expr {
+    fn child_count(&self) -> usize {
+        match self {
+            Expr::Lit(_) => 0,
+            Expr::Add(_, _) => 2,
+        }
+    }
+
+    fn child(&self, index: usize) -> Option<&Self> {
+        match self {
+            Expr::Lit(_) => None,
+            Expr::Add(left, right) => match index {
+                0 => Some(left),
+                1 => Some(right),
+                _ => None,
+            },
+        }
+    }
+
+    fn replace_child(&self, index: usize, replacement: Self) -> amari_rewrite::RewriteResult<Self> {
+        match (self, index) {
+            (Expr::Add(_, right), 0) => Ok(Expr::Add(Box::new(replacement), right.clone())),
+            (Expr::Add(left, _), 1) => Ok(Expr::Add(left.clone(), Box::new(replacement))),
+            _ => Err(amari_rewrite::RewriteError::InvalidChildIndex { index }),
+        }
+    }
+}
+
+#[test]
+fn positions_include_root_and_descendants() {
+    let expr = Expr::Add(Box::new(Expr::Lit(1)), Box::new(Expr::Lit(2)));
+    assert_eq!(expr.positions(), vec![Path::root(), Path::from([0]), Path::from([1])]);
+}
+
+#[test]
+fn subterm_reads_by_path() {
+    let expr = Expr::Add(Box::new(Expr::Lit(1)), Box::new(Expr::Lit(2)));
+    assert_eq!(expr.subterm(&Path::from([1])), Some(&Expr::Lit(2)));
+}
+
+#[test]
+fn replace_at_replaces_nested_subterm() {
+    let expr = Expr::Add(
+        Box::new(Expr::Lit(1)),
+        Box::new(Expr::Add(Box::new(Expr::Lit(2)), Box::new(Expr::Lit(3)))),
+    );
+
+    let rewritten = expr.replace_at(&Path::from([1, 0]), Expr::Lit(20)).unwrap();
+
+    assert_eq!(
+        rewritten,
+        Expr::Add(
+            Box::new(Expr::Lit(1)),
+            Box::new(Expr::Add(Box::new(Expr::Lit(20)), Box::new(Expr::Lit(3)))),
+        )
+    );
+}

--- a/amari-rewrite/tests/rule_inference.rs
+++ b/amari-rewrite/tests/rule_inference.rs
@@ -1,0 +1,25 @@
+use amari_rewrite::{synthesis::infer_rule, trs::Term};
+
+#[test]
+fn infer_add_zero_rule_from_positive_examples() {
+    let examples = vec![
+        (
+            Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+            Term::constant("a"),
+        ),
+        (
+            Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("a")])]),
+            Term::sym("s", [Term::constant("a")]),
+        ),
+    ];
+
+    let rule = infer_rule(&examples).unwrap();
+
+    assert_eq!(rule.apply_root(&examples[0].0).unwrap(), examples[0].1);
+    assert_eq!(rule.apply_root(&examples[1].0).unwrap(), examples[1].1);
+}
+
+#[test]
+fn infer_rule_rejects_empty_examples() {
+    assert!(infer_rule(&[]).is_err());
+}

--- a/amari-rewrite/tests/rule_inference.rs
+++ b/amari-rewrite/tests/rule_inference.rs
@@ -8,7 +8,10 @@ fn infer_add_zero_rule_from_positive_examples() {
             Term::constant("a"),
         ),
         (
-            Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("a")])]),
+            Term::sym(
+                "add",
+                [Term::constant("0"), Term::sym("s", [Term::constant("a")])],
+            ),
             Term::sym("s", [Term::constant("a")]),
         ),
     ];

--- a/amari-rewrite/tests/trs_matching.rs
+++ b/amari-rewrite/tests/trs_matching.rs
@@ -1,0 +1,32 @@
+use amari_rewrite::trs::{match_pattern, Rule, Term};
+
+#[test]
+fn match_pattern_binds_variable() {
+    let pat = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    let term = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
+    let subst = match_pattern(&pat, &term).unwrap();
+    assert_eq!(subst.get("X"), Some(&Term::sym("s", [Term::constant("0")])));
+}
+
+#[test]
+fn nonlinear_pattern_requires_consistent_binding() {
+    let pat = Term::sym("f", [Term::var("X"), Term::var("X")]);
+    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("a")])).is_some());
+    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("b")])).is_none());
+}
+
+#[test]
+fn rule_rejects_rhs_variable_missing_from_lhs() {
+    let err = Rule::new(Term::var("X"), Term::var("Y")).unwrap_err();
+    assert!(err.to_string().contains("rhs variable"));
+}
+
+#[test]
+fn rule_applies_at_root() {
+    let rule = Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    ).unwrap();
+    let term = Term::sym("add", [Term::constant("0"), Term::constant("a")]);
+    assert_eq!(rule.apply_root(&term).unwrap(), Term::constant("a"));
+}

--- a/amari-rewrite/tests/trs_matching.rs
+++ b/amari-rewrite/tests/trs_matching.rs
@@ -3,7 +3,10 @@ use amari_rewrite::trs::{match_pattern, Rule, Term};
 #[test]
 fn match_pattern_binds_variable() {
     let pat = Term::sym("add", [Term::constant("0"), Term::var("X")]);
-    let term = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
+    let term = Term::sym(
+        "add",
+        [Term::constant("0"), Term::sym("s", [Term::constant("0")])],
+    );
     let subst = match_pattern(&pat, &term).unwrap();
     assert_eq!(subst.get("X"), Some(&Term::sym("s", [Term::constant("0")])));
 }
@@ -11,8 +14,16 @@ fn match_pattern_binds_variable() {
 #[test]
 fn nonlinear_pattern_requires_consistent_binding() {
     let pat = Term::sym("f", [Term::var("X"), Term::var("X")]);
-    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("a")])).is_some());
-    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("b")])).is_none());
+    assert!(match_pattern(
+        &pat,
+        &Term::sym("f", [Term::constant("a"), Term::constant("a")])
+    )
+    .is_some());
+    assert!(match_pattern(
+        &pat,
+        &Term::sym("f", [Term::constant("a"), Term::constant("b")])
+    )
+    .is_none());
 }
 
 #[test]
@@ -26,7 +37,8 @@ fn rule_applies_at_root() {
     let rule = Rule::new(
         Term::sym("add", [Term::constant("0"), Term::var("X")]),
         Term::var("X"),
-    ).unwrap();
+    )
+    .unwrap();
     let term = Term::sym("add", [Term::constant("0"), Term::constant("a")]);
     assert_eq!(rule.apply_root(&term).unwrap(), Term::constant("a"));
 }

--- a/amari-rewrite/tests/trs_substitution.rs
+++ b/amari-rewrite/tests/trs_substitution.rs
@@ -12,6 +12,9 @@ fn substitution_replaces_variables_recursively() {
     let subst = Substitution::new().with("X", Term::sym("s", [Term::constant("0")]));
     assert_eq!(
         subst.apply(&term),
-        Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])])
+        Term::sym(
+            "add",
+            [Term::constant("0"), Term::sym("s", [Term::constant("0")])]
+        )
     );
 }

--- a/amari-rewrite/tests/trs_substitution.rs
+++ b/amari-rewrite/tests/trs_substitution.rs
@@ -1,0 +1,17 @@
+use amari_rewrite::trs::{Substitution, Term};
+
+#[test]
+fn term_rewritable_positions_include_all_nodes() {
+    let term = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    assert_eq!(term.positions().len(), 3);
+}
+
+#[test]
+fn substitution_replaces_variables_recursively() {
+    let term = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    let subst = Substitution::new().with("X", Term::sym("s", [Term::constant("0")]));
+    assert_eq!(
+        subst.apply(&term),
+        Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])])
+    );
+}

--- a/amari-rewrite/tests/trs_system.rs
+++ b/amari-rewrite/tests/trs_system.rs
@@ -2,14 +2,22 @@ use amari_rewrite::trs::{Rule, Term, TermSystem};
 
 #[test]
 fn peano_add_zero_normalizes_nested_term() {
-    let system = TermSystem::new(vec![
-        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
-    ]);
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    )
+    .unwrap()]);
 
-    let term = Term::sym("add", [
-        Term::constant("0"),
-        Term::sym("add", [Term::constant("0"), Term::constant("a")]),
-    ]);
+    let term = Term::sym(
+        "add",
+        [
+            Term::constant("0"),
+            Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+        ],
+    );
 
-    assert_eq!(system.normalize_with_limit(&term, 8).unwrap(), Term::constant("a"));
+    assert_eq!(
+        system.normalize_with_limit(&term, 8).unwrap(),
+        Term::constant("a")
+    );
 }

--- a/amari-rewrite/tests/trs_system.rs
+++ b/amari-rewrite/tests/trs_system.rs
@@ -1,0 +1,15 @@
+use amari_rewrite::trs::{Rule, Term, TermSystem};
+
+#[test]
+fn peano_add_zero_normalizes_nested_term() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let term = Term::sym("add", [
+        Term::constant("0"),
+        Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+    ]);
+
+    assert_eq!(system.normalize_with_limit(&term, 8).unwrap(), Term::constant("a"));
+}

--- a/docs/plans/2026-05-10-amari-rewrite-design.md
+++ b/docs/plans/2026-05-10-amari-rewrite-design.md
@@ -1,0 +1,295 @@
+# amari-rewrite 0.23.0 Design
+
+Date: 2026-05-10
+Status: validated design for 0.23.0 implementation
+Source context: `/home/lucien/working/industrial-algebra/IA-documents/Amari/rewrite/rewrite-ideation-session.md`
+
+## Goal
+
+`amari-rewrite` is a foundational rewrite-systems crate for Amari. It should be a toolkit for building and exploring rewrite systems over Amari-owned or user-owned data structures, not a wrapper around an external e-graph engine and not a rewrite engine that takes over existing data.
+
+The 0.23.0 target is a broad experimental toolkit with a stable symbolic core and explicitly feature-gated research surfaces.
+
+## Stability tiers
+
+Stable/default 0.23.0 surface:
+
+- `rewritable`: path/subterm traversal for user-owned data
+- `ars`: abstract rewrite systems over arbitrary `T: Rewritable`
+- `trs`: first-order terms, variables, substitutions, matching, and rewrite rules
+- `inverse`: bounded predecessor/backward search
+- `synthesis`: anti-unification and basic rule inference from examples
+
+Experimental feature-gated surfaces:
+
+- `macros`: future `derive(Rewritable)` and term/rule helper macros
+- `smt`: placeholder interfaces for solver-backed validation and synthesis
+- `neural`: trait-level scaffolding for differentiable/neural rewrite rules
+- `network`: optional `amari-network` bridge for graph/geometric rewrite guidance
+
+The default crate should remain lightweight and inspectable. It should not depend on `egg`, `egglog`, neural tensor frameworks, or SMT solvers in the default path.
+
+## Crate layout
+
+```rust
+pub mod rewritable;
+pub mod ars;
+pub mod trs;
+pub mod inverse;
+pub mod synthesis;
+
+#[cfg(feature = "macros")]
+pub mod macros;
+
+#[cfg(feature = "smt")]
+pub mod smt;
+
+#[cfg(feature = "neural")]
+pub mod neural;
+
+#[cfg(feature = "network")]
+pub mod network;
+
+pub mod prelude;
+```
+
+The prelude should include only everyday user-facing items: `Rewritable`, `Path`, `Strategy`, `System`, `Term`, `Rule`, and `Substitution`.
+
+## Core abstraction
+
+`Rewritable` keeps user-owned data at the center. `trs::Term` is useful and concrete, but it must not be mandatory for all rewriting.
+
+```rust
+pub trait Rewritable: Clone + PartialEq + core::fmt::Debug {
+    fn children(&self) -> Children<'_, Self>;
+    fn replace_at(&self, path: &Path, replacement: Self) -> RewriteResult<Self>;
+
+    fn subterm(&self, path: &Path) -> Option<&Self> { /* provided */ }
+    fn positions(&self) -> Vec<Path> { /* provided */ }
+}
+```
+
+Avoid `Box<dyn Iterator>` in the public trait if a simple `Children<'a, T>` helper or slice-like adapter can keep implementations straightforward without heap allocation.
+
+## ARS layer
+
+The ARS layer models rewriting as abstract state transitions over any `T: Rewritable`.
+
+Primary types:
+
+```rust
+ars::Rule<T>
+ars::System<T>
+ars::Strategy
+ars::RewriteStep<T>
+```
+
+Initial strategy set:
+
+```rust
+Strategy::OuterFirst
+Strategy::InnerFirst
+Strategy::FirstRule
+Strategy::All
+```
+
+Behavioral API:
+
+- `apply_once(term, strategy)`
+- `rewrite_steps(term, limit)`
+- `normalize(term)`
+- `normalize_with_limit(term, max_steps)`
+- `normal_forms(term, max_depth)` for bounded exploration
+
+`Strategy::All` should return possible one-step successors, not choose one.
+
+## TRS layer
+
+The TRS layer provides a concrete first-order term rewriting system on top of ARS.
+
+Primary types:
+
+```rust
+trs::Term
+trs::Variable
+trs::Symbol
+trs::Substitution
+trs::Rule
+trs::TermSystem
+```
+
+`trs::Rule { lhs, rhs }` should validate the usual TRS condition: variables appearing in `rhs` must also appear in `lhs`. Unchecked or experimental construction should be explicit.
+
+Matching must be deterministic and substitution-consistent:
+
+```text
+match_pattern(add(0, X), add(0, s(0))) => { X ↦ s(0) }
+match_pattern(f(X, X), f(a, b)) => None
+```
+
+## Inverse rewriting
+
+Inverse rewriting is not a true functional inverse. It is bounded predecessor generation.
+
+Proposed API:
+
+```rust
+inverse::predecessors(system, target)
+inverse::BackwardSearch::new(system, target)
+    .max_depth(...)
+    .max_nodes(...)
+    .strategy(...)
+```
+
+Rules can be explored backward by matching the original RHS and instantiating the original LHS. Search must be explicitly bounded and should deduplicate visited terms.
+
+Use cases:
+
+- backward reachability
+- debugging rewrite traces
+- finding candidate predecessors for synthesis
+- exploring inverse TRS behavior
+
+## Synthesis and anti-unification
+
+Initial synthesis should be lightweight, symbolic, and honest about limitations.
+
+Public functions:
+
+```rust
+anti_unify(a, b)
+anti_unify_all(terms)
+infer_rule(positive_examples)
+infer_rules(positive_examples, negative_examples, config)
+```
+
+Anti-unification should compute a most-specific generalization for first-order terms. Rule inference should use positive examples first, then apply simple negative-example filtering or heuristic specialization. The 0.23.0 docs must state that negative-example specialization is heuristic, not complete.
+
+Important tests:
+
+- constants anti-unify to themselves
+- different constants produce fresh variables
+- nested examples such as `add(0, succ(0))` and `add(0, succ(succ(0)))` produce `add(0, succ(X))`
+- the generated generalization can instantiate back to all positive examples
+- non-linear patterns are handled consistently
+
+## Experimental neural module
+
+The `neural` feature should initially provide trait scaffolding only. It should not pick `burn`, `candle`, `ndarray`, or another tensor dependency in 0.23.0.
+
+Example trait shape:
+
+```rust
+pub trait DifferentiableRule<State> {
+    type Parameters;
+    type Gradient;
+    type Error;
+
+    fn forward(&self, state: &State) -> Result<State, Self::Error>;
+    fn loss(&self, predicted: &State, target: &State) -> Result<f64, Self::Error>;
+}
+```
+
+The near-term purpose is to keep the architecture open for learned rewrite rules, neural inverse rewriting, and neural-guided strategies without coupling the stable symbolic crate to a research stack.
+
+## Optional amari-network integration
+
+`amari-network` should contribute to the experimental neural direction as an optional bridge, not as a default dependency.
+
+Feature shape:
+
+```toml
+[features]
+default = ["std"]
+neural = []
+network = ["dep:amari-network", "neural"]
+```
+
+Integration role:
+
+- model rewrite search spaces as directed graphs where terms are nodes and rewrite steps are edges
+- rank forward/backward search frontiers using graph/geometric heuristics
+- represent rule embeddings, state embeddings, and rewrite trajectories for learned strategy selection
+- support neural-guided inverse rewriting by prioritizing likely predecessors
+
+Boundary: `amari-rewrite` core must not depend on `amari-network`. The optional `network` module is a strategy/guidance layer over the symbolic core.
+
+## Experimental SMT module
+
+The `smt` feature should define interfaces before integrating a concrete solver.
+
+Example trait shape:
+
+```rust
+pub trait RewriteSolver {
+    type Term;
+    type Certificate;
+    type Error;
+
+    fn prove_equivalent(
+        &self,
+        lhs: &Self::Term,
+        rhs: &Self::Term,
+    ) -> Result<Self::Certificate, Self::Error>;
+}
+```
+
+Use cases are solver-backed rule validation, equivalence checks, and eventual rule synthesis. No solver dependency is required for the first crate scaffold.
+
+## Macros
+
+The `macros` feature is reserved for ergonomics. A future release may add:
+
+- `derive(Rewritable)`
+- `term!` helper macro
+- `rule!` helper macro
+
+For 0.23.0, prioritize the explicit core API. Proc macros should be deferred unless they are trivial and do not destabilize the release.
+
+## Tests
+
+Required first-wave tests:
+
+- path traversal and replacement on a sample recursive `Expr`
+- ARS normalization and bounded-step behavior
+- ARS strategies: outer-first, inner-first, all successors
+- TRS substitution and matching consistency
+- non-linear pattern matching: `f(X, X)`
+- RHS variable validation
+- inverse predecessor generation on Peano arithmetic
+- anti-unification examples and generalization property checks
+- rule inference from positive examples
+- negative examples filtered or marked inconclusive
+- feature-gated neural/network/smt trait compilation tests
+
+## Examples
+
+Ship examples such as:
+
+- `symbolic_simplification.rs`
+- `peano_trs.rs`
+- `inverse_search.rs`
+- `infer_rule_from_examples.rs`
+- `network_guided_search.rs` behind the `network` feature
+- `neural_rule_trait.rs` behind the `neural` feature
+
+## Documentation
+
+Crate docs should explain:
+
+- ARS vs TRS
+- rewrite strategies
+- normal forms and termination limits
+- inverse rewriting as bounded predecessor search
+- anti-unification and rule inference limits
+- why neural/SMT/network modules are feature-gated and experimental
+
+The README should include a minimal symbolic simplification example and a small TRS example.
+
+## 0.23.0 success criteria
+
+- `amari-rewrite` is a workspace crate with stable ARS/TRS/inverse/synthesis APIs.
+- Default build uses no heavy external rewrite, neural, or SMT dependencies.
+- Feature-gated experimental modules compile and document their boundaries.
+- The crate has enough tests/examples to demonstrate symbolic simplification, Peano TRS, inverse search, and positive-example rule inference.
+- The design remains compatible with later `amari-surcomplex` and future Amari DSLs.

--- a/docs/plans/2026-05-10-amari-rewrite-implementation-plan.md
+++ b/docs/plans/2026-05-10-amari-rewrite-implementation-plan.md
@@ -1,0 +1,1172 @@
+# amari-rewrite Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Add the `amari-rewrite` workspace crate for Amari 0.23.0 with a stable ARS/TRS/inverse/synthesis core and feature-gated experimental neural/SMT/network scaffolding.
+
+**Architecture:** `amari-rewrite` is a standalone foundational crate. The default build exposes `rewritable`, `ars`, `trs`, `inverse`, `synthesis`, and `prelude`. Experimental `neural`, `smt`, `macros`, and `network` modules are feature-gated; `network` depends optionally on `amari-network` and builds on `neural`.
+
+**Tech Stack:** Rust 2021, Cargo workspace versioning, `thiserror`, optional `serde`, optional `amari-network`, test-first implementation with `cargo +stable test -p amari-rewrite`.
+
+---
+
+## Execution rules
+
+- Use TDD for behavior: write each test first, run it and confirm RED, implement minimal code, run GREEN.
+- Commit after each task or small group of tightly related files.
+- Do not add external rewrite, SMT, neural, or tensor dependencies in default features.
+- Keep public docs honest: neural/SMT/network modules are experimental scaffolding in 0.23.0.
+
+---
+
+### Task 1: Scaffold workspace crate
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `amari-rewrite/Cargo.toml`
+- Create: `amari-rewrite/src/lib.rs`
+- Create: `amari-rewrite/src/prelude.rs`
+- Create: `amari-rewrite/README.md`
+
+**Step 1: Add workspace membership and dependency wiring**
+
+Modify root `Cargo.toml`:
+
+- Add `amari-rewrite` to `[workspace].members`.
+- Add workspace dependency:
+
+```toml
+amari-rewrite = { path = "amari-rewrite", version = "0.22.0" }
+```
+
+Note: if the active branch has already bumped to 0.23.0, use `0.23.0` consistently instead.
+
+**Step 2: Create crate manifest**
+
+Create `amari-rewrite/Cargo.toml`:
+
+```toml
+[package]
+name = "amari-rewrite"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Abstract and term rewriting systems for the Amari library"
+repository = "https://github.com/justinelliottcobb/Amari"
+homepage = "https://github.com/justinelliottcobb/Amari"
+keywords = ["mathematics", "rewriting", "trs", "rules", "synthesis"]
+categories = ["mathematics", "science", "algorithms"]
+
+[dependencies]
+thiserror = { workspace = true }
+serde = { workspace = true, optional = true }
+amari-network = { workspace = true, optional = true }
+
+[features]
+default = ["std"]
+std = []
+serialize = ["dep:serde"]
+macros = []
+smt = []
+neural = []
+network = ["dep:amari-network", "neural"]
+```
+
+**Step 3: Create minimal lib and prelude**
+
+Create `amari-rewrite/src/lib.rs`:
+
+```rust
+//! Abstract and term rewriting systems for Amari.
+//!
+//! `amari-rewrite` provides foundational rewriting tools: abstract rewriting
+//! systems (ARS), first-order term rewriting systems (TRS), bounded inverse
+//! rewriting, and lightweight rule synthesis via anti-unification.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod prelude;
+```
+
+Create `amari-rewrite/src/prelude.rs`:
+
+```rust
+//! Common imports for `amari-rewrite`.
+```
+
+Create a README with the same stability-tier message from `docs/plans/2026-05-10-amari-rewrite-design.md`.
+
+**Step 4: Verify scaffold**
+
+Run:
+
+```bash
+cargo +stable check -p amari-rewrite
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml amari-rewrite
+git commit -m "feat: scaffold amari-rewrite crate"
+```
+
+---
+
+### Task 2: Add error, path, and Rewritable core
+
+**Files:**
+- Create: `amari-rewrite/src/error.rs`
+- Create: `amari-rewrite/src/rewritable.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+- Modify: `amari-rewrite/src/prelude.rs`
+- Create: `amari-rewrite/tests/rewritable_expr.rs`
+
+**Step 1: Write failing test**
+
+Create `amari-rewrite/tests/rewritable_expr.rs`:
+
+```rust
+use amari_rewrite::{Path, Rewritable};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Expr {
+    Lit(i64),
+    Add(Box<Expr>, Box<Expr>),
+}
+
+impl Rewritable for Expr {
+    fn child_count(&self) -> usize {
+        match self {
+            Expr::Lit(_) => 0,
+            Expr::Add(_, _) => 2,
+        }
+    }
+
+    fn child(&self, index: usize) -> Option<&Self> {
+        match self {
+            Expr::Lit(_) => None,
+            Expr::Add(left, right) => match index {
+                0 => Some(left),
+                1 => Some(right),
+                _ => None,
+            },
+        }
+    }
+
+    fn replace_child(&self, index: usize, replacement: Self) -> amari_rewrite::RewriteResult<Self> {
+        match (self, index) {
+            (Expr::Add(_, right), 0) => Ok(Expr::Add(Box::new(replacement), right.clone())),
+            (Expr::Add(left, _), 1) => Ok(Expr::Add(left.clone(), Box::new(replacement))),
+            _ => Err(amari_rewrite::RewriteError::InvalidChildIndex { index }),
+        }
+    }
+}
+
+#[test]
+fn positions_include_root_and_descendants() {
+    let expr = Expr::Add(Box::new(Expr::Lit(1)), Box::new(Expr::Lit(2)));
+    assert_eq!(expr.positions(), vec![Path::root(), Path::from([0]), Path::from([1])]);
+}
+
+#[test]
+fn subterm_reads_by_path() {
+    let expr = Expr::Add(Box::new(Expr::Lit(1)), Box::new(Expr::Lit(2)));
+    assert_eq!(expr.subterm(&Path::from([1])), Some(&Expr::Lit(2)));
+}
+
+#[test]
+fn replace_at_replaces_nested_subterm() {
+    let expr = Expr::Add(
+        Box::new(Expr::Lit(1)),
+        Box::new(Expr::Add(Box::new(Expr::Lit(2)), Box::new(Expr::Lit(3)))),
+    );
+
+    let rewritten = expr.replace_at(&Path::from([1, 0]), Expr::Lit(20)).unwrap();
+
+    assert_eq!(
+        rewritten,
+        Expr::Add(
+            Box::new(Expr::Lit(1)),
+            Box::new(Expr::Add(Box::new(Expr::Lit(20)), Box::new(Expr::Lit(3)))),
+        )
+    );
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test rewritable_expr
+```
+
+Expected: FAIL because `Path`, `Rewritable`, `RewriteError`, and `RewriteResult` do not exist.
+
+**Step 3: Implement minimal core**
+
+Create `error.rs`:
+
+```rust
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum RewriteError {
+    #[error("invalid child index {index}")]
+    InvalidChildIndex { index: usize },
+    #[error("invalid path")]
+    InvalidPath,
+    #[error("rewrite step limit reached")]
+    StepLimitReached,
+    #[error("node limit reached")]
+    NodeLimitReached,
+    #[error("invalid rule: {message}")]
+    InvalidRule { message: alloc::string::String },
+}
+
+pub type RewriteResult<T> = Result<T, RewriteError>;
+```
+
+Create `rewritable.rs`:
+
+```rust
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt::Debug;
+
+use crate::{RewriteError, RewriteResult};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Path(Vec<usize>);
+
+impl Path {
+    pub fn root() -> Self { Self(Vec::new()) }
+    pub fn as_slice(&self) -> &[usize] { &self.0 }
+    pub fn child(&self, index: usize) -> Self {
+        let mut next = self.0.clone();
+        next.push(index);
+        Self(next)
+    }
+}
+
+impl<const N: usize> From<[usize; N]> for Path {
+    fn from(value: [usize; N]) -> Self { Self(value.into()) }
+}
+
+impl From<Vec<usize>> for Path {
+    fn from(value: Vec<usize>) -> Self { Self(value) }
+}
+
+pub trait Rewritable: Clone + PartialEq + Debug {
+    fn child_count(&self) -> usize;
+    fn child(&self, index: usize) -> Option<&Self>;
+    fn replace_child(&self, index: usize, replacement: Self) -> RewriteResult<Self>;
+
+    fn subterm(&self, path: &Path) -> Option<&Self> {
+        let mut current = self;
+        for &index in path.as_slice() {
+            current = current.child(index)?;
+        }
+        Some(current)
+    }
+
+    fn replace_at(&self, path: &Path, replacement: Self) -> RewriteResult<Self> {
+        match path.as_slice().split_first() {
+            None => Ok(replacement),
+            Some((&index, rest)) => {
+                let child = self.child(index).ok_or(RewriteError::InvalidChildIndex { index })?;
+                let replaced_child = child.replace_at(&Path::from(rest.to_vec()), replacement)?;
+                self.replace_child(index, replaced_child)
+            }
+        }
+    }
+
+    fn positions(&self) -> Vec<Path> {
+        fn walk<T: Rewritable>(term: &T, path: Path, out: &mut Vec<Path>) {
+            out.push(path.clone());
+            for index in 0..term.child_count() {
+                if let Some(child) = term.child(index) {
+                    walk(child, path.child(index), out);
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(self, Path::root(), &mut out);
+        out
+    }
+}
+```
+
+Update `lib.rs` exports:
+
+```rust
+extern crate alloc;
+
+pub mod error;
+pub mod prelude;
+pub mod rewritable;
+
+pub use error::{RewriteError, RewriteResult};
+pub use rewritable::{Path, Rewritable};
+```
+
+Update `prelude.rs`:
+
+```rust
+pub use crate::{Path, Rewritable, RewriteError, RewriteResult};
+```
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test rewritable_expr
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src amari-rewrite/tests/rewritable_expr.rs
+git commit -m "feat: add rewritable path core"
+```
+
+---
+
+### Task 3: Add ARS rules, systems, and strategies
+
+**Files:**
+- Create: `amari-rewrite/src/ars/mod.rs`
+- Create: `amari-rewrite/tests/ars_system.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+- Modify: `amari-rewrite/src/prelude.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/ars_system.rs` using the same `Expr` fixture style as Task 2. Add tests:
+
+```rust
+#[test]
+fn normalize_applies_rule_until_fixed_point() {
+    let system = System::new(vec![Rule::new("add-zero-left", |expr: &Expr| match expr {
+        Expr::Add(left, right) if **left == Expr::Lit(0) => Some((**right).clone()),
+        _ => None,
+    })]);
+
+    let expr = Expr::Add(
+        Box::new(Expr::Lit(0)),
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(5)))),
+    );
+
+    assert_eq!(system.normalize_with_limit(&expr, 8).unwrap(), Expr::Lit(5));
+}
+
+#[test]
+fn all_successors_returns_every_one_step_rewrite() {
+    let system = System::new(vec![Rule::new("add-zero-left", |expr: &Expr| match expr {
+        Expr::Add(left, right) if **left == Expr::Lit(0) => Some((**right).clone()),
+        _ => None,
+    })]);
+
+    let expr = Expr::Add(
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(1)))),
+        Box::new(Expr::Add(Box::new(Expr::Lit(0)), Box::new(Expr::Lit(2)))),
+    );
+
+    let successors = system.successors(&expr).unwrap();
+    assert_eq!(successors.len(), 2);
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test ars_system
+```
+
+Expected: FAIL because `ars::{Rule, System, Strategy}` do not exist.
+
+**Step 3: Implement minimal ARS**
+
+Implement:
+
+```rust
+pub struct Rule<T> {
+    name: alloc::string::String,
+    apply: alloc::boxed::Box<dyn Fn(&T) -> Option<T>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Strategy { OuterFirst, InnerFirst, FirstRule, All }
+
+pub struct System<T> { rules: Vec<Rule<T>> }
+```
+
+Implement `successors`, `apply_once`, and `normalize_with_limit` by traversing `positions()` and using `replace_at`.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test ars_system
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/ars amari-rewrite/src/lib.rs amari-rewrite/src/prelude.rs amari-rewrite/tests/ars_system.rs
+git commit -m "feat: add abstract rewrite systems"
+```
+
+---
+
+### Task 4: Add TRS terms and substitutions
+
+**Files:**
+- Create: `amari-rewrite/src/trs/mod.rs`
+- Create: `amari-rewrite/src/trs/term.rs`
+- Create: `amari-rewrite/src/trs/substitution.rs`
+- Create: `amari-rewrite/tests/trs_substitution.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+- Modify: `amari-rewrite/src/prelude.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/trs_substitution.rs`:
+
+```rust
+use amari_rewrite::trs::{Substitution, Term};
+
+#[test]
+fn term_rewritable_positions_include_all_nodes() {
+    let term = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    assert_eq!(term.positions().len(), 3);
+}
+
+#[test]
+fn substitution_replaces_variables_recursively() {
+    let term = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    let subst = Substitution::new().with("X", Term::sym("s", [Term::constant("0")]));
+    assert_eq!(
+        subst.apply(&term),
+        Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])])
+    );
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_substitution
+```
+
+Expected: FAIL because TRS module does not exist.
+
+**Step 3: Implement minimal terms and substitutions**
+
+Implement:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Variable(Arc<str>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Symbol(Arc<str>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Term {
+    Var(Variable),
+    Sym(Symbol, Vec<Term>),
+}
+```
+
+Use `alloc::sync::Arc` or `alloc::string::String` depending on `no_std` constraints. Implement `Rewritable` for `Term`.
+
+Implement `Substitution` as a map from `Variable` to `Term`. In `no_std`, use `alloc::collections::BTreeMap` rather than `HashMap`.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_substitution
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/trs amari-rewrite/src/lib.rs amari-rewrite/src/prelude.rs amari-rewrite/tests/trs_substitution.rs
+git commit -m "feat: add TRS terms and substitutions"
+```
+
+---
+
+### Task 5: Add TRS pattern matching and rules
+
+**Files:**
+- Create: `amari-rewrite/src/trs/matching.rs`
+- Create: `amari-rewrite/src/trs/rule.rs`
+- Create: `amari-rewrite/tests/trs_matching.rs`
+- Modify: `amari-rewrite/src/trs/mod.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/trs_matching.rs`:
+
+```rust
+use amari_rewrite::trs::{match_pattern, Rule, Term};
+
+#[test]
+fn match_pattern_binds_variable() {
+    let pat = Term::sym("add", [Term::constant("0"), Term::var("X")]);
+    let term = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
+    let subst = match_pattern(&pat, &term).unwrap();
+    assert_eq!(subst.get("X"), Some(&Term::sym("s", [Term::constant("0")])));
+}
+
+#[test]
+fn nonlinear_pattern_requires_consistent_binding() {
+    let pat = Term::sym("f", [Term::var("X"), Term::var("X")]);
+    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("a")])).is_some());
+    assert!(match_pattern(&pat, &Term::sym("f", [Term::constant("a"), Term::constant("b")])).is_none());
+}
+
+#[test]
+fn rule_rejects_rhs_variable_missing_from_lhs() {
+    let err = Rule::new(Term::var("X"), Term::var("Y")).unwrap_err();
+    assert!(err.to_string().contains("rhs variable"));
+}
+
+#[test]
+fn rule_applies_at_root() {
+    let rule = Rule::new(
+        Term::sym("add", [Term::constant("0"), Term::var("X")]),
+        Term::var("X"),
+    ).unwrap();
+    let term = Term::sym("add", [Term::constant("0"), Term::constant("a")]);
+    assert_eq!(rule.apply_root(&term).unwrap(), Term::constant("a"));
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_matching
+```
+
+Expected: FAIL because matching/rules do not exist.
+
+**Step 3: Implement matching and rules**
+
+Implement `match_pattern` with consistent substitution merge.
+
+Implement `Rule::new(lhs, rhs) -> RewriteResult<Rule>` by checking `rhs.variables().is_subset(lhs.variables())`.
+
+Implement `Rule::apply_root`.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_matching
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/trs amari-rewrite/tests/trs_matching.rs
+git commit -m "feat: add TRS matching and rules"
+```
+
+---
+
+### Task 6: Add TermSystem integration with ARS
+
+**Files:**
+- Modify: `amari-rewrite/src/trs/mod.rs`
+- Create: `amari-rewrite/src/trs/system.rs`
+- Create: `amari-rewrite/tests/trs_system.rs`
+
+**Step 1: Write failing test**
+
+Create `amari-rewrite/tests/trs_system.rs`:
+
+```rust
+use amari_rewrite::trs::{Rule, Term, TermSystem};
+
+#[test]
+fn peano_add_zero_normalizes_nested_term() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let term = Term::sym("add", [
+        Term::constant("0"),
+        Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+    ]);
+
+    assert_eq!(system.normalize_with_limit(&term, 8).unwrap(), Term::constant("a"));
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_system
+```
+
+Expected: FAIL because `TermSystem` does not exist.
+
+**Step 3: Implement TermSystem**
+
+Implement `TermSystem { rules: Vec<trs::Rule> }` with `successors`, `apply_once`, and `normalize_with_limit` using TRS rules at every `Term` position.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test trs_system
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/trs amari-rewrite/tests/trs_system.rs
+git commit -m "feat: add TRS system normalization"
+```
+
+---
+
+### Task 7: Add inverse rewriting / bounded backward search
+
+**Files:**
+- Create: `amari-rewrite/src/inverse/mod.rs`
+- Create: `amari-rewrite/tests/inverse_search.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+- Modify: `amari-rewrite/src/prelude.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/inverse_search.rs`:
+
+```rust
+use amari_rewrite::{inverse::BackwardSearch, trs::{Rule, Term, TermSystem}};
+
+#[test]
+fn backward_search_finds_one_step_predecessor() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let target = Term::constant("a");
+    let predecessors: Vec<_> = BackwardSearch::new(&system, target)
+        .max_depth(1)
+        .max_nodes(16)
+        .collect();
+
+    assert!(predecessors.contains(&Term::sym("add", [Term::constant("0"), Term::constant("a")])));
+}
+
+#[test]
+fn backward_search_honors_depth_limit() {
+    let system = TermSystem::new(vec![
+        Rule::new(Term::sym("add", [Term::constant("0"), Term::var("X")]), Term::var("X")).unwrap(),
+    ]);
+
+    let predecessors: Vec<_> = BackwardSearch::new(&system, Term::constant("a"))
+        .max_depth(0)
+        .collect();
+
+    assert!(predecessors.is_empty());
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test inverse_search
+```
+
+Expected: FAIL because inverse module does not exist.
+
+**Step 3: Implement bounded backward search**
+
+Implement BFS over terms. For each current term, generate one-step predecessors by applying each TRS rule in reverse at each position: match `rule.rhs` against a subterm, instantiate `rule.lhs`, and replace at that path. Deduplicate using `BTreeSet<Term>`.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test inverse_search
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/inverse amari-rewrite/src/lib.rs amari-rewrite/src/prelude.rs amari-rewrite/tests/inverse_search.rs
+git commit -m "feat: add bounded inverse rewriting"
+```
+
+---
+
+### Task 8: Add anti-unification
+
+**Files:**
+- Create: `amari-rewrite/src/synthesis/mod.rs`
+- Create: `amari-rewrite/src/synthesis/anti_unify.rs`
+- Create: `amari-rewrite/tests/anti_unification.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+- Modify: `amari-rewrite/src/prelude.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/anti_unification.rs`:
+
+```rust
+use amari_rewrite::{synthesis::anti_unify, trs::{match_pattern, Term}};
+
+#[test]
+fn identical_terms_generalize_to_themselves() {
+    let zero = Term::constant("0");
+    assert_eq!(anti_unify(&zero, &zero), zero);
+}
+
+#[test]
+fn nested_terms_generalize_at_disagreement() {
+    let a = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("0")])]);
+    let b = Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::sym("s", [Term::constant("0")])])]);
+
+    let generalized = anti_unify(&a, &b);
+
+    match &generalized {
+        Term::Sym(symbol, args) => {
+            assert_eq!(symbol.as_str(), "add");
+            assert_eq!(args[0], Term::constant("0"));
+            assert!(matches!(&args[1], Term::Sym(s, inner) if s.as_str() == "s" && matches!(inner[0], Term::Var(_))));
+        }
+        _ => panic!("expected symbolic generalization"),
+    }
+
+    assert!(match_pattern(&generalized, &a).is_some());
+    assert!(match_pattern(&generalized, &b).is_some());
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test anti_unification
+```
+
+Expected: FAIL because synthesis module does not exist.
+
+**Step 3: Implement anti-unification**
+
+Implement a local `VarGen` with generated variable names like `_G0`, `_G1`. For two `Term::Sym` values with same symbol/arity, recurse. Otherwise return a fresh variable.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test anti_unification
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/synthesis amari-rewrite/src/lib.rs amari-rewrite/src/prelude.rs amari-rewrite/tests/anti_unification.rs
+git commit -m "feat: add TRS anti-unification"
+```
+
+---
+
+### Task 9: Add rule inference from examples
+
+**Files:**
+- Create: `amari-rewrite/src/synthesis/inference.rs`
+- Create: `amari-rewrite/tests/rule_inference.rs`
+- Modify: `amari-rewrite/src/synthesis/mod.rs`
+
+**Step 1: Write failing tests**
+
+Create `amari-rewrite/tests/rule_inference.rs`:
+
+```rust
+use amari_rewrite::{synthesis::infer_rule, trs::Term};
+
+#[test]
+fn infer_add_zero_rule_from_positive_examples() {
+    let examples = vec![
+        (
+            Term::sym("add", [Term::constant("0"), Term::constant("a")]),
+            Term::constant("a"),
+        ),
+        (
+            Term::sym("add", [Term::constant("0"), Term::sym("s", [Term::constant("a")])]),
+            Term::sym("s", [Term::constant("a")]),
+        ),
+    ];
+
+    let rule = infer_rule(&examples).unwrap();
+
+    assert_eq!(rule.apply_root(&examples[0].0).unwrap(), examples[0].1);
+    assert_eq!(rule.apply_root(&examples[1].0).unwrap(), examples[1].1);
+}
+
+#[test]
+fn infer_rule_rejects_empty_examples() {
+    assert!(infer_rule(&[]).is_err());
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test rule_inference
+```
+
+Expected: FAIL because `infer_rule` does not exist.
+
+**Step 3: Implement inference**
+
+Implement `infer_rule(&[(Term, Term)]) -> RewriteResult<trs::Rule>` by anti-unifying all LHSs and all RHSs. If RHS variables do not appear in LHS due to independent anti-unification naming, add the minimal variable alignment needed for examples to pass. If alignment becomes complex, implement a small pair anti-unification result that tracks disagreement pairs consistently across LHS/RHS examples.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --test rule_inference
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/synthesis amari-rewrite/tests/rule_inference.rs
+git commit -m "feat: infer rewrite rules from examples"
+```
+
+---
+
+### Task 10: Add experimental neural and SMT scaffolding
+
+**Files:**
+- Create: `amari-rewrite/src/neural/mod.rs`
+- Create: `amari-rewrite/src/smt/mod.rs`
+- Create: `amari-rewrite/tests/experimental_features.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+
+**Step 1: Write compile tests**
+
+Create `amari-rewrite/tests/experimental_features.rs`:
+
+```rust
+#![cfg(any(feature = "neural", feature = "smt"))]
+
+#[cfg(feature = "neural")]
+#[test]
+fn differentiable_rule_trait_can_be_implemented() {
+    use amari_rewrite::neural::DifferentiableRule;
+
+    struct IdentityRule;
+    impl DifferentiableRule<f64> for IdentityRule {
+        type Parameters = ();
+        type Gradient = ();
+        type Error = core::convert::Infallible;
+
+        fn forward(&self, state: &f64) -> Result<f64, Self::Error> { Ok(*state) }
+        fn loss(&self, predicted: &f64, target: &f64) -> Result<f64, Self::Error> {
+            Ok((predicted - target).abs())
+        }
+    }
+
+    assert_eq!(IdentityRule.forward(&3.0).unwrap(), 3.0);
+}
+
+#[cfg(feature = "smt")]
+#[test]
+fn rewrite_solver_trait_can_be_implemented() {
+    use amari_rewrite::smt::RewriteSolver;
+
+    struct TrivialSolver;
+    impl RewriteSolver for TrivialSolver {
+        type Term = i32;
+        type Certificate = bool;
+        type Error = core::convert::Infallible;
+
+        fn prove_equivalent(&self, lhs: &i32, rhs: &i32) -> Result<bool, Self::Error> {
+            Ok(lhs == rhs)
+        }
+    }
+
+    assert!(TrivialSolver.prove_equivalent(&1, &1).unwrap());
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --features neural,smt --test experimental_features
+```
+
+Expected: FAIL because modules/traits do not exist.
+
+**Step 3: Implement traits**
+
+Create `neural::DifferentiableRule<State>` and `smt::RewriteSolver` exactly as in the design doc.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --features neural,smt --test experimental_features
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/neural amari-rewrite/src/smt amari-rewrite/src/lib.rs amari-rewrite/tests/experimental_features.rs
+git commit -m "feat: add experimental rewrite extension traits"
+```
+
+---
+
+### Task 11: Add optional amari-network bridge
+
+**Files:**
+- Create: `amari-rewrite/src/network/mod.rs`
+- Create: `amari-rewrite/tests/network_feature.rs`
+- Modify: `amari-rewrite/src/lib.rs`
+
+**Step 1: Write compile test**
+
+Create `amari-rewrite/tests/network_feature.rs`:
+
+```rust
+#![cfg(feature = "network")]
+
+use amari_rewrite::{network::RewriteGraphSummary, trs::Term};
+
+#[test]
+fn rewrite_graph_summary_tracks_terms_and_steps() {
+    let summary = RewriteGraphSummary::from_trace(&[
+        Term::constant("a"),
+        Term::sym("f", [Term::constant("a")]),
+    ]);
+
+    assert_eq!(summary.nodes, 2);
+    assert_eq!(summary.edges, 1);
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --features network --test network_feature
+```
+
+Expected: FAIL because network bridge does not exist.
+
+**Step 3: Implement minimal network bridge**
+
+Implement a conservative bridge that compiles with `amari-network` but does not overpromise learned behavior:
+
+```rust
+pub struct RewriteGraphSummary {
+    pub nodes: usize,
+    pub edges: usize,
+}
+
+impl RewriteGraphSummary {
+    pub fn from_trace<T>(trace: &[T]) -> Self {
+        Self { nodes: trace.len(), edges: trace.len().saturating_sub(1) }
+    }
+}
+```
+
+Add docs explaining that richer `GeometricNetwork` adapters are experimental future work.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo +stable test -p amari-rewrite --features network --test network_feature
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add amari-rewrite/src/network amari-rewrite/src/lib.rs amari-rewrite/tests/network_feature.rs
+git commit -m "feat: add optional network rewrite bridge"
+```
+
+---
+
+### Task 12: Add examples and docs
+
+**Files:**
+- Create: `amari-rewrite/examples/symbolic_simplification.rs`
+- Create: `amari-rewrite/examples/peano_trs.rs`
+- Create: `amari-rewrite/examples/inverse_search.rs`
+- Create: `amari-rewrite/examples/infer_rule_from_examples.rs`
+- Modify: `amari-rewrite/README.md`
+- Modify: `README.md`
+- Modify: `Cargo.toml`
+
+**Step 1: Add examples**
+
+Each example should compile and be runnable with `cargo +stable run -p amari-rewrite --example <name>`.
+
+Example topics:
+
+- symbolic simplification with custom `Expr: Rewritable`
+- Peano TRS normalization
+- predecessor search from target term
+- inferring `add(0, X) -> X`-style rules from examples
+
+**Step 2: Add root workspace visibility**
+
+Modify root `Cargo.toml`:
+
+- Add `amari-rewrite = { workspace = true, optional = true }` to root `[dependencies]`.
+- Add feature:
+
+```toml
+rewrite = ["dep:amari-rewrite"]
+```
+
+- Add `rewrite` to `full` if that is the workspace convention for new crates.
+
+Modify root `README.md` to mention `amari-rewrite` in domain/integration crate lists and 0.23.0 roadmap notes if present.
+
+**Step 3: Verify examples**
+
+Run:
+
+```bash
+cargo +stable run -p amari-rewrite --example symbolic_simplification
+cargo +stable run -p amari-rewrite --example peano_trs
+cargo +stable run -p amari-rewrite --example inverse_search
+cargo +stable run -p amari-rewrite --example infer_rule_from_examples
+```
+
+Expected: all PASS/run successfully.
+
+**Step 4: Commit**
+
+```bash
+git add Cargo.toml README.md amari-rewrite/README.md amari-rewrite/examples
+git commit -m "docs: add amari-rewrite examples"
+```
+
+---
+
+### Task 13: Full verification and cleanup
+
+**Files:**
+- Potentially modify any files with formatting/clippy/doc issues.
+
+**Step 1: Run formatting**
+
+```bash
+cargo +stable fmt --check
+```
+
+Expected: PASS. If it fails, run `cargo +stable fmt`, inspect diff, then rerun check.
+
+**Step 2: Run crate tests**
+
+```bash
+cargo +stable test -p amari-rewrite --quiet
+cargo +stable test -p amari-rewrite --all-features --quiet
+```
+
+Expected: PASS.
+
+**Step 3: Run workspace check**
+
+```bash
+cargo +stable test --workspace --quiet
+```
+
+Expected: PASS.
+
+**Step 4: Run clippy for the new crate**
+
+```bash
+cargo +stable clippy -p amari-rewrite --all-features --tests -- -D warnings
+```
+
+Expected: PASS.
+
+**Step 5: Commit cleanup if needed**
+
+```bash
+git add <changed-files>
+git commit -m "chore: verify amari-rewrite implementation"
+```
+
+---
+
+## Final PR checklist
+
+- [ ] `amari-rewrite` is in workspace members.
+- [ ] Root crate exposes optional `rewrite` feature.
+- [ ] Default build has no heavy rewrite/neural/SMT dependencies.
+- [ ] `network` feature depends on `amari-network` optionally and compiles.
+- [ ] ARS/TRS/inverse/synthesis tests pass.
+- [ ] Experimental feature tests pass.
+- [ ] Examples compile and run.
+- [ ] README and crate docs honestly mark neural/SMT/network as experimental.
+- [ ] Verification commands from Task 13 pass.


### PR DESCRIPTION
## Summary

Adds the new `amari-rewrite` workspace crate for the 0.23.0 rewrite-systems track.

- Adds stable symbolic foundations: `Rewritable`, path replacement/traversal, ARS rules/systems/strategies, TRS terms/substitutions/matching/rules, and `TermSystem` normalization.
- Adds bounded inverse rewriting and synthesis helpers: backward predecessor search, anti-unification, and basic rule inference from positive examples.
- Adds experimental feature-gated scaffolding for `neural`, `smt`, and optional `amari-network` rewrite-search guidance.
- Adds examples and README/root feature wiring for the optional umbrella `rewrite` feature.

## Design docs

- `docs/plans/2026-05-10-amari-rewrite-design.md`
- `docs/plans/2026-05-10-amari-rewrite-implementation-plan.md`

## Test Plan

- [x] `cargo +stable fmt --check`
- [x] `cargo +stable test -p amari-rewrite --all-features --quiet`
- [x] `cargo +stable clippy -p amari-rewrite --all-features --tests -- -D warnings`
- [x] `cargo +stable test --workspace --quiet`
- [x] examples run manually:
  - `cargo +stable run -p amari-rewrite --example symbolic_simplification`
  - `cargo +stable run -p amari-rewrite --example peano_trs`
  - `cargo +stable run -p amari-rewrite --example inverse_search`
  - `cargo +stable run -p amari-rewrite --example infer_rule_from_examples`

## Notes

The default crate intentionally avoids external e-graph, SMT, neural, and tensor framework dependencies. Experimental neural/SMT/network surfaces are trait/scaffold level for 0.23.0.