### PR TITLE
Prepare Amari v0.23.0 rational surreal and surcomplex release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,7 @@ jobs:
             "amari-automata"
             "amari-cgt"
             "amari-surreal"
+            "amari-surcomplex"
             "amari-enumerative"
             "amari-flynn-macros"
             "amari-flynn"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+.worktrees/
 **/*.rs.bk
 Cargo.lock
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - Unreleased
+
+### Added
+
+#### amari-surreal — exact rational scalar layer
+
+- `RationalSurreal` type providing exact rational arithmetic (not limited to dyadics), bridging the gap between `ShortSurreal`'s dyadic layer and full surreal generality
+- `RationalSurreal` supports exact construction from integer ratios (`from_ratio`), exact comparison, addition, subtraction, multiplication, and checked division
+- `from_short` / `to_short_if_dyadic` conversion between `RationalSurreal` and `ShortSurreal` (partial: `to_short_if_dyadic` returns `None` for non-dyadic rational values)
+- Sign, ordering, and arithmetic utilities including `is_zero`, `is_positive`, `is_negative`, `abs`, `checked_reciprocal`, and `checked_div`
+
+#### amari-surreal — experimental epsilon rational functions
+
+- New `experimental-epsilon` feature gate exposing `EpsilonExponent`, `EpsilonRational`, `EpsilonPolynomial`, and supporting types
+- Polynomials and rational functions in a formal positive infinitesimal `ε` ordered by asymptotic behaviour as `ε → 0⁺`
+- This is **not** a nilpotent-dual-number system: `ε²` is a smaller positive infinitesimal, not zero
+- The exponent type (`EpsilonExponent`) is a newtype wrapper so that future Puiseux / Hahn series extensions can replace the exponent without changing the public API shape
+- Future extension path: Puiseux series (rational exponents), Hahn series (well-ordered monomials), and generalized ordered-series fields are deferred — not implemented in v0.23
+
+#### New crate: `amari-surcomplex`
+
+- Exact rational complex arithmetic over `RationalSurreal` coefficients
+- `RationalSurcomplex` type with exact addition, subtraction, multiplication, checked division, conjugation, and norm-square
+- `1 / (1 + 1/2 i) = 4/5 - 2/5i` demonstrates why dyadic `ShortSurreal` coefficients are insufficient and rational scalars are needed for surcomplex closure
+- Full `Debug`, `Clone`, `PartialEq`, `Eq`, `Hash`, and `Display` support
+
+#### WASM bindings (`amari-wasm`)
+
+- `WasmRationalSurreal` with exact rational construction, conversion, arithmetic, and comparison
+- `WasmRationalSurcomplex` with exact complex arithmetic, checked division, and component accessors
+- `WasmExperimentalEpsilonRational` behind an `experimental-epsilon` feature gate for epsilon-polynomial and epsilon-rational-function construction and evaluation
+
+#### Examples suite
+
+- Surcomplex interactive page with arithmetic, division, and identity demonstrations
+- WASM version-gated coverage for rational surreal, rational surcomplex, and experimental epsilon rational bindings
+
+### Changed
+
+- `amari-surreal` `ShortSurreal` remains the finite short/dyadic layer — it does **not** claim to represent arbitrary rationals or the full surreal universe
+- `amari-surreal` README updated to document `RationalSurreal`, the `experimental-epsilon` feature, and explicit scope boundaries
+
+### Documentation
+
+- Root `README.md` updated with v0.23.0 highlights, installation examples, and surcomplex umbrella feature
+- New `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md`
+- New `docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md`
+- `docs/roadmap/amari-surreal_design.md` updated to reflect `RationalSurreal` and epsilon module
+- `docs/roadmap/amari-surcomplex_design.md` updated to reflect v0.23.0 implementation
+
+---
+
 ## [0.22.0] - Unreleased
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ amari-surreal = { path = "amari-surreal", version = "0.22.0" }
 amari-wasm = { path = "amari-wasm", version = "0.22.0" }
 
 # External dependencies
+num-rational = "0.4"
 bytemuck = "1.14"
 rayon = "1.8"
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ amari-topology = { workspace = true, optional = true }
 amari-dynamics = { workspace = true, optional = true }
 amari-cgt = { workspace = true, optional = true }
 amari-surreal = { workspace = true, optional = true }
+amari-surcomplex = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -54,10 +55,11 @@ topology = ["dep:amari-topology"]
 dynamics = ["dep:amari-dynamics"]
 cgt = ["dep:amari-cgt", "amari-enumerative/cgt-bridge"]
 surreal = ["dep:amari-surreal", "cgt"]
+surcomplex = ["dep:amari-surcomplex", "surreal"]
 # Deterministic mode for networked physics (~10-20% slower but bit-exact)
 deterministic = []
 # Enable all optional crates
-full = ["gpu", "optimization", "flynn", "measure", "calculus", "holographic", "probabilistic", "functional", "topology", "dynamics", "cgt", "surreal"]
+full = ["gpu", "optimization", "flynn", "measure", "calculus", "holographic", "probabilistic", "functional", "topology", "dynamics", "cgt", "surreal", "surcomplex"]
 
 [[test]]
 name = "integration"
@@ -69,11 +71,11 @@ path = "examples/networked_physics.rs"
 required-features = ["deterministic"]
 
 [workspace]
-members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal"]
+members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tropical", "amari-dual", "amari-fusion", "amari-automata", "amari-enumerative", "amari-relativistic", "amari-network", "amari-optimization", "amari-flynn", "amari-flynn-macros", "amari-measure", "amari-calculus", "amari-holographic", "amari-probabilistic", "amari-functional", "amari-topology", "amari-dynamics", "amari-cgt", "amari-surreal", "amari-surcomplex"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Amari Contributors"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -81,30 +83,31 @@ rust-version = "1.75"
 
 [workspace.dependencies]
 # Amari crates (internal dependencies)
-amari = { path = ".", version = "0.22.0" }
-amari-core = { path = "amari-core", version = "0.22.0" }
-amari-tropical = { path = "amari-tropical", version = "0.22.0" }
-amari-dual = { path = "amari-dual", version = "0.22.0" }
-amari-fusion = { path = "amari-fusion", version = "0.22.0" }
-amari-info-geom = { path = "amari-info-geom", version = "0.22.0" }
-amari-automata = { path = "amari-automata", version = "0.22.0" }
-amari-enumerative = { path = "amari-enumerative", version = "0.22.0" }
-amari-relativistic = { path = "amari-relativistic", version = "0.22.0" }
-amari-gpu = { path = "amari-gpu", version = "0.22.0" }
-amari-network = { path = "amari-network", version = "0.22.0" }
-amari-optimization = { path = "amari-optimization", version = "0.22.0" }
-amari-flynn = { path = "amari-flynn", version = "0.22.0" }
-amari-flynn-macros = { path = "amari-flynn-macros", version = "0.22.0" }
-amari-measure = { path = "amari-measure", version = "0.22.0" }
-amari-calculus = { path = "amari-calculus", version = "0.22.0" }
-amari-holographic = { path = "amari-holographic", version = "0.22.0" }
-amari-probabilistic = { path = "amari-probabilistic", version = "0.22.0" }
-amari-functional = { path = "amari-functional", version = "0.22.0" }
-amari-topology = { path = "amari-topology", version = "0.22.0" }
-amari-dynamics = { path = "amari-dynamics", version = "0.22.0" }
-amari-cgt = { path = "amari-cgt", version = "0.22.0" }
-amari-surreal = { path = "amari-surreal", version = "0.22.0" }
-amari-wasm = { path = "amari-wasm", version = "0.22.0" }
+amari = { path = ".", version = "0.23.0" }
+amari-core = { path = "amari-core", version = "0.23.0" }
+amari-tropical = { path = "amari-tropical", version = "0.23.0" }
+amari-dual = { path = "amari-dual", version = "0.23.0" }
+amari-fusion = { path = "amari-fusion", version = "0.23.0" }
+amari-info-geom = { path = "amari-info-geom", version = "0.23.0" }
+amari-automata = { path = "amari-automata", version = "0.23.0" }
+amari-enumerative = { path = "amari-enumerative", version = "0.23.0" }
+amari-relativistic = { path = "amari-relativistic", version = "0.23.0" }
+amari-gpu = { path = "amari-gpu", version = "0.23.0" }
+amari-network = { path = "amari-network", version = "0.23.0" }
+amari-optimization = { path = "amari-optimization", version = "0.23.0" }
+amari-flynn = { path = "amari-flynn", version = "0.23.0" }
+amari-flynn-macros = { path = "amari-flynn-macros", version = "0.23.0" }
+amari-measure = { path = "amari-measure", version = "0.23.0" }
+amari-calculus = { path = "amari-calculus", version = "0.23.0" }
+amari-holographic = { path = "amari-holographic", version = "0.23.0" }
+amari-probabilistic = { path = "amari-probabilistic", version = "0.23.0" }
+amari-functional = { path = "amari-functional", version = "0.23.0" }
+amari-topology = { path = "amari-topology", version = "0.23.0" }
+amari-dynamics = { path = "amari-dynamics", version = "0.23.0" }
+amari-cgt = { path = "amari-cgt", version = "0.23.0" }
+amari-surreal = { path = "amari-surreal", version = "0.23.0" }
+amari-surcomplex = { path = "amari-surcomplex", version = "0.23.0" }
+amari-wasm = { path = "amari-wasm", version = "0.23.0" }
 
 # External dependencies
 num-rational = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Amari v0.22.0
+# Amari v0.23.0
 
 **Comprehensive Mathematical Computing Platform with Geometric Algebra, Differential Calculus, Measure Theory, Probability Theory, Functional Analysis, Algebraic Topology, Dynamical Systems, and Vector Symbolic Architectures**
 
-A unified mathematical computing library featuring geometric algebra, differential calculus, measure theory, probability theory on geometric spaces, functional analysis (Hilbert spaces, operators, spectral theory), algebraic topology (homology, persistent homology, Morse theory), dynamical systems analysis (ODE solvers, stability, bifurcations, chaos, Lyapunov exponents), relativistic physics, tropical algebra, automatic differentiation, holographic associative memory (Vector Symbolic Architectures), optical field operations for holographic displays, and information geometry. The library provides multi-GPU infrastructure with intelligent workload distribution and complete WebAssembly support for browser deployment. Version 0.22.0 releases the `amari-cgt` and `amari-surreal` exact game-theoretic crates while preserving the 0.21.0 tropical/dual extension surface and the 0.20.0 correctness-first GPU stabilization baseline.
+A unified mathematical computing library featuring geometric algebra, differential calculus, measure theory, probability theory on geometric spaces, functional analysis (Hilbert spaces, operators, spectral theory), algebraic topology (homology, persistent homology, Morse theory), dynamical systems analysis (ODE solvers, stability, bifurcations, chaos, Lyapunov exponents), relativistic physics, tropical algebra, automatic differentiation, holographic associative memory (Vector Symbolic Architectures), optical field operations for holographic displays, and information geometry. The library provides multi-GPU infrastructure with intelligent workload distribution and complete WebAssembly support for browser deployment. Version 0.23.0 releases the `RationalSurreal` exact rational scalar layer, experimental epsilon rational functions, and the new `amari-surcomplex` exact rational complex crate while preserving the v0.22.0 CGT/surreal surface and the v0.21.0 tropical/dual extension surface.
 
 [![Rust](https://img.shields.io/badge/Rust-1.75+-orange.svg)](https://www.rust-lang.org/)
 [![WebAssembly](https://img.shields.io/badge/WebAssembly-Ready-blue.svg)](https://webassembly.org/)
@@ -11,6 +11,13 @@ A unified mathematical computing library featuring geometric algebra, differenti
 
 **[Live Examples Suite](https://amari-math.netlify.app)** | **[API Documentation](https://docs.rs/amari)** | **[MCP Server](https://github.com/justinelliottcobb/Amari-mcp)**
 
+
+## v0.23.0 Highlights
+
+- **`RationalSurreal`** in `amari-surreal` is now a stable exact rational scalar field backed by `BigRational`, going beyond the finite dyadic `ShortSurreal` layer. `ShortSurreal` remains the short/dyadic slice — it does not claim arbitrary rationals or the full surreal universe.
+- **`amari-surcomplex`** is a new crate providing exact rational complex arithmetic over `RationalSurreal`. Division `1 / (1 + 1/2 i) = 4/5 - 2/5i` demonstrates why dyadic `ShortSurreal` coefficients are insufficient for surcomplex closure and rational scalars are needed.
+- **Epsilon rational functions** are available behind `experimental-epsilon` in `amari-surreal` — polynomials and rational functions in a formal positive infinitesimal `ε`, ordered by asymptotic behaviour as `ε → 0⁺`. This is **not** a nilpotent-dual-number system. Puiseux series, Hahn series, and generalized ordered-series fields remain a future extension path, not implemented in v0.23.
+- **`amari-wasm`** exposes `WasmRationalSurreal`, `WasmRationalSurcomplex`, and `WasmExperimentalEpsilonRational` to TypeScript, with dynamic WASM version-gating in the examples suite.
 
 ## v0.22.0 Highlights
 
@@ -73,21 +80,22 @@ A unified mathematical computing library featuring geometric algebra, differenti
 - **TypeScript Support**: Complete TypeScript definitions included
 - **Cross-Platform**: Linux, macOS, Windows, browsers, Node.js, and edge computing environments
 
-## v0.22.0 Exact Game-Theoretic Extensions
+## v0.23.0 Rational Surreal & Surcomplex Extensions
 
-The workspace now includes two opt-in exact game-theoretic crates released for the `0.22.0` cycle:
+The workspace now includes the exact rational surreal scalar layer, experimental epsilon rational functions, and the new `amari-surcomplex` crate:
 
-- **`amari-cgt`**: computational combinatorial game theory for short normal-play games, including canonicalization, nimbers, and small exhaustive layer generation
-- **`amari-surreal`**: computable short surreal numbers built on validated numeric games from `amari-cgt`, with exact dyadic arithmetic
+- **`RationalSurreal`** in `amari-surreal`: exact rational scalar field bridging the gap between the dyadic `ShortSurreal` layer and full surreal generality. `ShortSurreal` remains the short/dyadic slice — it does not claim arbitrary rationals or the full surreal universe.
+- **`amari-surreal` experimental-epsilon**: epsilon polynomials and rational functions in a formal positive infinitesimal `ε` (not nilpotent dual numbers; Puiseux/Hahn/generalized series deferred to future extensions)
+- **`amari-surcomplex`**: exact rational complex arithmetic over `RationalSurreal`, separate crate from `amari-surreal`
 
 At the umbrella-crate level these are exposed through optional features:
 
 ```toml
 [dependencies]
-amari = { version = "0.22.0", features = ["cgt", "surreal"] }
+amari = { version = "0.23.0", features = ["surreal", "surcomplex"] }
 ```
 
-`surreal` implies `cgt`, while `cgt` also enables the lightweight `amari-enumerative` bridge for CGT layer-growth summaries.
+`surcomplex` implies `surreal`, which implies `cgt`. The `surreal` feature also gates `RationalSurreal` and the opt-in `experimental-epsilon` feature.
 
 ## Installation
 
@@ -98,71 +106,72 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Complete library with all features
-amari = "0.22.0"
+amari = "0.23.0"
 
 # Or individual crates:
 
 # Core geometric algebra and mathematical foundations
-amari-core = "0.22.0"
+amari-core = "0.23.0"
 
 # Differential calculus with geometric algebra
-amari-calculus = "0.22.0"
+amari-calculus = "0.23.0"
 
 # Measure theory and integration
-amari-measure = "0.22.0"
+amari-measure = "0.23.0"
 
 # Probability theory on geometric algebra spaces
-amari-probabilistic = "0.22.0"
+amari-probabilistic = "0.23.0"
 
 # Functional analysis: Hilbert spaces, operators, spectral theory
-amari-functional = "0.22.0"
+amari-functional = "0.23.0"
 
 # Algebraic topology: homology, persistent homology, Morse theory
-amari-topology = "0.22.0"
+amari-topology = "0.23.0"
 
 # Dynamical systems: ODE solvers, stability, bifurcations, Lyapunov exponents
-amari-dynamics = "0.22.0"
+amari-dynamics = "0.23.0"
 
 # Vector Symbolic Architectures, holographic memory, and optical fields
-amari-holographic = "0.22.0"
+amari-holographic = "0.23.0"
 
 # High-precision relativistic physics
-amari-relativistic = { version = "0.22.0", features = ["high-precision"] }
+amari-relativistic = { version = "0.23.0", features = ["high-precision"] }
 
 # GPU acceleration (includes optical field GPU operations)
-amari-gpu = "0.22.0"
+amari-gpu = "0.23.0"
 
 # Optimization algorithms
-amari-optimization = "0.22.0"
+amari-optimization = "0.23.0"
 
 # Additional mathematical systems
-amari-tropical = "0.22.0"    # max-plus semiring + ordinal weights below ε₀
-amari-dual = "0.22.0"        # forward-mode AD + branch policies + static gradients
-amari-info-geom = "0.22.0"
-amari-automata = "0.22.0"
-amari-fusion = "0.22.0"
-amari-network = "0.22.0"
-amari-enumerative = "0.22.0"
-amari-cgt = "0.22.0"         # short combinatorial games + nimbers
-amari-surreal = "0.22.0"    # exact short surreal numbers over numeric games
+amari-tropical = "0.23.0"    # max-plus semiring + ordinal weights below ε₀
+amari-dual = "0.23.0"        # forward-mode AD + branch policies + static gradients
+amari-info-geom = "0.23.0"
+amari-automata = "0.23.0"
+amari-fusion = "0.23.0"
+amari-network = "0.23.0"
+amari-enumerative = "0.23.0"
+amari-cgt = "0.23.0"         # short combinatorial games + nimbers
+amari-surreal = "0.23.0"    # exact rational surreal scalars + epsilon rationals
+amari-surcomplex = "0.23.0" # exact rational surcomplex arithmetic
 
 # Probabilistic verification contracts (SMT-LIB2, Monte Carlo)
-amari-flynn = "0.22.0"
+amari-flynn = "0.23.0"
 
 # Optional Rust-side WebAssembly crate
-amari-wasm = "0.22.0"
+amari-wasm = "0.23.0"
 ```
 
 ### JavaScript/TypeScript (WebAssembly)
 
 ```bash
-npm install @justinelliottcobb/amari-wasm@0.22.0
+npm install @justinelliottcobb/amari-wasm@0.23.0
 ```
 
 Or with yarn:
 
 ```bash
-yarn add @justinelliottcobb/amari-wasm@0.22.0
+yarn add @justinelliottcobb/amari-wasm@0.23.0
 ```
 
 ## Quick Start
@@ -826,12 +835,13 @@ The **[Amari Examples Suite](https://amari-math.netlify.app)** provides comprehe
 
 - **Interactive Playground**: Write and run JavaScript code with live WASM execution
 
-## Examples & Documentation (v0.22.0)
+## Examples & Documentation (v0.23.0)
 
-The examples suite is versioned for `0.22.0` and now includes release-focused CGT/surreal WebAssembly workflows alongside the broader mathematical catalog:
+The examples suite is versioned for `0.23.0` and now includes release-focused rational surreal / surcomplex workflows alongside the v0.22 CGT/surreal workflows and the broader mathematical catalog:
 
 - **CGT 0.22.0 WASM examples**: `WasmCgtArena`, short-game cuts, outcomes, comparison, nimbers, and `WasmGameInspection`
 - **Surreal 0.22.0 WASM examples**: `WasmDyadic`, `WasmShortSurreal`, exact dyadic arithmetic, checked division, and numeric-game conversion
+- **Rational surreal / surcomplex 0.23.0 WASM examples**: `WasmRationalSurreal`, `WasmRationalSurcomplex`, `WasmExperimentalEpsilonRational`, exact rational division, surcomplex division, and infinitesimal ordering
 - **Tropical 0.21.0 WASM examples**: `TropicalBatch.foldOplus`, `TropicalBatch.foldOtimes`, `WasmOrdinalArena`, and `WasmOrdinalWeight`
 - **Dual 0.21.0 WASM examples**: `WasmBranchPolicy`, `WasmMultiDualNumber.variables(...)`, and `WasmStaticMultiDual2` hot-loop gradients
 - **API reference coverage**: the new CGT/surreal and tropical/dual extension classes and methods are listed in the browser reference

--- a/amari-gpu/Cargo.toml
+++ b/amari-gpu/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["mathematics", "science", "algorithms"]
 # Default to no high-precision for GPU (and WASM compatibility)
 # These are specified directly instead of via workspace inheritance so
 # `default-features = false` is honored without Cargo warnings.
-amari-core = { path = "../amari-core", version = "0.22.0", default-features = false, features = ["std", "phantom-types"] }
-amari-info-geom = { path = "../amari-info-geom", version = "0.22.0", default-features = false, features = ["std"] }
-amari-network = { path = "../amari-network", version = "0.22.0", default-features = false, features = ["std"] }
-amari-relativistic = { path = "../amari-relativistic", version = "0.22.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
+amari-info-geom = { path = "../amari-info-geom", version = "0.23.0", default-features = false, features = ["std"] }
+amari-network = { path = "../amari-network", version = "0.23.0", default-features = false, features = ["std"] }
+amari-relativistic = { path = "../amari-relativistic", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
 amari-measure = { workspace = true, optional = true }
 amari-calculus = { workspace = true, optional = true }
 amari-tropical = { workspace = true, optional = true }

--- a/amari-relativistic/Cargo.toml
+++ b/amari-relativistic/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["mathematics", "science", "simulation", "algorithms"]
 [dependencies]
 # Use a direct dependency instead of workspace inheritance so `default-features = false`
 # is honored (Cargo ignores it unless the workspace dependency also sets it).
-amari-core = { path = "../amari-core", version = "0.22.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
 nalgebra = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 num-traits = { workspace = true }

--- a/amari-surcomplex/Cargo.toml
+++ b/amari-surcomplex/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "amari-surcomplex"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Exact rational surcomplex numbers for the Amari library"
+repository = "https://github.com/justinelliottcobb/Amari"
+homepage = "https://github.com/justinelliottcobb/Amari"
+keywords = ["mathematics", "surreal", "complex", "exact"]
+categories = ["mathematics", "science", "algorithms"]
+
+[dependencies]
+amari-surreal = { workspace = true }
+thiserror = { workspace = true }
+num-bigint = "0.4"
+
+[dev-dependencies]
+criterion = "0.8"

--- a/amari-surcomplex/Cargo.toml
+++ b/amari-surcomplex/Cargo.toml
@@ -14,7 +14,3 @@ categories = ["mathematics", "science", "algorithms"]
 [dependencies]
 amari-surreal = { workspace = true }
 thiserror = { workspace = true }
-num-bigint = "0.4"
-
-[dev-dependencies]
-criterion = "0.8"

--- a/amari-surcomplex/README.md
+++ b/amari-surcomplex/README.md
@@ -1,0 +1,33 @@
+# amari-surcomplex
+
+Exact rational surcomplex numbers for the [Amari](https://github.com/justinelliottcobb/Amari) mathematical computing library.
+
+`amari-surcomplex` provides [`RationalSurcomplex`](crate::RationalSurcomplex), an exact complex number backed by the rational surreal scalars in `amari-surreal`. All arithmetic — addition, subtraction, multiplication, division, conjugation, and norm — is exact, with no floating-point rounding.
+
+## Features
+
+- **Exact complex arithmetic** over the rationals
+- **Division** producing non-dyadic coefficients (e.g., `1 / (1 + 1/2 i) = 4/5 - 2/5 i`)
+- **Conjugate** and **norm** operations
+- Full `Debug`, `Clone`, `PartialEq`, `Eq`, `Hash`, and `Display` support
+
+## Usage
+
+```rust
+use amari_surcomplex::RationalSurcomplex;
+use amari_surreal::RationalSurreal;
+
+let i = RationalSurcomplex::i();
+assert_eq!(i.clone() * i, RationalSurcomplex::from_integer(-1));
+
+let one = RationalSurreal::one();
+let half = RationalSurreal::from_ratio(1, 2).unwrap();
+let z = RationalSurcomplex::from_parts(one, half);
+let q = RationalSurcomplex::one().checked_div(&z).unwrap();
+assert_eq!(q.real().to_string(), "4/5");
+assert_eq!(q.imag().to_string(), "-2/5");
+```
+
+## License
+
+Licensed under either of [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE), at your option.

--- a/amari-surcomplex/src/error.rs
+++ b/amari-surcomplex/src/error.rs
@@ -1,0 +1,17 @@
+use amari_surreal::SurrealError;
+use thiserror::Error;
+
+/// Result type for `amari-surcomplex` operations.
+pub type Result<T> = core::result::Result<T, SurcomplexError>;
+
+/// Errors produced by `amari-surcomplex`.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SurcomplexError {
+    /// Returned when division by zero is attempted.
+    #[error("division by zero")]
+    DivisionByZero,
+
+    /// Error propagated from `amari-surreal`.
+    #[error(transparent)]
+    Surreal(#[from] SurrealError),
+}

--- a/amari-surcomplex/src/lib.rs
+++ b/amari-surcomplex/src/lib.rs
@@ -1,0 +1,28 @@
+//! Exact rational surcomplex numbers for Amari.
+//!
+//! This crate provides [`RationalSurcomplex`], an exact complex number
+//! backed by [`RationalSurreal`] from `amari-surreal`.  It supports
+//! addition, subtraction, multiplication, division, conjugation, and
+//! norm — all exact without floating-point rounding.
+//!
+//! # Example
+//!
+//! ```rust
+//! use amari_surcomplex::RationalSurcomplex;
+//! use amari_surreal::RationalSurreal;
+//!
+//! // 1 / (1 + 1/2 i) = 4/5 - 2/5 i
+//! let one = RationalSurreal::one();
+//! let half = RationalSurreal::from_ratio(1, 2).unwrap();
+//! let z = RationalSurcomplex::from_parts(one, half);
+//! let q = RationalSurcomplex::one().checked_div(&z).unwrap();
+//! assert_eq!(q.real().to_string(), "4/5");
+//! assert_eq!(q.imag().to_string(), "-2/5");
+//! ```
+
+pub mod error;
+pub mod prelude;
+pub mod rational;
+
+pub use error::{Result, SurcomplexError};
+pub use rational::RationalSurcomplex;

--- a/amari-surcomplex/src/lib.rs
+++ b/amari-surcomplex/src/lib.rs
@@ -1,7 +1,7 @@
 //! Exact rational surcomplex numbers for Amari.
 //!
 //! This crate provides [`RationalSurcomplex`], an exact complex number
-//! backed by [`RationalSurreal`] from `amari-surreal`.  It supports
+//! backed by `RationalSurreal` from `amari-surreal`.  It supports
 //! addition, subtraction, multiplication, division, conjugation, and
 //! norm — all exact without floating-point rounding.
 //!

--- a/amari-surcomplex/src/prelude.rs
+++ b/amari-surcomplex/src/prelude.rs
@@ -1,0 +1,4 @@
+//! Common imports for `amari-surcomplex`.
+
+pub use crate::error::{Result, SurcomplexError};
+pub use crate::rational::RationalSurcomplex;

--- a/amari-surcomplex/src/rational.rs
+++ b/amari-surcomplex/src/rational.rs
@@ -45,9 +45,9 @@ impl RationalSurcomplex {
 
     /// Creates a real surcomplex from an integer.
     #[must_use]
-    pub fn from_integer<N: Into<num_bigint::BigInt>>(n: N) -> Self {
+    pub fn from_integer<N: Into<i128>>(n: N) -> Self {
         Self {
-            real: RationalSurreal::from_integer(n),
+            real: RationalSurreal::from_integer(n.into()),
             imag: RationalSurreal::zero(),
         }
     }

--- a/amari-surcomplex/src/rational.rs
+++ b/amari-surcomplex/src/rational.rs
@@ -102,12 +102,14 @@ impl RationalSurcomplex {
 
     /// Returns a checked reciprocal (`1 / self`).
     ///
-    /// Returns `SurcomplexError::DivisionByZero` when the value is zero.
-    ///
     /// Uses the formula:
     /// ```text
     /// 1 / (a + bi) = (a - bi) / (a² + b²) = conjugate / norm_sq
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurcomplexError::DivisionByZero`] when the value is zero.
     pub fn checked_reciprocal(&self) -> Result<Self> {
         let norm = self.norm_sq();
         if norm.is_zero() {
@@ -122,12 +124,14 @@ impl RationalSurcomplex {
 
     /// Returns `self / rhs`.
     ///
-    /// Returns `SurcomplexError::DivisionByZero` when `rhs` is zero.
-    ///
     /// Uses the formula:
     /// ```text
     /// (a + bi) / (c + di) = ((a + bi)(c - di)) / (c² + d²)
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SurcomplexError::DivisionByZero`] when `rhs` is zero.
     pub fn checked_div(&self, rhs: &Self) -> Result<Self> {
         let denom_norm = rhs.norm_sq();
         if denom_norm.is_zero() {
@@ -163,13 +167,23 @@ impl Hash for RationalSurcomplex {
 
 impl fmt::Display for RationalSurcomplex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let one = RationalSurreal::one();
         match (self.real.is_zero(), self.imag.is_zero()) {
             (true, true) => write!(f, "0"),
             (false, true) => write!(f, "{}", self.real),
+            (true, false) if self.imag == one => write!(f, "i"),
+            (true, false) if self.imag == -one.clone() => write!(f, "-i"),
             (true, false) => write!(f, "{}i", self.imag),
             (false, false) => {
                 if self.imag.is_negative() {
-                    write!(f, "{} - {}i", self.real, self.imag.abs())
+                    let imag_abs = self.imag.abs();
+                    if imag_abs == one {
+                        write!(f, "{} - i", self.real)
+                    } else {
+                        write!(f, "{} - {}i", self.real, imag_abs)
+                    }
+                } else if self.imag == one {
+                    write!(f, "{} + i", self.real)
                 } else {
                     write!(f, "{} + {}i", self.real, self.imag)
                 }

--- a/amari-surcomplex/src/rational.rs
+++ b/amari-surcomplex/src/rational.rs
@@ -1,0 +1,228 @@
+use crate::error::{Result, SurcomplexError};
+use amari_surreal::RationalSurreal;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Mul, Neg, Sub};
+
+/// Exact rational surcomplex number `a + bi` with `a, b ∈ Q`.
+///
+/// `RationalSurcomplex` pairs two [`RationalSurreal`] values to form an
+/// exact complex number over the rationals.  It supports addition,
+/// subtraction, multiplication, conjugation, norm, and division.
+#[derive(Debug, Clone)]
+pub struct RationalSurcomplex {
+    real: RationalSurreal,
+    imag: RationalSurreal,
+}
+
+impl RationalSurcomplex {
+    /// Returns zero (`0 + 0i`).
+    #[must_use]
+    pub fn zero() -> Self {
+        Self {
+            real: RationalSurreal::zero(),
+            imag: RationalSurreal::zero(),
+        }
+    }
+
+    /// Returns one (`1 + 0i`).
+    #[must_use]
+    pub fn one() -> Self {
+        Self {
+            real: RationalSurreal::one(),
+            imag: RationalSurreal::zero(),
+        }
+    }
+
+    /// Returns the imaginary unit `i` (`0 + 1i`).
+    #[must_use]
+    pub fn i() -> Self {
+        Self {
+            real: RationalSurreal::zero(),
+            imag: RationalSurreal::one(),
+        }
+    }
+
+    /// Creates a real surcomplex from an integer.
+    #[must_use]
+    pub fn from_integer<N: Into<num_bigint::BigInt>>(n: N) -> Self {
+        Self {
+            real: RationalSurreal::from_integer(n),
+            imag: RationalSurreal::zero(),
+        }
+    }
+
+    /// Creates a real surcomplex from a [`RationalSurreal`].
+    #[must_use]
+    pub fn from_real(real: RationalSurreal) -> Self {
+        Self {
+            real,
+            imag: RationalSurreal::zero(),
+        }
+    }
+
+    /// Creates a surcomplex from real and imaginary parts.
+    #[must_use]
+    pub fn from_parts(real: RationalSurreal, imag: RationalSurreal) -> Self {
+        Self { real, imag }
+    }
+
+    /// Returns a reference to the real part.
+    #[must_use]
+    pub fn real(&self) -> &RationalSurreal {
+        &self.real
+    }
+
+    /// Returns a reference to the imaginary part.
+    #[must_use]
+    pub fn imag(&self) -> &RationalSurreal {
+        &self.imag
+    }
+
+    /// Returns the complex conjugate `a - bi`.
+    #[must_use]
+    pub fn conjugate(&self) -> Self {
+        Self {
+            real: self.real.clone(),
+            imag: -self.imag.clone(),
+        }
+    }
+
+    /// Returns the squared norm `a² + b²`.
+    #[must_use]
+    pub fn norm_sq(&self) -> RationalSurreal {
+        self.real.clone() * self.real.clone() + self.imag.clone() * self.imag.clone()
+    }
+
+    /// Returns whether the surcomplex is zero.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.real.is_zero() && self.imag.is_zero()
+    }
+
+    /// Returns a checked reciprocal (`1 / self`).
+    ///
+    /// Returns `SurcomplexError::DivisionByZero` when the value is zero.
+    ///
+    /// Uses the formula:
+    /// ```text
+    /// 1 / (a + bi) = (a - bi) / (a² + b²) = conjugate / norm_sq
+    /// ```
+    pub fn checked_reciprocal(&self) -> Result<Self> {
+        let norm = self.norm_sq();
+        if norm.is_zero() {
+            return Err(SurcomplexError::DivisionByZero);
+        }
+        let inv_norm = norm.checked_reciprocal()?;
+        Ok(Self {
+            real: self.real.clone() * inv_norm.clone(),
+            imag: -self.imag.clone() * inv_norm,
+        })
+    }
+
+    /// Returns `self / rhs`.
+    ///
+    /// Returns `SurcomplexError::DivisionByZero` when `rhs` is zero.
+    ///
+    /// Uses the formula:
+    /// ```text
+    /// (a + bi) / (c + di) = ((a + bi)(c - di)) / (c² + d²)
+    /// ```
+    pub fn checked_div(&self, rhs: &Self) -> Result<Self> {
+        let denom_norm = rhs.norm_sq();
+        if denom_norm.is_zero() {
+            return Err(SurcomplexError::DivisionByZero);
+        }
+        // (a + bi)(c - di) = (ac + bd) + (bc - ad)i
+        let ac = self.real.clone() * rhs.real.clone();
+        let bd = self.imag.clone() * rhs.imag.clone();
+        let bc = self.imag.clone() * rhs.real.clone();
+        let ad = self.real.clone() * rhs.imag.clone();
+        let inv_denom = denom_norm.checked_reciprocal()?;
+        Ok(Self {
+            real: (ac + bd) * inv_denom.clone(),
+            imag: (bc - ad) * inv_denom,
+        })
+    }
+}
+
+impl PartialEq for RationalSurcomplex {
+    fn eq(&self, other: &Self) -> bool {
+        self.real == other.real && self.imag == other.imag
+    }
+}
+
+impl Eq for RationalSurcomplex {}
+
+impl Hash for RationalSurcomplex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.real.hash(state);
+        self.imag.hash(state);
+    }
+}
+
+impl fmt::Display for RationalSurcomplex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.real.is_zero(), self.imag.is_zero()) {
+            (true, true) => write!(f, "0"),
+            (false, true) => write!(f, "{}", self.real),
+            (true, false) => write!(f, "{}i", self.imag),
+            (false, false) => {
+                if self.imag.is_negative() {
+                    write!(f, "{} - {}i", self.real, self.imag.abs())
+                } else {
+                    write!(f, "{} + {}i", self.real, self.imag)
+                }
+            }
+        }
+    }
+}
+
+impl Add for RationalSurcomplex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            real: self.real + rhs.real,
+            imag: self.imag + rhs.imag,
+        }
+    }
+}
+
+impl Sub for RationalSurcomplex {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            real: self.real - rhs.real,
+            imag: self.imag - rhs.imag,
+        }
+    }
+}
+
+impl Mul for RationalSurcomplex {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        // (a + bi)(c + di) = (ac - bd) + (ad + bc)i
+        let ac = self.real.clone() * rhs.real.clone();
+        let bd = self.imag.clone() * rhs.imag.clone();
+        let ad = self.real * rhs.imag;
+        let bc = self.imag * rhs.real;
+        Self {
+            real: ac - bd,
+            imag: ad + bc,
+        }
+    }
+}
+
+impl Neg for RationalSurcomplex {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            real: -self.real,
+            imag: -self.imag,
+        }
+    }
+}

--- a/amari-surcomplex/tests/arithmetic.rs
+++ b/amari-surcomplex/tests/arithmetic.rs
@@ -1,4 +1,4 @@
-use amari_surcomplex::RationalSurcomplex;
+use amari_surcomplex::{RationalSurcomplex, SurcomplexError};
 use amari_surreal::RationalSurreal;
 
 #[test]
@@ -26,4 +26,87 @@ fn rational_surcomplex_norm_and_conjugate_identity() {
     let product = z.clone() * z.conjugate();
     assert_eq!(product.imag(), &RationalSurreal::zero());
     assert_eq!(product.real(), &z.norm_sq());
+}
+
+// ── division-by-zero error paths ──────────────────────────────────
+
+#[test]
+fn checked_reciprocal_of_zero_returns_error() {
+    assert_eq!(
+        RationalSurcomplex::zero().checked_reciprocal(),
+        Err(SurcomplexError::DivisionByZero),
+    );
+}
+
+#[test]
+fn checked_div_by_zero_returns_error() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(3, 1).unwrap(),
+        RationalSurreal::from_ratio(4, 1).unwrap(),
+    );
+    assert_eq!(
+        z.checked_div(&RationalSurcomplex::zero()),
+        Err(SurcomplexError::DivisionByZero),
+    );
+}
+
+// ── core identities ──────────────────────────────────────────────
+
+#[test]
+fn zero_is_additive_identity() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(7, 5).unwrap(),
+        RationalSurreal::from_ratio(-3, 2).unwrap(),
+    );
+    let zero = RationalSurcomplex::zero();
+    assert_eq!(z.clone() + zero.clone(), z);
+    assert_eq!(zero + z.clone(), z);
+}
+
+#[test]
+fn one_is_multiplicative_identity() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(7, 5).unwrap(),
+        RationalSurreal::from_ratio(-3, 2).unwrap(),
+    );
+    let one = RationalSurcomplex::one();
+    assert_eq!(z.clone() * one.clone(), z);
+    assert_eq!(one * z.clone(), z);
+}
+
+#[test]
+fn negation_is_additive_inverse() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(7, 5).unwrap(),
+        RationalSurreal::from_ratio(-3, 2).unwrap(),
+    );
+    let neg = -z.clone();
+    assert_eq!(z + neg, RationalSurcomplex::zero());
+}
+
+// ── Display smoke tests ──────────────────────────────────────────
+
+#[test]
+fn display_zero() {
+    assert_eq!(RationalSurcomplex::zero().to_string(), "0");
+}
+
+#[test]
+fn display_pure_real() {
+    let r = RationalSurcomplex::from_integer(5);
+    assert_eq!(r.to_string(), "5");
+}
+
+#[test]
+fn display_i() {
+    assert_eq!(RationalSurcomplex::i().to_string(), "1i");
+}
+
+#[test]
+fn display_full_complex() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(3, 2).unwrap(),
+        RationalSurreal::from_ratio(-5, 3).unwrap(),
+    );
+    assert_eq!(z.to_string(), "3/2 - 5/3i");
 }

--- a/amari-surcomplex/tests/arithmetic.rs
+++ b/amari-surcomplex/tests/arithmetic.rs
@@ -99,7 +99,8 @@ fn display_pure_real() {
 
 #[test]
 fn display_i() {
-    assert_eq!(RationalSurcomplex::i().to_string(), "1i");
+    assert_eq!(RationalSurcomplex::i().to_string(), "i");
+    assert_eq!((-RationalSurcomplex::i()).to_string(), "-i");
 }
 
 #[test]
@@ -109,4 +110,12 @@ fn display_full_complex() {
         RationalSurreal::from_ratio(-5, 3).unwrap(),
     );
     assert_eq!(z.to_string(), "3/2 - 5/3i");
+
+    let unit_imag =
+        RationalSurcomplex::from_parts(RationalSurreal::from_integer(2), RationalSurreal::one());
+    assert_eq!(unit_imag.to_string(), "2 + i");
+
+    let negative_unit_imag =
+        RationalSurcomplex::from_parts(RationalSurreal::from_integer(2), -RationalSurreal::one());
+    assert_eq!(negative_unit_imag.to_string(), "2 - i");
 }

--- a/amari-surcomplex/tests/arithmetic.rs
+++ b/amari-surcomplex/tests/arithmetic.rs
@@ -1,0 +1,29 @@
+use amari_surcomplex::RationalSurcomplex;
+use amari_surreal::RationalSurreal;
+
+#[test]
+fn rational_surcomplex_multiplies_i_squared_to_minus_one() {
+    let i = RationalSurcomplex::i();
+    assert_eq!(i.clone() * i, RationalSurcomplex::from_integer(-1));
+}
+
+#[test]
+fn rational_surcomplex_division_produces_non_dyadic_coefficients() {
+    let one = RationalSurreal::one();
+    let half = RationalSurreal::from_ratio(1, 2).unwrap();
+    let z = RationalSurcomplex::from_parts(one.clone(), half);
+    let quotient = RationalSurcomplex::one().checked_div(&z).unwrap();
+    assert_eq!(quotient.real().to_string(), "4/5");
+    assert_eq!(quotient.imag().to_string(), "-2/5");
+}
+
+#[test]
+fn rational_surcomplex_norm_and_conjugate_identity() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(3, 2).unwrap(),
+        RationalSurreal::from_ratio(-5, 3).unwrap(),
+    );
+    let product = z.clone() * z.conjugate();
+    assert_eq!(product.imag(), &RationalSurreal::zero());
+    assert_eq!(product.real(), &z.norm_sq());
+}

--- a/amari-surreal/Cargo.toml
+++ b/amari-surreal/Cargo.toml
@@ -27,6 +27,7 @@ criterion = "0.8"
 default = ["std"]
 std = []
 serialize = ["dep:serde"]
+experimental-epsilon = []
 
 [[bench]]
 name = "dyadic"

--- a/amari-surreal/Cargo.toml
+++ b/amari-surreal/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 serde = { workspace = true, optional = true }
 num-bigint = "0.4"
 num-integer = "0.1"
+num-rational = { workspace = true }
 num-traits = { workspace = true }
 
 [dev-dependencies]

--- a/amari-surreal/README.md
+++ b/amari-surreal/README.md
@@ -4,7 +4,9 @@ Computable surreal numbers for the Amari library.
 
 ## Current scope
 
-The current implementation focuses on **short surreal numbers**:
+The crate provides two layers:
+
+### `ShortSurreal` — finite short/dyadic layer
 
 - exact dyadic arithmetic
 - conversion from numeric short games in `amari-cgt`
@@ -12,9 +14,31 @@ The current implementation focuses on **short surreal numbers**:
 - simplest-number construction for finite cuts
 - birthday-aware short surreal values
 
+### `RationalSurreal` — exact rational scalar field
+
+- exact rational arithmetic backed by `BigRational`, not limited to dyadics
+- bridges the gap between the dyadic `ShortSurreal` layer and full surreal generality
+- exact construction from integer ratios (`from_ratio`), exact comparison, addition, subtraction, multiplication, and checked division
+- `from_short` / `to_short_if_dyadic` conversion between `RationalSurreal` and `ShortSurreal` (partial: non-dyadic rational values return `None`)
+- sign, ordering, and arithmetic utilities (`is_zero`, `is_positive`, `is_negative`, `abs`, `checked_reciprocal`, `checked_div`)
+
+### Experimental epsilon rational functions
+
+Behind the `experimental-epsilon` feature gate:
+
+- polynomials and rational functions in a formal positive infinitesimal `ε`
+- ordered by asymptotic behaviour as `ε → 0⁺`
+- coefficient field is `RationalSurreal`
+- **not** a nilpotent-dual-number system: `ε²` is a smaller positive infinitesimal, not zero
+- the exponent type (`EpsilonExponent`) is a newtype wrapper so that future Puiseux / Hahn series extensions can replace the exponent without changing the public API shape
+
 ## Important scope boundary
 
-This crate does **not** currently claim to implement the full proper class of surreal numbers. The implemented scope is the computationally useful short-surreal / dyadic layer.
+This crate does **not** currently claim to implement the full proper class of surreal numbers. The implemented scope is:
+
+- `ShortSurreal` — the computationally useful short-surreal / dyadic layer, not arbitrary rationals
+- `RationalSurreal` — the exact rational scalar field, not arbitrary surreal numbers
+- `experimental-epsilon` — formal epsilon rational functions, not Puiseux series, Hahn series, or generalized ordered-series fields (all deferred to future extensions)
 
 ## Example
 
@@ -30,4 +54,15 @@ let half = ShortSurreal::from_game(&mut arena, half_game)?;
 
 assert_eq!(half.to_dyadic(), Dyadic::new(1, 1));
 # Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+### RationalSurreal example
+
+```rust
+use amari_surreal::RationalSurreal;
+
+let a = RationalSurreal::from_ratio(1, 3).unwrap();
+let b = RationalSurreal::from_ratio(2, 5).unwrap();
+let sum = a + b; // 11/15
+assert_eq!(sum.to_string(), "11/15");
 ```

--- a/amari-surreal/src/epsilon.rs
+++ b/amari-surreal/src/epsilon.rs
@@ -1,0 +1,766 @@
+//! Experimental epsilon rational functions.
+//!
+//! Polynomials and rational functions in a formal positive infinitesimal
+//! `ε`, ordered by asymptotic behaviour as `ε → 0⁺`.
+//!
+//! The coefficient field is [`RationalSurreal`](crate::RationalSurreal).
+//! A polynomial in ε is stored as a map from integer exponents to
+//! nonzero rational surreal coefficients.  A rational function is a
+//! pair of such polynomials with the denominator normalised to have a
+//! positive leading coefficient.
+//!
+//! # Design notes
+//!
+//! - The exponent type is a newtype wrapper (`EpsilonExponent`) so that
+//!   future Puiseux / Hahn extensions can replace the exponent without
+//!   changing the public API shape.
+//! - `ε²` is a *positive* infinitesimal smaller than `ε` — this is **not**
+//!   a nilpotent-dual-number system.
+//! - No polynomial GCD normalisation is attempted; zero removal and
+//!   denominator-sign normalisation are enough to keep display and
+//!   testing stable for the current feature set.
+
+use crate::error::SurrealError;
+use crate::rational::RationalSurreal;
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::ops::{Add, Mul, Neg, Sub};
+
+// ---------------------------------------------------------------------------
+// Exponent newtype
+// ---------------------------------------------------------------------------
+
+/// Exponent for epsilon terms.
+///
+/// Wraps `i32` to leave room for non-integer exponent types in future
+/// Puiseux-series or Hahn-series extensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EpsilonExponent(pub i32);
+
+// ---------------------------------------------------------------------------
+// EpsilonPolynomial
+// ---------------------------------------------------------------------------
+
+/// A polynomial in a formal positive infinitesimal `ε` with rational
+/// surreal coefficients.
+///
+/// # Internal representation
+///
+/// Terms are stored in a [`BTreeMap`] keyed by [`EpsilonExponent`].
+/// Zero coefficients are removed during normalisation so that every
+/// stored term carries a nonzero coefficient.  The polynomial is
+/// ordered by increasing exponent.
+///
+/// # Asymptotic ordering (ε → 0⁺)
+///
+/// Terms with **smaller** exponents dominate — the leading term for
+/// asymptotic comparison is the smallest exponent with nonzero
+/// coefficient.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EpsilonPolynomial {
+    terms: BTreeMap<EpsilonExponent, RationalSurreal>,
+}
+
+// -- constructors -----------------------------------------------------------
+
+impl EpsilonPolynomial {
+    /// The zero polynomial.
+    #[must_use]
+    pub fn zero() -> Self {
+        Self {
+            terms: BTreeMap::new(),
+        }
+    }
+
+    /// The constant polynomial `1`.
+    #[must_use]
+    pub fn one() -> Self {
+        Self::from_scalar(RationalSurreal::one())
+    }
+
+    /// The monomial `ε` (coefficient 1 at exponent 1).
+    #[must_use]
+    pub fn epsilon() -> Self {
+        Self::monomial(RationalSurreal::one(), 1)
+    }
+
+    /// A single monomial `coeff · ε^exp`.
+    ///
+    /// Returns the zero polynomial when `coeff` is zero.
+    #[must_use]
+    pub fn monomial(coeff: RationalSurreal, exp: i32) -> Self {
+        if coeff.is_zero() {
+            Self::zero()
+        } else {
+            let mut terms = BTreeMap::new();
+            terms.insert(EpsilonExponent(exp), coeff);
+            Self { terms }
+        }
+    }
+
+    /// Build a polynomial from a scalar (constant term).
+    #[must_use]
+    pub fn from_scalar(scalar: RationalSurreal) -> Self {
+        if scalar.is_zero() {
+            Self::zero()
+        } else {
+            let mut terms = BTreeMap::new();
+            terms.insert(EpsilonExponent(0), scalar);
+            Self { terms }
+        }
+    }
+
+    /// Build a polynomial from a coefficient vector.
+    ///
+    /// The coefficient at index `k` is the coefficient of `ε^k`.
+    /// Zero coefficients are skipped.
+    #[must_use]
+    pub fn from_coefficients(coeffs: Vec<RationalSurreal>) -> Self {
+        let mut terms = BTreeMap::new();
+        for (k, coeff) in coeffs.into_iter().enumerate() {
+            if !coeff.is_zero() {
+                terms.insert(EpsilonExponent(k as i32), coeff);
+            }
+        }
+        Self { terms }
+    }
+}
+
+// -- queries ----------------------------------------------------------------
+
+impl EpsilonPolynomial {
+    /// The degree (largest exponent with a nonzero coefficient) or
+    /// `None` for the zero polynomial.
+    #[must_use]
+    pub fn degree(&self) -> Option<i32> {
+        self.terms.keys().last().map(|e| e.0)
+    }
+
+    /// The valuation (smallest exponent with a nonzero coefficient) or
+    /// `None` for the zero polynomial.
+    #[must_use]
+    pub fn valuation(&self) -> Option<i32> {
+        self.terms.keys().next().map(|e| e.0)
+    }
+
+    /// Whether the polynomial is identically zero.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// Whether the polynomial is the constant `1`.
+    #[must_use]
+    pub fn is_one(&self) -> bool {
+        matches!(self.degree(), Some(0))
+            && self.terms.get(&EpsilonExponent(0)) == Some(&RationalSurreal::one())
+    }
+
+    /// Sign of the polynomial as `ε → 0⁺`.
+    ///
+    /// Returns `Some(Ordering::Less)` for negative, `Some(Ordering::Greater)`
+    /// for positive, and `None` for the zero polynomial.
+    #[must_use]
+    pub fn sign_epsilon(&self) -> Option<Ordering> {
+        self.valuation()
+            .map(|v| self.terms[&EpsilonExponent(v)].cmp(&RationalSurreal::zero()))
+    }
+
+    /// Reference to the internal term map (for tests / inspection).
+    #[must_use]
+    pub fn terms(&self) -> &BTreeMap<EpsilonExponent, RationalSurreal> {
+        &self.terms
+    }
+}
+
+// -- arithmetic -------------------------------------------------------------
+
+impl Add for EpsilonPolynomial {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut terms = self.terms;
+        for (exp, coeff) in rhs.terms {
+            let entry = terms.entry(exp).or_insert_with(RationalSurreal::zero);
+            *entry = entry.clone() + coeff;
+        }
+        terms.retain(|_, v| !v.is_zero());
+        Self { terms }
+    }
+}
+
+impl Sub for EpsilonPolynomial {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Mul for EpsilonPolynomial {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut terms: BTreeMap<EpsilonExponent, RationalSurreal> = BTreeMap::new();
+        for (&exp_a, coeff_a) in &self.terms {
+            for (&exp_b, coeff_b) in &rhs.terms {
+                let exp = EpsilonExponent(exp_a.0 + exp_b.0);
+                let prod = coeff_a.clone() * coeff_b.clone();
+                let entry = terms.entry(exp).or_insert_with(RationalSurreal::zero);
+                *entry = entry.clone() + prod;
+            }
+        }
+        terms.retain(|_, v| !v.is_zero());
+        Self { terms }
+    }
+}
+
+impl Neg for EpsilonPolynomial {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        let terms: BTreeMap<_, _> = self.terms.into_iter().map(|(k, v)| (k, -v)).collect();
+        Self { terms }
+    }
+}
+
+// -- formatting -------------------------------------------------------------
+
+impl fmt::Display for EpsilonPolynomial {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0");
+        }
+        let mut first = true;
+        for (exp, coeff) in &self.terms {
+            if !first {
+                write!(f, " + ")?;
+            }
+            first = false;
+            match exp.0 {
+                0 => write!(f, "{coeff}")?,
+                1 => write!(f, "{coeff}·ε")?,
+                e => write!(f, "{coeff}·ε^{e}")?,
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EpsilonRational
+// ---------------------------------------------------------------------------
+
+/// A rational function of a formal positive infinitesimal `ε` with
+/// rational surreal coefficients.
+///
+/// Internally represented as a numerator and denominator polynomial.
+/// The denominator is normalised so that its leading coefficient
+/// (as `ε → 0⁺`) is positive, which makes comparison straightforward.
+#[derive(Debug, Clone)]
+pub struct EpsilonRational {
+    numer: EpsilonPolynomial,
+    denom: EpsilonPolynomial,
+}
+
+// -- constructors -----------------------------------------------------------
+
+impl EpsilonRational {
+    /// The rational function `0 / 1`.
+    #[must_use]
+    pub fn zero() -> Self {
+        Self {
+            numer: EpsilonPolynomial::zero(),
+            denom: EpsilonPolynomial::one(),
+        }
+    }
+
+    /// The rational function `1 / 1`.
+    #[must_use]
+    pub fn one() -> Self {
+        Self {
+            numer: EpsilonPolynomial::one(),
+            denom: EpsilonPolynomial::one(),
+        }
+    }
+
+    /// The rational function `ε / 1`.
+    #[must_use]
+    pub fn epsilon() -> Self {
+        Self::monomial(RationalSurreal::one(), 1)
+    }
+
+    /// A monomial rational function `coeff · ε^exp / 1`.
+    #[must_use]
+    pub fn monomial(coeff: RationalSurreal, exp: i32) -> Self {
+        Self {
+            numer: EpsilonPolynomial::monomial(coeff, exp),
+            denom: EpsilonPolynomial::one(),
+        }
+    }
+
+    /// Build from a scalar constant: `scalar / 1`.
+    #[must_use]
+    pub fn from_scalar(scalar: RationalSurreal) -> Self {
+        Self {
+            numer: EpsilonPolynomial::from_scalar(scalar),
+            denom: EpsilonPolynomial::one(),
+        }
+    }
+
+    /// Build a rational function from a coefficient vector.
+    ///
+    /// The coefficient at index `k` is the coefficient of `ε^k` in the
+    /// numerator; the denominator is `1`.
+    #[must_use]
+    pub fn from_polynomial(coeffs: Vec<RationalSurreal>) -> Self {
+        Self {
+            numer: EpsilonPolynomial::from_coefficients(coeffs),
+            denom: EpsilonPolynomial::one(),
+        }
+    }
+
+    /// Build directly from numerator and denominator polynomials.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when the denominator is
+    /// the zero polynomial.
+    pub fn from_parts(
+        numer: EpsilonPolynomial,
+        denom: EpsilonPolynomial,
+    ) -> Result<Self, SurrealError> {
+        if denom.is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        Ok(Self { numer, denom }.normalize())
+    }
+}
+
+// -- accessors --------------------------------------------------------------
+
+impl EpsilonRational {
+    /// Reference to the numerator polynomial.
+    #[must_use]
+    pub fn numer(&self) -> &EpsilonPolynomial {
+        &self.numer
+    }
+
+    /// Reference to the denominator polynomial.
+    #[must_use]
+    pub fn denom(&self) -> &EpsilonPolynomial {
+        &self.denom
+    }
+}
+
+// -- arithmetic -------------------------------------------------------------
+
+impl EpsilonRational {
+    /// Checked reciprocal `1 / self`.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when the numerator is zero
+    /// (i.e. `self` is the zero rational function).
+    pub fn checked_reciprocal(&self) -> Result<Self, SurrealError> {
+        if self.numer.is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        Ok(Self {
+            numer: self.denom.clone(),
+            denom: self.numer.clone(),
+        }
+        .normalize())
+    }
+
+    /// Checked division `self / rhs`.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when `rhs` is zero.
+    pub fn checked_div(&self, rhs: &Self) -> Result<Self, SurrealError> {
+        let recip = rhs.checked_reciprocal()?;
+        Ok(self.clone() * recip)
+    }
+}
+
+impl Add for EpsilonRational {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        // N1/D1 + N2/D2 = (N1*D2 + N2*D1) / (D1*D2)
+        let numer = self.numer.clone() * rhs.denom.clone() + rhs.numer.clone() * self.denom.clone();
+        let denom = self.denom * rhs.denom;
+        Self { numer, denom }.normalize()
+    }
+}
+
+impl Sub for EpsilonRational {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + (-rhs)
+    }
+}
+
+impl Mul for EpsilonRational {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let numer = self.numer * rhs.numer;
+        let denom = self.denom * rhs.denom;
+        Self { numer, denom }.normalize()
+    }
+}
+
+impl Neg for EpsilonRational {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            numer: -self.numer,
+            denom: self.denom,
+        }
+    }
+}
+
+// -- equality (cross-multiplication) --------------------------------------
+
+impl PartialEq for EpsilonRational {
+    fn eq(&self, other: &Self) -> bool {
+        // N₁/D₁ == N₂/D₂  ⇔  N₁·D₂ == N₂·D₁
+        let left = self.numer.clone() * other.denom.clone();
+        let right = other.numer.clone() * self.denom.clone();
+        left == right
+    }
+}
+
+impl Eq for EpsilonRational {}
+
+// -- ordering ---------------------------------------------------------------
+
+impl PartialOrd for EpsilonRational {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EpsilonRational {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // self - other = (N1*D2 - N2*D1) / (D1*D2).
+        //
+        // Both denominators are normalised so that their leading
+        // coefficients are positive, therefore D1*D2 also has a
+        // positive leading coefficient and the sign of the difference
+        // is exactly the sign of the numerator polynomial.
+        let diff_num =
+            self.numer.clone() * other.denom.clone() - other.numer.clone() * self.denom.clone();
+        diff_num.sign_epsilon().unwrap_or(Ordering::Equal)
+    }
+}
+
+// -- internal normalisation -------------------------------------------------
+
+impl EpsilonRational {
+    /// Normalise by removing zero coefficients and ensuring the
+    /// denominator's leading coefficient is positive.
+    fn normalize(mut self) -> Self {
+        // Remove any zero coefficients that may have been introduced.
+        self.numer.terms.retain(|_, v| !v.is_zero());
+        self.denom.terms.retain(|_, v| !v.is_zero());
+
+        // If the denominator's leading coefficient is negative, negate
+        // both numerator and denominator to keep the denominator
+        // positive.  (The denominator is known to be nonzero.)
+        if let Some(ordering) = self.denom.sign_epsilon() {
+            if ordering == Ordering::Less {
+                self.numer = -self.numer;
+                self.denom = -self.denom;
+            }
+        }
+
+        // If both numerator and denominator are scalar constants,
+        // simplify to a / 1 via rational scalar division.
+        if self.numer.degree() == Some(0) && self.denom.degree() == Some(0) {
+            let num_val = self.numer.terms().get(&EpsilonExponent(0)).unwrap();
+            let den_val = self.denom.terms().get(&EpsilonExponent(0)).unwrap();
+            // denom is nonzero (already checked).
+            let scalar = num_val
+                .clone()
+                .checked_div(den_val)
+                .expect("denominator constant is nonzero");
+            self.numer = EpsilonPolynomial::from_scalar(scalar);
+            self.denom = EpsilonPolynomial::one();
+        }
+
+        self
+    }
+}
+
+// -- formatting -------------------------------------------------------------
+
+impl fmt::Display for EpsilonRational {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.denom.is_one() {
+            write!(f, "{}", self.numer)
+        } else {
+            write!(f, "({}) / ({})", self.numer, self.denom)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RationalSurreal;
+
+    // -- polynomial utilities -----------------------------------------------
+
+    #[test]
+    fn zero_polynomial_is_zero() {
+        let z = EpsilonPolynomial::zero();
+        assert!(z.is_zero());
+        assert_eq!(z.degree(), None);
+        assert_eq!(z.valuation(), None);
+        assert_eq!(z.sign_epsilon(), None);
+    }
+
+    #[test]
+    fn one_polynomial_has_degree_zero() {
+        let one = EpsilonPolynomial::one();
+        assert!(one.is_one());
+        assert_eq!(one.degree(), Some(0));
+        assert_eq!(one.valuation(), Some(0));
+    }
+
+    #[test]
+    fn epsilon_polynomial_has_degree_one() {
+        let eps = EpsilonPolynomial::epsilon();
+        assert_eq!(eps.degree(), Some(1));
+        assert_eq!(eps.valuation(), Some(1));
+    }
+
+    #[test]
+    fn polynomial_addition() {
+        let a = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::from_integer(1),
+            RationalSurreal::from_integer(2),
+        ]);
+        let b = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::from_integer(3),
+            RationalSurreal::from_integer(4),
+        ]);
+        let sum = a + b;
+        assert_eq!(sum.degree(), Some(1));
+        let c0 = sum.terms().get(&EpsilonExponent(0)).unwrap();
+        assert_eq!(*c0, RationalSurreal::from_integer(4));
+        let c1 = sum.terms().get(&EpsilonExponent(1)).unwrap();
+        assert_eq!(*c1, RationalSurreal::from_integer(6));
+    }
+
+    #[test]
+    fn polynomial_multiplication() {
+        // (1 + ε) * (1 - ε) = 1 - ε²
+        let a = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::one(),
+            RationalSurreal::one(),
+        ]);
+        let neg_one = RationalSurreal::one().neg();
+        let b = EpsilonPolynomial::from_coefficients(vec![RationalSurreal::one(), neg_one]);
+        let product = a * b;
+        assert_eq!(product.degree(), Some(2));
+        assert_eq!(
+            *product.terms().get(&EpsilonExponent(0)).unwrap(),
+            RationalSurreal::one()
+        );
+        assert_eq!(
+            *product.terms().get(&EpsilonExponent(2)).unwrap(),
+            RationalSurreal::one().neg()
+        );
+    }
+
+    #[test]
+    fn polynomial_negation() {
+        let a = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::from_integer(3),
+            RationalSurreal::from_integer(-2),
+        ]);
+        let neg = -a.clone();
+        let sum = a + neg;
+        assert!(sum.is_zero());
+    }
+
+    #[test]
+    fn polynomial_sign_epsilon() {
+        // 1 - 1000ε: leading term is 1 > 0
+        let p = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::one(),
+            RationalSurreal::from_integer(-1000),
+        ]);
+        assert_eq!(p.sign_epsilon(), Some(Ordering::Greater));
+
+        // -0.5 + ε: leading term is -0.5 < 0
+        let q = EpsilonPolynomial::from_coefficients(vec![
+            RationalSurreal::from_ratio(-1, 2).unwrap(),
+            RationalSurreal::one(),
+        ]);
+        assert_eq!(q.sign_epsilon(), Some(Ordering::Less));
+
+        // ε: positive
+        let r = EpsilonPolynomial::epsilon();
+        assert_eq!(r.sign_epsilon(), Some(Ordering::Greater));
+    }
+
+    // -- ordering -----------------------------------------------------------
+
+    #[test]
+    fn epsilon_is_positive_infinitesimal() {
+        let eps = EpsilonRational::epsilon();
+        assert!(eps > EpsilonRational::zero());
+        assert!(
+            eps < EpsilonRational::from_scalar(RationalSurreal::from_ratio(1, 1_000_000).unwrap())
+        );
+    }
+
+    #[test]
+    fn epsilon_squared_is_strictly_smaller_than_epsilon() {
+        let eps = EpsilonRational::epsilon();
+        let eps_sq = eps.clone() * eps.clone();
+        assert!(eps_sq < eps);
+    }
+
+    #[test]
+    fn inverse_epsilon_is_larger_than_any_test_integer() {
+        let inv = EpsilonRational::one()
+            .checked_div(&EpsilonRational::epsilon())
+            .unwrap();
+        assert!(inv > EpsilonRational::from_scalar(RationalSurreal::from_integer(1_000_000)));
+    }
+
+    #[test]
+    fn rational_arithmetic_is_exact() {
+        let eps = EpsilonRational::epsilon();
+        let one = EpsilonRational::one();
+        // (1 + ε) / (1 - ε)
+        let expr = (one.clone() + eps.clone())
+            .checked_div(&(one.clone() - eps.clone()))
+            .unwrap();
+        // Denominator (from checked_div) = (1) * (1 - ε) = 1 - ε
+        assert_eq!(expr.denom().degree(), Some(1));
+    }
+
+    #[test]
+    fn polynomial_degree() {
+        // 3 + 2ε + ε² as a polynomial (from_polynomial builds numer only)
+        let coeffs = vec![
+            RationalSurreal::from_integer(3),
+            RationalSurreal::from_integer(2),
+            RationalSurreal::one(),
+        ];
+        let poly = EpsilonRational::from_polynomial(coeffs.clone());
+        let numer: &EpsilonPolynomial = poly.numer();
+        assert_eq!(numer.degree(), Some(2));
+        assert_eq!(poly.denom().degree(), Some(0));
+    }
+
+    #[test]
+    fn polynomial_ordering() {
+        // 3 + 2ε + ε²
+        let coeffs = vec![
+            RationalSurreal::from_integer(3),
+            RationalSurreal::from_integer(2),
+            RationalSurreal::one(),
+        ];
+        let poly = EpsilonRational::from_polynomial(coeffs.clone());
+        // It must be positive and larger than 3
+        assert!(poly > EpsilonRational::from_scalar(RationalSurreal::from_integer(3)));
+        // And less than 4 (since 2ε + ε² < 1 for small epsilon)
+        assert!(poly < EpsilonRational::from_scalar(RationalSurreal::from_integer(4)));
+    }
+
+    #[test]
+    fn division_and_multiplication_are_consistent() {
+        let a = EpsilonRational::from_scalar(RationalSurreal::from_integer(6));
+        let b = EpsilonRational::from_scalar(RationalSurreal::from_integer(3));
+        let q = a.checked_div(&b).unwrap();
+        assert_eq!(
+            q,
+            EpsilonRational::from_scalar(RationalSurreal::from_integer(2))
+        );
+    }
+
+    #[test]
+    fn reciprocal_of_scalar() {
+        let two = EpsilonRational::from_scalar(RationalSurreal::from_integer(2));
+        let half = two.checked_reciprocal().unwrap();
+        assert_eq!(half.numer().degree(), Some(0));
+        assert_eq!(half.denom().degree(), Some(0));
+        assert!(half > EpsilonRational::zero() && half < EpsilonRational::one());
+    }
+
+    #[test]
+    fn addition_commutative() {
+        let a = EpsilonRational::from_polynomial(vec![
+            RationalSurreal::from_integer(1),
+            RationalSurreal::from_integer(2),
+        ]);
+        let b = EpsilonRational::from_polynomial(vec![
+            RationalSurreal::from_integer(3),
+            RationalSurreal::one(),
+        ]);
+        assert_eq!(a.clone() + b.clone(), b + a);
+    }
+
+    #[test]
+    fn zero_is_additive_identity() {
+        let p = EpsilonRational::monomial(RationalSurreal::from_integer(5), 0);
+        assert_eq!(p.clone() + EpsilonRational::zero(), p);
+    }
+
+    #[test]
+    fn negative_is_additive_inverse() {
+        let p = EpsilonRational::from_polynomial(vec![
+            RationalSurreal::from_integer(1),
+            RationalSurreal::from_integer(-2),
+            RationalSurreal::one(),
+        ]);
+        let neg = -p.clone();
+        assert_eq!(p + neg, EpsilonRational::zero());
+    }
+
+    #[test]
+    fn one_is_multiplicative_identity() {
+        let p = EpsilonRational::monomial(RationalSurreal::from_integer(7), 2);
+        assert_eq!(p.clone() * EpsilonRational::one(), p);
+    }
+
+    #[test]
+    fn denominator_sign_normalization() {
+        // Construct a negative-denom rational via from_parts.
+        let numer = EpsilonPolynomial::from_coefficients(vec![RationalSurreal::one()]);
+        let denom = EpsilonPolynomial::from_coefficients(vec![RationalSurreal::one().neg()]);
+        let r = EpsilonRational::from_parts(numer, denom).unwrap();
+        // Denom should have been flipped to 1, numer to -1.
+        assert_eq!(r.numer().degree(), Some(0));
+        assert!(r < EpsilonRational::zero());
+    }
+
+    #[test]
+    fn equal_values_compare_equal() {
+        // Same rational value, different representation.
+        let a = EpsilonRational::from_scalar(RationalSurreal::from_integer(2));
+        let b = EpsilonRational::from_parts(
+            EpsilonPolynomial::from_scalar(RationalSurreal::from_integer(6)),
+            EpsilonPolynomial::from_scalar(RationalSurreal::from_integer(3)),
+        )
+        .unwrap();
+        assert_eq!(a, b);
+        // Verify Ord (not just PartialEq) handles equality correctly.
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+    }
+
+    #[test]
+    fn zero_denom_rejected() {
+        let r = EpsilonRational::from_parts(EpsilonPolynomial::one(), EpsilonPolynomial::zero());
+        assert!(r.is_err());
+    }
+}

--- a/amari-surreal/src/epsilon.rs
+++ b/amari-surreal/src/epsilon.rs
@@ -3,7 +3,7 @@
 //! Polynomials and rational functions in a formal positive infinitesimal
 //! `ε`, ordered by asymptotic behaviour as `ε → 0⁺`.
 //!
-//! The coefficient field is [`RationalSurreal`](crate::RationalSurreal).
+//! The coefficient field is [`RationalSurreal`].
 //! A polynomial in ε is stored as a map from integer exponents to
 //! nonzero rational surreal coefficients.  A rational function is a
 //! pair of such polynomials with the denominator normalised to have a

--- a/amari-surreal/src/epsilon.rs
+++ b/amari-surreal/src/epsilon.rs
@@ -350,6 +350,12 @@ impl EpsilonRational {
     pub fn denom(&self) -> &EpsilonPolynomial {
         &self.denom
     }
+
+    /// Whether the rational function is identically zero.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.numer.is_zero()
+    }
 }
 
 // -- arithmetic -------------------------------------------------------------
@@ -420,6 +426,21 @@ impl Neg for EpsilonRational {
 }
 
 // -- equality (cross-multiplication) --------------------------------------
+//
+// IMPORTANT: Hash footgun warning.
+//
+// `PartialEq` / `Eq` compare rational functions via cross-multiplication
+//   N₁/D₁ == N₂/D₂  ⇔  N₁·D₂ == N₂·D₁
+// without first reducing to a canonical normal form (no polynomial GCD
+// normalisation is performed).  Equality is therefore representation-
+// independent, but the internal `numer` / `denom` fields may differ for
+// equal values.
+//
+// **Do NOT derive `Hash` structurally** on `EpsilonRational` unless a
+// canonical normal form is introduced.  A structural hash would violate
+// the `Hash` / `Eq` contract: two equal values with different internal
+// representations would produce different hashes, breaking `HashSet` and
+// `HashMap` correctness.
 
 impl PartialEq for EpsilonRational {
     fn eq(&self, other: &Self) -> bool {
@@ -476,10 +497,18 @@ impl EpsilonRational {
 
         // If both numerator and denominator are scalar constants,
         // simplify to a / 1 via rational scalar division.
+        //
+        // Safety of `unwrap` / `expect` below:
+        // - `degree() == Some(0)` guarantees that the map contains the
+        //   key `EpsilonExponent(0)` with a nonzero coefficient (zero
+        //   coefficients are retained during normalisation only at
+        //   exponent 0 for constant denominators, and `retain` above
+        //   removes all-zero entries elsewhere).
+        // - The denominator is known nonzero from the constructor guard,
+        //   so `checked_div` on a nonzero denominator succeeds.
         if self.numer.degree() == Some(0) && self.denom.degree() == Some(0) {
             let num_val = self.numer.terms().get(&EpsilonExponent(0)).unwrap();
             let den_val = self.denom.terms().get(&EpsilonExponent(0)).unwrap();
-            // denom is nonzero (already checked).
             let scalar = num_val
                 .clone()
                 .checked_div(den_val)

--- a/amari-surreal/src/epsilon.rs
+++ b/amari-surreal/src/epsilon.rs
@@ -366,7 +366,7 @@ impl EpsilonRational {
     /// Returns `SurrealError::DivisionByZero` when the numerator is zero
     /// (i.e. `self` is the zero rational function).
     pub fn checked_reciprocal(&self) -> Result<Self, SurrealError> {
-        if self.numer.is_zero() {
+        if self.is_zero() {
             return Err(SurrealError::DivisionByZero);
         }
         Ok(Self {
@@ -499,11 +499,10 @@ impl EpsilonRational {
         // simplify to a / 1 via rational scalar division.
         //
         // Safety of `unwrap` / `expect` below:
-        // - `degree() == Some(0)` guarantees that the map contains the
-        //   key `EpsilonExponent(0)` with a nonzero coefficient (zero
-        //   coefficients are retained during normalisation only at
-        //   exponent 0 for constant denominators, and `retain` above
-        //   removes all-zero entries elsewhere).
+        // - The `retain` call above removes every zero coefficient from
+        //   the map.  Therefore `degree() == Some(0)` guarantees that
+        //   the key `EpsilonExponent(0)` is present with a nonzero
+        //   coefficient.
         // - The denominator is known nonzero from the constructor guard,
         //   so `checked_div` on a nonzero denominator succeeds.
         if self.numer.degree() == Some(0) && self.denom.degree() == Some(0) {
@@ -637,73 +636,6 @@ mod tests {
         // ε: positive
         let r = EpsilonPolynomial::epsilon();
         assert_eq!(r.sign_epsilon(), Some(Ordering::Greater));
-    }
-
-    // -- ordering -----------------------------------------------------------
-
-    #[test]
-    fn epsilon_is_positive_infinitesimal() {
-        let eps = EpsilonRational::epsilon();
-        assert!(eps > EpsilonRational::zero());
-        assert!(
-            eps < EpsilonRational::from_scalar(RationalSurreal::from_ratio(1, 1_000_000).unwrap())
-        );
-    }
-
-    #[test]
-    fn epsilon_squared_is_strictly_smaller_than_epsilon() {
-        let eps = EpsilonRational::epsilon();
-        let eps_sq = eps.clone() * eps.clone();
-        assert!(eps_sq < eps);
-    }
-
-    #[test]
-    fn inverse_epsilon_is_larger_than_any_test_integer() {
-        let inv = EpsilonRational::one()
-            .checked_div(&EpsilonRational::epsilon())
-            .unwrap();
-        assert!(inv > EpsilonRational::from_scalar(RationalSurreal::from_integer(1_000_000)));
-    }
-
-    #[test]
-    fn rational_arithmetic_is_exact() {
-        let eps = EpsilonRational::epsilon();
-        let one = EpsilonRational::one();
-        // (1 + ε) / (1 - ε)
-        let expr = (one.clone() + eps.clone())
-            .checked_div(&(one.clone() - eps.clone()))
-            .unwrap();
-        // Denominator (from checked_div) = (1) * (1 - ε) = 1 - ε
-        assert_eq!(expr.denom().degree(), Some(1));
-    }
-
-    #[test]
-    fn polynomial_degree() {
-        // 3 + 2ε + ε² as a polynomial (from_polynomial builds numer only)
-        let coeffs = vec![
-            RationalSurreal::from_integer(3),
-            RationalSurreal::from_integer(2),
-            RationalSurreal::one(),
-        ];
-        let poly = EpsilonRational::from_polynomial(coeffs.clone());
-        let numer: &EpsilonPolynomial = poly.numer();
-        assert_eq!(numer.degree(), Some(2));
-        assert_eq!(poly.denom().degree(), Some(0));
-    }
-
-    #[test]
-    fn polynomial_ordering() {
-        // 3 + 2ε + ε²
-        let coeffs = vec![
-            RationalSurreal::from_integer(3),
-            RationalSurreal::from_integer(2),
-            RationalSurreal::one(),
-        ];
-        let poly = EpsilonRational::from_polynomial(coeffs.clone());
-        // It must be positive and larger than 3
-        assert!(poly > EpsilonRational::from_scalar(RationalSurreal::from_integer(3)));
-        // And less than 4 (since 2ε + ε² < 1 for small epsilon)
-        assert!(poly < EpsilonRational::from_scalar(RationalSurreal::from_integer(4)));
     }
 
     #[test]

--- a/amari-surreal/src/lib.rs
+++ b/amari-surreal/src/lib.rs
@@ -27,9 +27,11 @@ pub mod dyadic;
 pub mod error;
 pub mod numeric;
 pub mod prelude;
+pub mod rational;
 pub mod short;
 
 pub use dyadic::Dyadic;
 pub use error::{Result, SurrealError};
 pub use numeric::NumericGame;
+pub use rational::RationalSurreal;
 pub use short::ShortSurreal;

--- a/amari-surreal/src/lib.rs
+++ b/amari-surreal/src/lib.rs
@@ -30,8 +30,14 @@ pub mod prelude;
 pub mod rational;
 pub mod short;
 
+#[cfg(feature = "experimental-epsilon")]
+pub mod epsilon;
+
 pub use dyadic::Dyadic;
 pub use error::{Result, SurrealError};
 pub use numeric::NumericGame;
 pub use rational::RationalSurreal;
 pub use short::ShortSurreal;
+
+#[cfg(feature = "experimental-epsilon")]
+pub use epsilon::{EpsilonPolynomial, EpsilonRational};

--- a/amari-surreal/src/prelude.rs
+++ b/amari-surreal/src/prelude.rs
@@ -3,4 +3,5 @@
 pub use crate::dyadic::Dyadic;
 pub use crate::error::{Result, SurrealError};
 pub use crate::numeric::NumericGame;
+pub use crate::rational::RationalSurreal;
 pub use crate::short::ShortSurreal;

--- a/amari-surreal/src/prelude.rs
+++ b/amari-surreal/src/prelude.rs
@@ -5,3 +5,6 @@ pub use crate::error::{Result, SurrealError};
 pub use crate::numeric::NumericGame;
 pub use crate::rational::RationalSurreal;
 pub use crate::short::ShortSurreal;
+
+#[cfg(feature = "experimental-epsilon")]
+pub use crate::epsilon::{EpsilonPolynomial, EpsilonRational};

--- a/amari-surreal/src/rational.rs
+++ b/amari-surreal/src/rational.rs
@@ -138,6 +138,11 @@ impl RationalSurreal {
     ///
     /// Returns `Some` only when the normalized denominator is a power
     /// of two (dyadic rational); returns `None` for non-dyadic values.
+    ///
+    /// `BigRational` always stores the value in normalised form with
+    /// a positive denominator, so we only need to check whether that
+    /// denominator is a power of two.  The loop strips factors of two
+    /// and, if the residual is one, the denominator is a power of two.
     #[must_use]
     pub fn to_short_if_dyadic(&self) -> Option<ShortSurreal> {
         let denom = self.value.denom();

--- a/amari-surreal/src/rational.rs
+++ b/amari-surreal/src/rational.rs
@@ -1,0 +1,228 @@
+use crate::dyadic::Dyadic;
+use crate::error::SurrealError;
+use crate::short::ShortSurreal;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_rational::BigRational;
+use num_traits::{One, Signed, Zero};
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Mul, Neg, Sub};
+
+/// Exact rational number backed by `num_rational::BigRational`.
+///
+/// `RationalSurreal` provides an exact rational scalar field for the
+/// surcomplex layer (v0.23+). It augments the existing dyadic
+/// [`ShortSurreal`] layer with true rational division, supporting
+/// denominators that are not powers of two.
+#[derive(Debug, Clone)]
+pub struct RationalSurreal {
+    value: BigRational,
+}
+
+impl RationalSurreal {
+    /// Returns zero.
+    #[must_use]
+    pub fn zero() -> Self {
+        Self {
+            value: BigRational::from_integer(BigInt::from(0)),
+        }
+    }
+
+    /// Returns one.
+    #[must_use]
+    pub fn one() -> Self {
+        Self {
+            value: BigRational::from_integer(BigInt::from(1)),
+        }
+    }
+
+    /// Creates a rational surreal from an integer.
+    #[must_use]
+    pub fn from_integer<N: Into<BigInt>>(n: N) -> Self {
+        Self {
+            value: BigRational::from_integer(n.into()),
+        }
+    }
+
+    /// Creates a rational surreal from a numerator and denominator.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when the denominator is zero.
+    pub fn from_ratio<N: Into<BigInt>, D: Into<BigInt>>(
+        numer: N,
+        denom: D,
+    ) -> Result<Self, SurrealError> {
+        let denom: BigInt = denom.into();
+        if denom.is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        let value = BigRational::new(numer.into(), denom);
+        Ok(Self { value })
+    }
+
+    /// Converts a [`ShortSurreal`] into a rational surreal.
+    #[must_use]
+    pub fn from_short(value: ShortSurreal) -> Self {
+        let dyadic = value.to_dyadic();
+        let numer = dyadic.numer().clone();
+        let denom = BigInt::from(1) << dyadic.exponent();
+        Self {
+            value: BigRational::new(numer, denom),
+        }
+    }
+
+    /// Returns the normalized numerator.
+    #[must_use]
+    pub fn numer(&self) -> &BigInt {
+        self.value.numer()
+    }
+
+    /// Returns the normalized denominator.
+    #[must_use]
+    pub fn denom(&self) -> &BigInt {
+        self.value.denom()
+    }
+
+    /// Returns whether the rational is zero.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.value.numer().is_zero()
+    }
+
+    /// Returns whether the rational is positive.
+    #[must_use]
+    pub fn is_positive(&self) -> bool {
+        self.value.numer().is_positive()
+    }
+
+    /// Returns whether the rational is negative.
+    #[must_use]
+    pub fn is_negative(&self) -> bool {
+        self.value.numer().is_negative()
+    }
+
+    /// Returns the absolute value of the rational.
+    #[must_use]
+    pub fn abs(&self) -> Self {
+        Self {
+            value: self.value.abs(),
+        }
+    }
+
+    /// Returns a checked reciprocal.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when the value is zero.
+    pub fn checked_reciprocal(&self) -> Result<Self, SurrealError> {
+        if self.value.numer().is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        Ok(Self {
+            value: self.value.recip(),
+        })
+    }
+
+    /// Returns `self / rhs`.
+    ///
+    /// Returns `SurrealError::DivisionByZero` when `rhs` is zero.
+    pub fn checked_div(&self, rhs: &Self) -> Result<Self, SurrealError> {
+        if rhs.value.numer().is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        Ok(Self {
+            value: &self.value / &rhs.value,
+        })
+    }
+
+    /// Converts to a [`ShortSurreal`] when the value is dyadic.
+    ///
+    /// Returns `Some` only when the normalized denominator is a power
+    /// of two (dyadic rational); returns `None` for non-dyadic values.
+    #[must_use]
+    pub fn to_short_if_dyadic(&self) -> Option<ShortSurreal> {
+        let denom = self.value.denom();
+        let mut d = denom.clone();
+        let mut exponent: u32 = 0;
+        while d.is_even() {
+            d >>= 1;
+            exponent += 1;
+        }
+        if !d.is_one() {
+            return None;
+        }
+        Some(ShortSurreal::from_dyadic(Dyadic::new(
+            self.value.numer().clone(),
+            exponent,
+        )))
+    }
+}
+
+impl PartialEq for RationalSurreal {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Eq for RationalSurreal {}
+
+impl Hash for RationalSurreal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl PartialOrd for RationalSurreal {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RationalSurreal {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl Add for RationalSurreal {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value + rhs.value,
+        }
+    }
+}
+
+impl Sub for RationalSurreal {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value - rhs.value,
+        }
+    }
+}
+
+impl Mul for RationalSurreal {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value * rhs.value,
+        }
+    }
+}
+
+impl Neg for RationalSurreal {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self { value: -self.value }
+    }
+}
+
+impl fmt::Display for RationalSurreal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}

--- a/amari-surreal/tests/epsilon.rs
+++ b/amari-surreal/tests/epsilon.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "experimental-epsilon")]
+
+use amari_surreal::epsilon::{EpsilonPolynomial, EpsilonRational};
+use amari_surreal::RationalSurreal;
+
+#[test]
+fn epsilon_is_positive_infinitesimal() {
+    let eps = EpsilonRational::epsilon();
+    assert!(eps > EpsilonRational::zero());
+    // from_ratio(1, 1_000_000) is known-valid because the denominator is nonzero.
+    assert!(eps < EpsilonRational::from_scalar(RationalSurreal::from_ratio(1, 1_000_000).unwrap()));
+}
+
+#[test]
+fn epsilon_squared_is_strictly_smaller_than_epsilon() {
+    let eps = EpsilonRational::epsilon();
+    let eps_sq = eps.clone() * eps.clone();
+    assert!(eps_sq < eps);
+}
+
+#[test]
+fn inverse_epsilon_is_larger_than_any_test_integer() {
+    let inv = EpsilonRational::one()
+        .checked_div(&EpsilonRational::epsilon())
+        .unwrap();
+    assert!(inv > EpsilonRational::from_scalar(RationalSurreal::from_integer(1_000_000)));
+}
+
+#[test]
+fn epsilon_rational_arithmetic_is_exact() {
+    let eps = EpsilonRational::epsilon();
+    let one = EpsilonRational::one();
+    let expr = (one.clone() + eps.clone())
+        .checked_div(&(one.clone() - eps.clone()))
+        .unwrap();
+    assert_eq!(expr.denom().degree(), Some(1));
+}
+
+#[test]
+fn epsilon_rational_polynomial_degree() {
+    // 3 + 2ε + ε² as a polynomial
+    let coeffs = vec![
+        RationalSurreal::from_integer(3),
+        RationalSurreal::from_integer(2),
+        RationalSurreal::one(),
+    ];
+    let poly = EpsilonRational::from_polynomial(coeffs.clone());
+    let numer: &EpsilonPolynomial = poly.numer();
+    assert_eq!(numer.degree(), Some(2));
+    assert_eq!(poly.denom().degree(), Some(0));
+}
+
+#[test]
+fn epsilon_rational_polynomial_ordering() {
+    // 3 + 2ε + ε²
+    let coeffs = vec![
+        RationalSurreal::from_integer(3),
+        RationalSurreal::from_integer(2),
+        RationalSurreal::one(),
+    ];
+    let poly = EpsilonRational::from_polynomial(coeffs.clone());
+    // It must be positive and larger than 3
+    assert!(poly > EpsilonRational::from_scalar(RationalSurreal::from_integer(3)));
+    // And less than 4 (since 2ε + ε² < 1 for small epsilon)
+    assert!(poly < EpsilonRational::from_scalar(RationalSurreal::from_integer(4)));
+}

--- a/amari-surreal/tests/epsilon.rs
+++ b/amari-surreal/tests/epsilon.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "experimental-epsilon")]
 
 use amari_surreal::epsilon::{EpsilonPolynomial, EpsilonRational};
-use amari_surreal::RationalSurreal;
+use amari_surreal::{RationalSurreal, SurrealError};
 
 #[test]
 fn epsilon_is_positive_infinitesimal() {
@@ -63,4 +63,47 @@ fn epsilon_rational_polynomial_ordering() {
     assert!(poly > EpsilonRational::from_scalar(RationalSurreal::from_integer(3)));
     // And less than 4 (since 2ε + ε² < 1 for small epsilon)
     assert!(poly < EpsilonRational::from_scalar(RationalSurreal::from_integer(4)));
+}
+
+// -- from_parts with non-scalar denominator ---------------------------------
+
+#[test]
+fn from_parts_with_nonscalar_denominator() {
+    // ε / (1 + ε) — denominator has degree 1, not a scalar constant.
+    let numer = EpsilonPolynomial::epsilon();
+    let denom =
+        EpsilonPolynomial::from_coefficients(vec![RationalSurreal::one(), RationalSurreal::one()]);
+    let r = EpsilonRational::from_parts(numer, denom).unwrap();
+    // Denominator is not simplified to 1 because it has degree > 0.
+    assert_eq!(r.denom().degree(), Some(1));
+    // Value is positive and between 0 and ε (since ε/(1+ε) < ε).
+    assert!(r > EpsilonRational::zero());
+    assert!(r < EpsilonRational::epsilon());
+}
+
+// -- checked_reciprocal of non-scalar ---------------------------------------
+
+#[test]
+fn checked_reciprocal_of_nonscalar() {
+    // 1 + ε as a rational function (denominator 1).
+    let r = EpsilonRational::from_polynomial(vec![RationalSurreal::one(), RationalSurreal::one()]);
+    // reciprocal = 1 / (1 + ε). The denominator is (1 + ε), degree 1.
+    let recip = r.checked_reciprocal().unwrap();
+    assert_eq!(recip.denom().degree(), Some(1));
+    assert!(recip > EpsilonRational::zero());
+    assert!(recip < EpsilonRational::one());
+}
+
+// -- error paths ------------------------------------------------------------
+
+#[test]
+fn checked_reciprocal_of_zero_returns_division_by_zero() {
+    let result = EpsilonRational::zero().checked_reciprocal();
+    assert!(matches!(result, Err(SurrealError::DivisionByZero)));
+}
+
+#[test]
+fn checked_div_by_zero_returns_division_by_zero() {
+    let result = EpsilonRational::one().checked_div(&EpsilonRational::zero());
+    assert!(matches!(result, Err(SurrealError::DivisionByZero)));
 }

--- a/amari-surreal/tests/rationals.rs
+++ b/amari-surreal/tests/rationals.rs
@@ -1,4 +1,5 @@
 use amari_surreal::{Dyadic, RationalSurreal, ShortSurreal, SurrealError};
+use std::cmp::Ordering;
 
 #[test]
 fn rational_surreal_normalizes_and_displays() {
@@ -34,6 +35,114 @@ fn rational_surreal_embeds_short_surreal() {
     let short = ShortSurreal::from_dyadic(Dyadic::new(3, 2));
     let rational = RationalSurreal::from_short(short);
     assert_eq!(rational.to_string(), "3/4");
+}
+
+#[test]
+fn rational_surreal_normalizes_negative_ratios() {
+    // Negative numerator with positive denominator
+    let r = RationalSurreal::from_ratio(-2, 4).unwrap();
+    assert_eq!(r.to_string(), "-1/2");
+    assert!(r.is_negative());
+
+    // Positive numerator with negative denominator
+    let r = RationalSurreal::from_ratio(2, -4).unwrap();
+    assert_eq!(r.to_string(), "-1/2");
+    assert!(r.is_negative());
+
+    // Both negative
+    let r = RationalSurreal::from_ratio(-3, -6).unwrap();
+    assert_eq!(r.to_string(), "1/2");
+    assert!(r.is_positive());
+}
+
+#[test]
+fn rational_surreal_equality_of_normalized_rationals() {
+    let a = RationalSurreal::from_ratio(2, 4).unwrap();
+    let b = RationalSurreal::from_ratio(1, 2).unwrap();
+    assert_eq!(a, b);
+    assert_eq!(a.to_string(), b.to_string());
+
+    // Negative equivalence
+    let c = RationalSurreal::from_ratio(-2, 4).unwrap();
+    let d = RationalSurreal::from_ratio(1, -2).unwrap();
+    assert_eq!(c, d);
+    assert_eq!(c.to_string(), "-1/2");
+    assert_eq!(d.to_string(), "-1/2");
+}
+
+#[test]
+fn rational_surreal_ordering() {
+    let neg_half = RationalSurreal::from_ratio(-1, 2).unwrap();
+    let zero = RationalSurreal::zero();
+    let third = RationalSurreal::from_ratio(1, 3).unwrap();
+
+    assert_eq!(neg_half.cmp(&zero), Ordering::Less);
+    assert_eq!(zero.cmp(&third), Ordering::Less);
+    assert_eq!(neg_half.cmp(&third), Ordering::Less);
+
+    // Complete chain: -1/2 < 0 < 1/3
+    assert!(neg_half < zero);
+    assert!(zero < third);
+    assert!(neg_half < third);
+
+    // Reflexivity: equal values compare equal
+    assert_eq!(zero.cmp(&RationalSurreal::zero()), Ordering::Equal);
+    let another_third = RationalSurreal::from_ratio(2, 6).unwrap();
+    assert_eq!(third.cmp(&another_third), Ordering::Equal);
+}
+
+#[test]
+fn rational_surreal_from_integer() {
+    let zero = RationalSurreal::from_integer(0);
+    assert_eq!(zero, RationalSurreal::zero());
+    assert!(zero.is_zero());
+
+    let pos = RationalSurreal::from_integer(42);
+    assert_eq!(pos.to_string(), "42");
+    assert!(pos.is_positive());
+
+    let neg = RationalSurreal::from_integer(-7);
+    assert_eq!(neg.to_string(), "-7");
+    assert!(neg.is_negative());
+}
+
+#[test]
+fn rational_surreal_abs() {
+    let zero = RationalSurreal::zero();
+    assert_eq!(zero.abs(), RationalSurreal::zero());
+
+    let pos = RationalSurreal::from_ratio(3, 4).unwrap();
+    assert_eq!(pos.abs(), pos);
+
+    let neg = RationalSurreal::from_ratio(-3, 4).unwrap();
+    let abs_neg = neg.abs();
+    assert_eq!(abs_neg.to_string(), "3/4");
+    assert!(abs_neg.is_positive());
+}
+
+#[test]
+fn rational_surreal_checked_reciprocal() {
+    // Success case
+    let two_thirds = RationalSurreal::from_ratio(2, 3).unwrap();
+    let recip = two_thirds.checked_reciprocal().unwrap();
+    assert_eq!(recip.to_string(), "3/2");
+
+    // Reciprocal of negative
+    let neg = RationalSurreal::from_ratio(-4, 5).unwrap();
+    let neg_recip = neg.checked_reciprocal().unwrap();
+    assert_eq!(neg_recip.to_string(), "-5/4");
+
+    // Reciprocal of one
+    assert_eq!(
+        RationalSurreal::one().checked_reciprocal().unwrap(),
+        RationalSurreal::one()
+    );
+
+    // Zero fails
+    assert_eq!(
+        RationalSurreal::zero().checked_reciprocal(),
+        Err(SurrealError::DivisionByZero)
+    );
 }
 
 #[test]

--- a/amari-surreal/tests/rationals.rs
+++ b/amari-surreal/tests/rationals.rs
@@ -1,0 +1,49 @@
+use amari_surreal::{Dyadic, RationalSurreal, ShortSurreal, SurrealError};
+
+#[test]
+fn rational_surreal_normalizes_and_displays() {
+    let value = RationalSurreal::from_ratio(2, 4).unwrap();
+    assert_eq!(value.to_string(), "1/2");
+    assert_eq!(value.numer().to_string(), "1");
+    assert_eq!(value.denom().to_string(), "2");
+}
+
+#[test]
+fn rational_surreal_supports_exact_field_arithmetic() {
+    let third = RationalSurreal::from_ratio(1, 3).unwrap();
+    let sixth = RationalSurreal::from_ratio(1, 6).unwrap();
+    assert_eq!((third.clone() + sixth.clone()).to_string(), "1/2");
+    assert_eq!((third.clone() * sixth.clone()).to_string(), "1/18");
+    assert_eq!(third.checked_div(&sixth).unwrap().to_string(), "2");
+}
+
+#[test]
+fn rational_surreal_converts_to_short_only_when_dyadic() {
+    let half = RationalSurreal::from_ratio(1, 2).unwrap();
+    assert_eq!(
+        half.to_short_if_dyadic().unwrap().to_dyadic(),
+        Dyadic::new(1, 1)
+    );
+
+    let third = RationalSurreal::from_ratio(1, 3).unwrap();
+    assert!(third.to_short_if_dyadic().is_none());
+}
+
+#[test]
+fn rational_surreal_embeds_short_surreal() {
+    let short = ShortSurreal::from_dyadic(Dyadic::new(3, 2));
+    let rational = RationalSurreal::from_short(short);
+    assert_eq!(rational.to_string(), "3/4");
+}
+
+#[test]
+fn rational_surreal_rejects_zero_denominator_and_division_by_zero() {
+    assert_eq!(
+        RationalSurreal::from_ratio(1, 0),
+        Err(SurrealError::DivisionByZero)
+    );
+    assert_eq!(
+        RationalSurreal::one().checked_div(&RationalSurreal::zero()),
+        Err(SurrealError::DivisionByZero)
+    );
+}

--- a/amari-wasm/Cargo.toml
+++ b/amari-wasm/Cargo.toml
@@ -29,7 +29,8 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 # Native users can opt-in to native-precision for rug backend
 amari-core = { path = "../amari-core", features = ["phantom-types"] }
 amari-cgt = { path = "../amari-cgt" }
-amari-surreal = { path = "../amari-surreal" }
+amari-surreal = { path = "../amari-surreal", features = ["experimental-epsilon"] }
+amari-surcomplex = { path = "../amari-surcomplex" }
 amari-network = { path = "../amari-network", features = ["high-precision"] }
 amari-tropical = { path = "../amari-tropical" }
 amari-dual = { path = "../amari-dual" }

--- a/amari-wasm/README.md
+++ b/amari-wasm/README.md
@@ -1,4 +1,4 @@
-# @justinelliottcobb/amari-wasm v0.22.0
+# @justinelliottcobb/amari-wasm v0.23.0
 
 **Unified Mathematical Computing Library with High-Precision WebAssembly Support**
 
@@ -17,6 +17,9 @@ Amari is a comprehensive mathematical computing library that brings advanced alg
 | [Automatic Differentiation](docs/automatic-differentiation.md) | amari-dual | v0.9.3 | Forward-mode AD with `0.21.0` branch policies, multi-dual seeding, and fixed-size gradient wrappers |
 | Combinatorial Game Theory | amari-cgt | v0.22.0 | Short normal-play games, cuts, outcomes, comparison, nimbers, and inspection helpers |
 | Short Surreal Numbers | amari-surreal | v0.22.0 | Exact dyadic short-surreal arithmetic and conversion to/from numeric CGT games |
+| Rational Surreals | amari-surreal | v0.23.0 | Exact rational surreal arithmetic with true rational division |
+| Rational Surcomplex | amari-surcomplex | v0.23.0 | Exact rational surcomplex arithmetic `a + bi` with full field operations |
+| Epsilon Rationals (experimental) | amari-surreal | v0.23.0 | Formal infinitesimal `ε` polynomials and rational functions, ordered by asymptotic behaviour |
 | [Cellular Automata](docs/cellular-automata.md) | amari-automata | v0.9.4 | Geometric cellular automata with multivector states |
 | [Holographic Memory](docs/holographic-memory.md) | amari-fusion | v0.12.3 | Vector Symbolic Architecture for associative memory with binding and bundling |
 | [Measure Theory](docs/measure-theory.md) | amari-measure | v0.10.0 | Lebesgue integration, probability measures, and measure-theoretic foundations |
@@ -31,6 +34,27 @@ Amari is a comprehensive mathematical computing library that brings advanced alg
 | [Orbital Mechanics](docs/orbital-mechanics.md) | amari-relativistic | v0.9.4 | Spacetime algebra (Cl(1,3)) with high-precision trajectory calculations |
 
 Also includes bindings for: amari-network (geometric network analysis), amari-optimization (gradient descent, NSGA-II), amari-info-geom (Fisher metrics, statistical manifolds), amari-calculus (differential geometry, manifolds).
+
+### v0.23.0 Rational Surreal / Surcomplex WASM Surface
+
+The `0.23.0` release adds exact rational arithmetic and surcomplex numbers to the WASM surface:
+
+- `WasmRationalSurreal` — exact rational numbers backed by `BigRational`.
+  - `zero()`, `one()`, `fromInteger(i32)`, `fromRatio(numer, denom)`
+  - `numeratorString()`, `denominatorString()`, `format()`
+  - `isZero`, `isPositive`, `isNegative`, `sign()`, `abs`, `add`, `sub`, `mul`, `neg`
+  - `checkedReciprocal`, `checkedDiv`, `compare`
+  - `toShortIfDyadic()` — returns `Some` when the denominator is a power of two
+  - `fromShort(short)` — converts a `WasmShortSurreal` into a rational
+
+- `WasmRationalSurcomplex` — exact complex numbers `a + bi` with rational parts.
+  - `zero()`, `one()`, `i()`, `fromInteger(i32)`, `fromReal(real)`, `fromParts(real, imag)`
+  - `real()`, `imag()`, `format()`, `conjugate`, `normSq()`, `isZero`
+  - `add`, `sub`, `mul`, `neg`, `checkedReciprocal`, `checkedDiv`
+
+- `WasmExperimentalEpsilonRational` — rational functions in a formal infinitesimal `ε`.
+  - `zero()`, `one()`, `epsilon()`, `fromScalar(scalar)`, `monomial(coeff, exponent)`
+  - `format()`, `add`, `sub`, `mul`, `neg`, `checkedReciprocal`, `checkedDiv`, `compare`
 
 ### v0.22.0 CGT / Surreal WASM Surface
 

--- a/amari-wasm/examples/package.json
+++ b/amari-wasm/examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amari-wasm-examples",
-  "version": "0.22.0",
-  "description": "Comprehensive examples for Amari v0.22.0 WebAssembly mathematical computing library",
+  "version": "0.23.0",
+  "description": "Comprehensive examples for Amari v0.23.0 WebAssembly mathematical computing library",
   "type": "module",
   "scripts": {
     "demo": "node --loader ts-node/esm complete-demo.ts",
@@ -15,7 +15,7 @@
     "all": "npm run demo && npm run geometric && npm run tropical && npm run autodiff && npm run infogeom && npm run fusion && npm run flynn && npm run gf2"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.22.0"
+    "@justinelliottcobb/amari-wasm": "^0.23.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/amari-wasm/package.json
+++ b/amari-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justinelliottcobb/amari-wasm",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "WebAssembly bindings for Amari mathematical computing library",
   "scripts": {
     "build": "wasm-pack build --target web --out-dir pkg --scope justinelliottcobb",

--- a/amari-wasm/src/lib.rs
+++ b/amari-wasm/src/lib.rs
@@ -85,6 +85,7 @@ pub mod optical; // Enabled for v0.15.1 - GA-native optical field operations and
 pub mod optimization; // Enabled for v0.9.7 - Advanced optimization algorithms for web
 pub mod probabilistic; // Enabled for v0.13.0 - Probability distributions on multivector spaces
 pub mod relativistic;
+pub mod surcomplex; // Enabled for v0.23.0 - Exact rational surcomplex arithmetic
 pub mod surreal; // Enabled for v0.22.0 - Exact short surreal dyadics and game conversion helpers
 pub mod topology; // Enabled for v0.16.0 - Simplicial complexes, homology, persistent homology
 pub mod tropical; // Enabled for v0.9.3 - critical for optimization algorithms in web

--- a/amari-wasm/src/surcomplex.rs
+++ b/amari-wasm/src/surcomplex.rs
@@ -15,8 +15,7 @@ fn surcomplex_error(error: SurcomplexError) -> JsValue {
 /// error-path tests can verify `is_err()` — the message is irrelevant
 /// for these assertions.
 #[cfg(not(target_arch = "wasm32"))]
-fn surcomplex_error(error: SurcomplexError) -> JsValue {
-    let _ = error;
+fn surcomplex_error(#[allow(unused_variables)] error: SurcomplexError) -> JsValue {
     JsValue::undefined()
 }
 
@@ -228,7 +227,9 @@ mod tests {
         let a = WasmRationalSurcomplex::from_integer(2);
         let b = WasmRationalSurcomplex::from_integer(3);
         assert_eq!(a.add(&b).format(), "5");
+        assert_eq!(b.sub(&a).format(), "1");
         assert_eq!(a.mul(&b).format(), "6");
+        assert_eq!(a.neg().format(), "-2");
     }
 
     #[test]

--- a/amari-wasm/src/surcomplex.rs
+++ b/amari-wasm/src/surcomplex.rs
@@ -2,11 +2,22 @@ use crate::surreal::WasmRationalSurreal;
 use amari_surcomplex::{RationalSurcomplex, SurcomplexError};
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
 fn surcomplex_error(error: SurcomplexError) -> JsValue {
     match error {
         SurcomplexError::DivisionByZero => JsValue::from_str("division by zero"),
         SurcomplexError::Surreal(e) => JsValue::from_str(&e.to_string()),
     }
+}
+
+/// On native targets `JsValue::from_str` panics (wasm-bindgen internals
+/// are only available under wasm32).  Return `JsValue::undefined()` so
+/// error-path tests can verify `is_err()` — the message is irrelevant
+/// for these assertions.
+#[cfg(not(target_arch = "wasm32"))]
+fn surcomplex_error(error: SurcomplexError) -> JsValue {
+    let _ = error;
+    JsValue::undefined()
 }
 
 /// Exact rational surcomplex number `a + bi` with `a, b ∈ Q`.
@@ -229,14 +240,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_arch = "wasm32")]
     fn surcomplex_reciprocal_fails_for_zero() {
         let zero = WasmRationalSurcomplex::zero();
         assert!(zero.checked_reciprocal().is_err());
     }
 
     #[test]
-    #[cfg(target_arch = "wasm32")]
     fn surcomplex_div_fails_for_zero() {
         let one = WasmRationalSurcomplex::one();
         let zero = WasmRationalSurcomplex::zero();

--- a/amari-wasm/src/surcomplex.rs
+++ b/amari-wasm/src/surcomplex.rs
@@ -1,0 +1,245 @@
+use crate::surreal::WasmRationalSurreal;
+use amari_surcomplex::{RationalSurcomplex, SurcomplexError};
+use wasm_bindgen::prelude::*;
+
+fn surcomplex_error(error: SurcomplexError) -> JsValue {
+    match error {
+        SurcomplexError::DivisionByZero => JsValue::from_str("division by zero"),
+        SurcomplexError::Surreal(e) => JsValue::from_str(&e.to_string()),
+    }
+}
+
+/// Exact rational surcomplex number `a + bi` with `a, b ∈ Q`.
+///
+/// `WasmRationalSurcomplex` wraps exact complex numbers backed by
+/// [`WasmRationalSurreal`] for the real and imaginary parts.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct WasmRationalSurcomplex {
+    inner: RationalSurcomplex,
+}
+
+#[wasm_bindgen]
+impl WasmRationalSurcomplex {
+    /// Return zero (`0 + 0i`).
+    pub fn zero() -> Self {
+        Self {
+            inner: RationalSurcomplex::zero(),
+        }
+    }
+
+    /// Return one (`1 + 0i`).
+    pub fn one() -> Self {
+        Self {
+            inner: RationalSurcomplex::one(),
+        }
+    }
+
+    /// Return the imaginary unit `i` (`0 + 1i`).
+    pub fn i() -> Self {
+        Self {
+            inner: RationalSurcomplex::i(),
+        }
+    }
+
+    /// Create a real surcomplex from an integer.
+    #[wasm_bindgen(js_name = fromInteger)]
+    pub fn from_integer(value: i32) -> Self {
+        Self {
+            inner: RationalSurcomplex::from_integer(value),
+        }
+    }
+
+    /// Create a real surcomplex from a rational surreal.
+    #[wasm_bindgen(js_name = fromReal)]
+    pub fn from_real(real: &WasmRationalSurreal) -> Self {
+        Self {
+            inner: RationalSurcomplex::from_real(real.inner_ref().clone()),
+        }
+    }
+
+    /// Create a surcomplex from real and imaginary parts.
+    #[wasm_bindgen(js_name = fromParts)]
+    pub fn from_parts(real: &WasmRationalSurreal, imag: &WasmRationalSurreal) -> Self {
+        Self {
+            inner: RationalSurcomplex::from_parts(
+                real.inner_ref().clone(),
+                imag.inner_ref().clone(),
+            ),
+        }
+    }
+
+    /// Return the real part as a rational surreal.
+    pub fn real(&self) -> WasmRationalSurreal {
+        WasmRationalSurreal::wrap(self.inner.real().clone())
+    }
+
+    /// Return the imaginary part as a rational surreal.
+    pub fn imag(&self) -> WasmRationalSurreal {
+        WasmRationalSurreal::wrap(self.inner.imag().clone())
+    }
+
+    /// Format the surcomplex as a string.
+    pub fn format(&self) -> String {
+        self.inner.to_string()
+    }
+
+    /// Return the complex conjugate `a - bi`.
+    pub fn conjugate(&self) -> WasmRationalSurcomplex {
+        WasmRationalSurcomplex {
+            inner: self.inner.conjugate(),
+        }
+    }
+
+    /// Return the squared norm `a² + b²` as a rational surreal.
+    #[wasm_bindgen(js_name = normSq)]
+    pub fn norm_sq(&self) -> WasmRationalSurreal {
+        WasmRationalSurreal::wrap(self.inner.norm_sq())
+    }
+
+    /// Return whether the surcomplex is zero.
+    #[wasm_bindgen(js_name = isZero)]
+    pub fn is_zero(&self) -> bool {
+        self.inner.is_zero()
+    }
+
+    /// Add two surcomplex numbers.
+    pub fn add(&self, rhs: &WasmRationalSurcomplex) -> WasmRationalSurcomplex {
+        WasmRationalSurcomplex {
+            inner: self.inner.clone() + rhs.inner.clone(),
+        }
+    }
+
+    /// Subtract two surcomplex numbers.
+    pub fn sub(&self, rhs: &WasmRationalSurcomplex) -> WasmRationalSurcomplex {
+        WasmRationalSurcomplex {
+            inner: self.inner.clone() - rhs.inner.clone(),
+        }
+    }
+
+    /// Multiply two surcomplex numbers.
+    pub fn mul(&self, rhs: &WasmRationalSurcomplex) -> WasmRationalSurcomplex {
+        WasmRationalSurcomplex {
+            inner: self.inner.clone() * rhs.inner.clone(),
+        }
+    }
+
+    /// Negate the surcomplex.
+    pub fn neg(&self) -> WasmRationalSurcomplex {
+        WasmRationalSurcomplex {
+            inner: -self.inner.clone(),
+        }
+    }
+
+    /// Checked reciprocal `1 / self`.
+    ///
+    /// Returns an error when the value is zero.
+    #[wasm_bindgen(js_name = checkedReciprocal)]
+    pub fn checked_reciprocal(&self) -> Result<WasmRationalSurcomplex, JsValue> {
+        Ok(WasmRationalSurcomplex {
+            inner: self.inner.checked_reciprocal().map_err(surcomplex_error)?,
+        })
+    }
+
+    /// Checked division `self / rhs`.
+    ///
+    /// Returns an error when `rhs` is zero.
+    #[wasm_bindgen(js_name = checkedDiv)]
+    pub fn checked_div(
+        &self,
+        rhs: &WasmRationalSurcomplex,
+    ) -> Result<WasmRationalSurcomplex, JsValue> {
+        Ok(WasmRationalSurcomplex {
+            inner: self
+                .inner
+                .checked_div(&rhs.inner)
+                .map_err(surcomplex_error)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::surreal::WasmRationalSurreal;
+
+    #[test]
+    fn surcomplex_division_one_over_one_plus_half_i() {
+        // 1 / (1 + 1/2 i) = 4/5 - 2/5 i
+        let one = WasmRationalSurreal::one();
+        let half = WasmRationalSurreal::from_ratio(1, 2).unwrap();
+        let z = WasmRationalSurcomplex::from_parts(&one, &half);
+        let q = WasmRationalSurcomplex::one().checked_div(&z).unwrap();
+
+        assert_eq!(q.real().format(), "4/5");
+        assert_eq!(q.imag().format(), "-2/5");
+        assert_eq!(q.format(), "4/5 - 2/5i");
+    }
+
+    #[test]
+    fn surcomplex_zero_one_and_i() {
+        let zero = WasmRationalSurcomplex::zero();
+        assert!(zero.is_zero());
+        assert_eq!(zero.format(), "0");
+
+        let one = WasmRationalSurcomplex::one();
+        assert!(!one.is_zero());
+        assert_eq!(one.format(), "1");
+
+        let i = WasmRationalSurcomplex::i();
+        assert!(!i.is_zero());
+        assert_eq!(i.format(), "i");
+    }
+
+    #[test]
+    fn surcomplex_conjugate() {
+        let r = WasmRationalSurreal::from_ratio(3, 2).unwrap();
+        let im = WasmRationalSurreal::from_ratio(4, 2).unwrap();
+        let z = WasmRationalSurcomplex::from_parts(&r, &im);
+        let conj = z.conjugate();
+
+        assert_eq!(conj.real().format(), "3/2");
+        assert_eq!(conj.imag().format(), "-2"); // -4/2 = -2
+    }
+
+    #[test]
+    fn surcomplex_norm_sq() {
+        // |3 + 4i|² = 3² + 4² = 9 + 16 = 25
+        let r = WasmRationalSurreal::from_integer(3);
+        let im = WasmRationalSurreal::from_integer(4);
+        let z = WasmRationalSurcomplex::from_parts(&r, &im);
+        let nsq = z.norm_sq();
+        assert_eq!(nsq.format(), "25");
+    }
+
+    #[test]
+    fn surcomplex_arithmetic() {
+        let a = WasmRationalSurcomplex::from_integer(2);
+        let b = WasmRationalSurcomplex::from_integer(3);
+        assert_eq!(a.add(&b).format(), "5");
+        assert_eq!(a.mul(&b).format(), "6");
+    }
+
+    #[test]
+    fn surcomplex_imul() {
+        // i * i = -1
+        let i = WasmRationalSurcomplex::i();
+        let i_sq = i.mul(&i);
+        assert_eq!(i_sq.format(), "-1");
+    }
+
+    #[test]
+    #[cfg(target_arch = "wasm32")]
+    fn surcomplex_reciprocal_fails_for_zero() {
+        let zero = WasmRationalSurcomplex::zero();
+        assert!(zero.checked_reciprocal().is_err());
+    }
+
+    #[test]
+    #[cfg(target_arch = "wasm32")]
+    fn surcomplex_div_fails_for_zero() {
+        let one = WasmRationalSurcomplex::one();
+        let zero = WasmRationalSurcomplex::zero();
+        assert!(one.checked_div(&zero).is_err());
+    }
+}

--- a/amari-wasm/src/surreal.rs
+++ b/amari-wasm/src/surreal.rs
@@ -1,5 +1,6 @@
 use crate::cgt::{WasmCgtArena, WasmGameId};
-use amari_surreal::{Dyadic, ShortSurreal};
+use amari_surreal::epsilon::EpsilonRational;
+use amari_surreal::{Dyadic, RationalSurreal, ShortSurreal};
 use wasm_bindgen::prelude::*;
 
 fn surreal_error(error: amari_surreal::SurrealError) -> JsValue {
@@ -310,6 +311,303 @@ impl WasmShortSurreal {
     }
 }
 
+impl WasmShortSurreal {
+    pub(crate) fn inner_ref(&self) -> &ShortSurreal {
+        &self.inner
+    }
+}
+
+/// Exact rational surreal backed by `BigRational`.
+///
+/// `WasmRationalSurreal` provides an exact rational scalar field for the
+/// surcomplex layer (v0.23+). It augments the existing dyadic
+/// `WasmShortSurreal` layer with true rational division, supporting
+/// denominators that are not powers of two.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct WasmRationalSurreal {
+    inner: RationalSurreal,
+}
+
+#[wasm_bindgen]
+impl WasmRationalSurreal {
+    /// Return zero.
+    pub fn zero() -> Self {
+        Self {
+            inner: RationalSurreal::zero(),
+        }
+    }
+
+    /// Return one.
+    pub fn one() -> Self {
+        Self {
+            inner: RationalSurreal::one(),
+        }
+    }
+
+    /// Create a rational surreal from an integer.
+    #[wasm_bindgen(js_name = fromInteger)]
+    pub fn from_integer(value: i32) -> Self {
+        Self {
+            inner: RationalSurreal::from_integer(value),
+        }
+    }
+
+    /// Create a rational surreal from a numerator and denominator.
+    ///
+    /// Returns an error when the denominator is zero.
+    #[wasm_bindgen(js_name = fromRatio)]
+    pub fn from_ratio(numer: i32, denom: i32) -> Result<WasmRationalSurreal, JsValue> {
+        Ok(WasmRationalSurreal {
+            inner: RationalSurreal::from_ratio(numer, denom).map_err(surreal_error)?,
+        })
+    }
+
+    /// Convert a short surreal into a rational surreal.
+    #[wasm_bindgen(js_name = fromShort)]
+    pub fn from_short(value: &WasmShortSurreal) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: RationalSurreal::from_short(value.inner_ref().clone()),
+        }
+    }
+
+    /// Numerator as a base-10 string.
+    #[wasm_bindgen(js_name = numeratorString)]
+    pub fn numerator_string(&self) -> String {
+        self.inner.numer().to_string()
+    }
+
+    /// Denominator as a base-10 string.
+    #[wasm_bindgen(js_name = denominatorString)]
+    pub fn denominator_string(&self) -> String {
+        self.inner.denom().to_string()
+    }
+
+    /// Format as a rational string.
+    pub fn format(&self) -> String {
+        self.inner.to_string()
+    }
+
+    /// Return whether the rational is zero.
+    #[wasm_bindgen(js_name = isZero)]
+    pub fn is_zero(&self) -> bool {
+        self.inner.is_zero()
+    }
+
+    /// Return whether the rational is positive.
+    #[wasm_bindgen(js_name = isPositive)]
+    pub fn is_positive(&self) -> bool {
+        self.inner.is_positive()
+    }
+
+    /// Return whether the rational is negative.
+    #[wasm_bindgen(js_name = isNegative)]
+    pub fn is_negative(&self) -> bool {
+        self.inner.is_negative()
+    }
+
+    /// Return the sign as `negative`, `zero`, or `positive`.
+    pub fn sign(&self) -> String {
+        sign_name(self.inner.is_negative(), self.inner.is_zero()).to_string()
+    }
+
+    /// Absolute value.
+    pub fn abs(&self) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: self.inner.abs(),
+        }
+    }
+
+    /// Add two rational surreals exactly.
+    pub fn add(&self, rhs: &WasmRationalSurreal) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: self.inner.clone() + rhs.inner.clone(),
+        }
+    }
+
+    /// Subtract two rational surreals exactly.
+    pub fn sub(&self, rhs: &WasmRationalSurreal) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: self.inner.clone() - rhs.inner.clone(),
+        }
+    }
+
+    /// Multiply two rational surreals exactly.
+    pub fn mul(&self, rhs: &WasmRationalSurreal) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: self.inner.clone() * rhs.inner.clone(),
+        }
+    }
+
+    /// Negate the value.
+    pub fn neg(&self) -> WasmRationalSurreal {
+        WasmRationalSurreal {
+            inner: -self.inner.clone(),
+        }
+    }
+
+    /// Checked reciprocal.
+    #[wasm_bindgen(js_name = checkedReciprocal)]
+    pub fn checked_reciprocal(&self) -> Result<WasmRationalSurreal, JsValue> {
+        Ok(WasmRationalSurreal {
+            inner: self.inner.checked_reciprocal().map_err(surreal_error)?,
+        })
+    }
+
+    /// Checked division.
+    #[wasm_bindgen(js_name = checkedDiv)]
+    pub fn checked_div(&self, rhs: &WasmRationalSurreal) -> Result<WasmRationalSurreal, JsValue> {
+        Ok(WasmRationalSurreal {
+            inner: self.inner.checked_div(&rhs.inner).map_err(surreal_error)?,
+        })
+    }
+
+    /// Compare two rational surreal values.
+    pub fn compare(&self, rhs: &WasmRationalSurreal) -> String {
+        match self.inner.cmp(&rhs.inner) {
+            std::cmp::Ordering::Less => "less",
+            std::cmp::Ordering::Equal => "equal",
+            std::cmp::Ordering::Greater => "greater",
+        }
+        .to_string()
+    }
+
+    /// Convert to a short surreal when the value is dyadic.
+    ///
+    /// Returns `Some` only when the normalized denominator is a power
+    /// of two (dyadic rational); returns `None` for non-dyadic values.
+    #[wasm_bindgen(js_name = toShortIfDyadic)]
+    pub fn to_short_if_dyadic(&self) -> Option<WasmShortSurreal> {
+        self.inner
+            .to_short_if_dyadic()
+            .map(|s| WasmShortSurreal { inner: s })
+    }
+}
+
+impl WasmRationalSurreal {
+    pub(crate) fn wrap(inner: RationalSurreal) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) fn inner_ref(&self) -> &RationalSurreal {
+        &self.inner
+    }
+}
+
+/// Experimental epsilon rational function.
+///
+/// A rational function in a formal positive infinitesimal `ε` with
+/// rational surreal coefficients.  Ordered by asymptotic behaviour as
+/// `ε → 0⁺`.
+///
+/// **Experimental**: this API is behind the `experimental-epsilon`
+/// feature flag and may change without semver guarantees.
+#[wasm_bindgen]
+pub struct WasmExperimentalEpsilonRational {
+    inner: EpsilonRational,
+}
+
+#[wasm_bindgen]
+impl WasmExperimentalEpsilonRational {
+    /// Return zero (`0 / 1`).
+    pub fn zero() -> Self {
+        Self {
+            inner: EpsilonRational::zero(),
+        }
+    }
+
+    /// Return one (`1 / 1`).
+    pub fn one() -> Self {
+        Self {
+            inner: EpsilonRational::one(),
+        }
+    }
+
+    /// Return the formal infinitesimal `ε`.
+    pub fn epsilon() -> Self {
+        Self {
+            inner: EpsilonRational::epsilon(),
+        }
+    }
+
+    /// Build from a scalar constant: `scalar / 1`.
+    #[wasm_bindgen(js_name = fromScalar)]
+    pub fn from_scalar(scalar: &WasmRationalSurreal) -> Self {
+        Self {
+            inner: EpsilonRational::from_scalar(scalar.inner_ref().clone()),
+        }
+    }
+
+    /// A monomial rational function `coeff · ε^exp / 1`.
+    pub fn monomial(coeff: &WasmRationalSurreal, exponent: i32) -> Self {
+        Self {
+            inner: EpsilonRational::monomial(coeff.inner_ref().clone(), exponent),
+        }
+    }
+
+    /// Format the epsilon rational.
+    pub fn format(&self) -> String {
+        self.inner.to_string()
+    }
+
+    /// Add two epsilon rationals.
+    pub fn add(&self, rhs: &WasmExperimentalEpsilonRational) -> WasmExperimentalEpsilonRational {
+        WasmExperimentalEpsilonRational {
+            inner: self.inner.clone() + rhs.inner.clone(),
+        }
+    }
+
+    /// Subtract two epsilon rationals.
+    pub fn sub(&self, rhs: &WasmExperimentalEpsilonRational) -> WasmExperimentalEpsilonRational {
+        WasmExperimentalEpsilonRational {
+            inner: self.inner.clone() - rhs.inner.clone(),
+        }
+    }
+
+    /// Multiply two epsilon rationals.
+    pub fn mul(&self, rhs: &WasmExperimentalEpsilonRational) -> WasmExperimentalEpsilonRational {
+        WasmExperimentalEpsilonRational {
+            inner: self.inner.clone() * rhs.inner.clone(),
+        }
+    }
+
+    /// Negate the value.
+    pub fn neg(&self) -> WasmExperimentalEpsilonRational {
+        WasmExperimentalEpsilonRational {
+            inner: -self.inner.clone(),
+        }
+    }
+
+    /// Checked reciprocal.
+    #[wasm_bindgen(js_name = checkedReciprocal)]
+    pub fn checked_reciprocal(&self) -> Result<WasmExperimentalEpsilonRational, JsValue> {
+        Ok(WasmExperimentalEpsilonRational {
+            inner: self.inner.checked_reciprocal().map_err(surreal_error)?,
+        })
+    }
+
+    /// Checked division.
+    #[wasm_bindgen(js_name = checkedDiv)]
+    pub fn checked_div(
+        &self,
+        rhs: &WasmExperimentalEpsilonRational,
+    ) -> Result<WasmExperimentalEpsilonRational, JsValue> {
+        Ok(WasmExperimentalEpsilonRational {
+            inner: self.inner.checked_div(&rhs.inner).map_err(surreal_error)?,
+        })
+    }
+
+    /// Compare two epsilon rationals.
+    pub fn compare(&self, rhs: &WasmExperimentalEpsilonRational) -> String {
+        match self.inner.cmp(&rhs.inner) {
+            std::cmp::Ordering::Less => "less",
+            std::cmp::Ordering::Equal => "equal",
+            std::cmp::Ordering::Greater => "greater",
+        }
+        .to_string()
+    }
+}
+
 fn sign_name(is_negative: bool, is_zero: bool) -> &'static str {
     if is_zero {
         "zero"
@@ -368,6 +666,134 @@ mod tests {
                 .unwrap()
                 .format(),
             "1/2"
+        );
+    }
+
+    // ========================================================================
+    // WasmRationalSurreal tests
+    // ========================================================================
+
+    #[test]
+    fn rational_exact_one_third_plus_one_sixth_is_one_half() {
+        let third = WasmRationalSurreal::from_ratio(1, 3).unwrap();
+        let sixth = WasmRationalSurreal::from_ratio(1, 6).unwrap();
+        let half = WasmRationalSurreal::from_ratio(1, 2).unwrap();
+        let sum = third.add(&sixth);
+        assert_eq!(sum.format(), "1/2");
+        assert_eq!(sum.compare(&half), "equal");
+    }
+
+    #[test]
+    fn rational_to_short_if_dyadic_one_half_is_some() {
+        let half = WasmRationalSurreal::from_ratio(1, 2).unwrap();
+        let short = half.to_short_if_dyadic();
+        assert!(short.is_some());
+        assert_eq!(short.unwrap().format(), "1/2");
+    }
+
+    #[test]
+    fn rational_to_short_if_dyadic_one_third_is_none() {
+        let third = WasmRationalSurreal::from_ratio(1, 3).unwrap();
+        let short = third.to_short_if_dyadic();
+        assert!(short.is_none());
+    }
+
+    #[test]
+    fn rational_from_integer_and_sign() {
+        let zero = WasmRationalSurreal::zero();
+        assert!(zero.is_zero());
+        assert_eq!(zero.sign(), "zero");
+
+        let five = WasmRationalSurreal::from_integer(5);
+        assert!(five.is_positive());
+        assert!(!five.is_negative());
+        assert_eq!(five.sign(), "positive");
+
+        let neg_three = WasmRationalSurreal::from_integer(-3);
+        assert!(neg_three.is_negative());
+        assert!(!neg_three.is_positive());
+        assert_eq!(neg_three.sign(), "negative");
+    }
+
+    #[test]
+    fn rational_arithmetic_and_reciprocal() {
+        let two = WasmRationalSurreal::from_integer(2);
+        let three = WasmRationalSurreal::from_integer(3);
+        assert_eq!(two.add(&three).format(), "5");
+        assert_eq!(two.mul(&three).format(), "6");
+        assert_eq!(three.sub(&two).format(), "1");
+        assert_eq!(two.neg().format(), "-2");
+        assert_eq!(two.abs().format(), "2");
+
+        let half = two.checked_reciprocal().unwrap();
+        assert_eq!(half.format(), "1/2");
+
+        let six = WasmRationalSurreal::from_integer(6);
+        let q = six.checked_div(&three).unwrap();
+        assert_eq!(q.format(), "2");
+    }
+
+    #[test]
+    fn rational_compare() {
+        let half = WasmRationalSurreal::from_ratio(1, 2).unwrap();
+        let third = WasmRationalSurreal::from_ratio(1, 3).unwrap();
+        assert_eq!(half.compare(&third), "greater");
+        assert_eq!(third.compare(&half), "less");
+        assert_eq!(half.compare(&half), "equal");
+    }
+
+    #[test]
+    fn rational_numerator_denominator_strings() {
+        let r = WasmRationalSurreal::from_ratio(3, 4).unwrap();
+        assert_eq!(r.numerator_string(), "3");
+        assert_eq!(r.denominator_string(), "4");
+    }
+
+    // ========================================================================
+    // WasmExperimentalEpsilonRational tests
+    // ========================================================================
+
+    #[test]
+    fn epsilon_epsilon_gt_zero() {
+        let eps = WasmExperimentalEpsilonRational::epsilon();
+        let zero = WasmExperimentalEpsilonRational::zero();
+        assert_eq!(eps.compare(&zero), "greater");
+        assert_eq!(zero.compare(&eps), "less");
+    }
+
+    #[test]
+    fn epsilon_squared_lt_epsilon() {
+        let eps = WasmExperimentalEpsilonRational::epsilon();
+        let eps_sq = eps.mul(&eps);
+        // ε² < ε (since ε → 0⁺)
+        assert_eq!(eps_sq.compare(&eps), "less");
+    }
+
+    #[test]
+    fn epsilon_reciprocal_larger_than_large_integer() {
+        let eps = WasmExperimentalEpsilonRational::epsilon();
+        let recip = eps.checked_reciprocal().unwrap();
+        let large = WasmExperimentalEpsilonRational::from_scalar(
+            &WasmRationalSurreal::from_integer(1_000_000),
+        );
+        // 1/ε > 1_000_000
+        assert_eq!(recip.compare(&large), "greater");
+    }
+
+    #[test]
+    fn epsilon_arithmetic_basics() {
+        let eps = WasmExperimentalEpsilonRational::epsilon();
+        let one = WasmExperimentalEpsilonRational::one();
+        let sum = one.add(&eps);
+        assert!(!sum.format().is_empty());
+
+        let diff = one.sub(&eps);
+        assert!(!diff.format().is_empty());
+
+        let neg = eps.neg();
+        assert_eq!(
+            neg.compare(&WasmExperimentalEpsilonRational::zero()),
+            "less"
         );
     }
 }

--- a/amari-wasm/src/surreal.rs
+++ b/amari-wasm/src/surreal.rs
@@ -3,8 +3,19 @@ use amari_surreal::epsilon::EpsilonRational;
 use amari_surreal::{Dyadic, RationalSurreal, ShortSurreal};
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
 fn surreal_error(error: amari_surreal::SurrealError) -> JsValue {
     JsValue::from_str(&error.to_string())
+}
+
+/// On native targets `JsValue::from_str` panics (wasm-bindgen internals
+/// are only available under wasm32).  Return `JsValue::undefined()` so
+/// error-path tests can verify `is_err()` — the message is irrelevant
+/// for these assertions.
+#[cfg(not(target_arch = "wasm32"))]
+fn surreal_error(error: amari_surreal::SurrealError) -> JsValue {
+    let _ = error;
+    JsValue::undefined()
 }
 
 /// Exact dyadic rational `numerator / 2^exponent` for short surreal values.
@@ -345,7 +356,10 @@ impl WasmRationalSurreal {
         }
     }
 
-    /// Create a rational surreal from an integer.
+    /// Create a rational surreal from a 32-bit signed integer.
+    ///
+    /// WASM boundary note: the argument is an `i32` (JavaScript `number`
+    /// that must fit in 32-bit signed range).
     #[wasm_bindgen(js_name = fromInteger)]
     pub fn from_integer(value: i32) -> Self {
         Self {
@@ -353,7 +367,11 @@ impl WasmRationalSurreal {
         }
     }
 
-    /// Create a rational surreal from a numerator and denominator.
+    /// Create a rational surreal from a 32-bit signed numerator and
+    /// denominator.
+    ///
+    /// WASM boundary note: both arguments are `i32` (JavaScript `number`
+    /// that must fit in 32-bit signed range).
     ///
     /// Returns an error when the denominator is zero.
     #[wasm_bindgen(js_name = fromRatio)]
@@ -503,6 +521,7 @@ impl WasmRationalSurreal {
 /// **Experimental**: this API is behind the `experimental-epsilon`
 /// feature flag and may change without semver guarantees.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct WasmExperimentalEpsilonRational {
     inner: EpsilonRational,
 }
@@ -784,16 +803,63 @@ mod tests {
     fn epsilon_arithmetic_basics() {
         let eps = WasmExperimentalEpsilonRational::epsilon();
         let one = WasmExperimentalEpsilonRational::one();
+        let zero = WasmExperimentalEpsilonRational::zero();
+
+        // 1 + ε > 1 (since ε > 0)
         let sum = one.add(&eps);
-        assert!(!sum.format().is_empty());
+        assert_eq!(sum.compare(&one), "greater");
 
+        // 1 - ε < 1
         let diff = one.sub(&eps);
-        assert!(!diff.format().is_empty());
+        assert_eq!(diff.compare(&one), "less");
+        // 1 - ε > 0
+        assert_eq!(diff.compare(&zero), "greater");
 
+        // -ε < 0
         let neg = eps.neg();
-        assert_eq!(
-            neg.compare(&WasmExperimentalEpsilonRational::zero()),
-            "less"
-        );
+        assert_eq!(neg.compare(&zero), "less");
+
+        // (1 + ε) + (-ε) == 1
+        let recomposed = sum.add(&neg);
+        assert_eq!(recomposed.compare(&one), "equal");
+    }
+
+    // ------------------------------------------------------------------
+    // WasmRationalSurreal error paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn rational_from_ratio_zero_denominator_is_err() {
+        assert!(WasmRationalSurreal::from_ratio(1, 0).is_err());
+    }
+
+    #[test]
+    fn rational_zero_reciprocal_is_err() {
+        let zero = WasmRationalSurreal::zero();
+        assert!(zero.checked_reciprocal().is_err());
+    }
+
+    #[test]
+    fn rational_div_by_zero_is_err() {
+        let one = WasmRationalSurreal::one();
+        let zero = WasmRationalSurreal::zero();
+        assert!(one.checked_div(&zero).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // WasmExperimentalEpsilonRational error paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn epsilon_zero_reciprocal_is_err() {
+        let zero = WasmExperimentalEpsilonRational::zero();
+        assert!(zero.checked_reciprocal().is_err());
+    }
+
+    #[test]
+    fn epsilon_div_by_zero_is_err() {
+        let one = WasmExperimentalEpsilonRational::one();
+        let zero = WasmExperimentalEpsilonRational::zero();
+        assert!(one.checked_div(&zero).is_err());
     }
 }

--- a/amari-wasm/src/surreal.rs
+++ b/amari-wasm/src/surreal.rs
@@ -13,8 +13,7 @@ fn surreal_error(error: amari_surreal::SurrealError) -> JsValue {
 /// error-path tests can verify `is_err()` — the message is irrelevant
 /// for these assertions.
 #[cfg(not(target_arch = "wasm32"))]
-fn surreal_error(error: amari_surreal::SurrealError) -> JsValue {
-    let _ = error;
+fn surreal_error(#[allow(unused_variables)] error: amari_surreal::SurrealError) -> JsValue {
     JsValue::undefined()
 }
 
@@ -558,6 +557,9 @@ impl WasmExperimentalEpsilonRational {
     }
 
     /// A monomial rational function `coeff · ε^exp / 1`.
+    ///
+    /// WASM boundary note: `exponent` is currently exposed as a 32-bit signed
+    /// integer, matching the experimental Rust exponent representation.
     pub fn monomial(coeff: &WasmRationalSurreal, exponent: i32) -> Self {
         Self {
             inner: EpsilonRational::monomial(coeff.inner_ref().clone(), exponent),

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Current release process documentation:
 
 Current planning and release-roadmap documentation:
 
+- **[v0.23.0 Rational Surreal / Surcomplex Roadmap](roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md)** - Planning for the `RationalSurreal`, epsilon rational, and `amari-surcomplex` cycle
+- **[v0.23.0 Rational Surreal / Surcomplex Checklist](roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md)** - Release gates and publish-order audit for the `0.23.0` cycle
 - **[v0.21.0 Tropical / Dual Roadmap](roadmap/v0.21.0-tropical-dual-roadmap.md)** - Planning for the optimization-oriented `amari-tropical` / `amari-dual` cycle
 - **[v0.21.0 Tropical / Dual Checklist](roadmap/v0.21.0-tropical-dual-checklist.md)** - Milestone tracker for the `0.21.0` extension cycle
 - **[Tropical / Dual Optimization Design](roadmap/amari-tropical-dual-optimization_design.md)** - Design notes for compiler/interpreter optimization use cases

--- a/docs/plans/2026-05-10-amari-0.23-rational-surreal-surcomplex-plan.md
+++ b/docs/plans/2026-05-10-amari-0.23-rational-surreal-surcomplex-plan.md
@@ -1,0 +1,762 @@
+# Amari 0.23 Rational Surreal / Surcomplex Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Build Amari v0.23.0 around a stable exact rational surreal scalar layer, a new `amari-surcomplex` crate over that layer, experimental rational-function infinitesimals, and full WASM/examples-suite exposure.
+
+**Architecture:** Preserve `ShortSurreal` as the finite numeric-game/dyadic layer. Add `RationalSurreal` as an exact `BigRational`-backed scalar field in `amari-surreal`; add feature-gated rational functions over a formal positive infinitesimal `ε`; add `amari-surcomplex` with `RationalSurcomplex = a + bi`; expose the release-shaped API through `amari-wasm` and examples-suite. Design epsilon internals so Puiseux/Hahn-style generalized series can be introduced later without renaming the whole public surface.
+
+**Tech Stack:** Rust workspace crates, `num-bigint`, `num-rational`, `num-traits`, `wasm-bindgen`, `wasm-pack`, React/Vite examples-suite, TDD.
+
+---
+
+## Confirmed Design Decisions
+
+- `ShortSurreal` keeps its current mathematical meaning: finite short surreal / dyadic values arising from short numeric games.
+- `RationalSurreal` is the stable v0.23 exact scalar extension and represents arbitrary exact rational surreal values.
+- `RationalSurreal -> ShortSurreal` conversion is partial and succeeds only for dyadic rationals.
+- Epsilon support lives in `amari-surreal` for now, behind an experimental feature.
+- Epsilon model for v0.23 is rational functions over a formal positive infinitesimal `ε`, not nilpotent dual numbers.
+- The epsilon API should leave room for future Puiseux/Hahn generalized series; if that future API grows large, consider extracting `amari-asymptotic` later.
+- `amari-surcomplex` is a separate crate and should build primarily on `RationalSurreal`, not `ShortSurreal`, so division is complete for nonzero rational surcomplex denominators.
+- WASM bindings and examples-suite updates are in scope for v0.23.0.
+- Release publishing must include a dependency-order audit before tagging; `publish.yml` failures must not be swallowed.
+
+---
+
+## Milestones
+
+1. **M1 — Rational surreal scalar layer**
+2. **M2 — Experimental epsilon rational functions**
+3. **M3 — `amari-surcomplex` crate**
+4. **M4 — WASM bindings and examples-suite**
+5. **M5 — Docs, roadmap, release polish, publish-order audit**
+
+---
+
+## Task 1: Add `RationalSurreal` tests first
+
+**Files:**
+- Create: `amari-surreal/tests/rationals.rs`
+- Later modify: `amari-surreal/src/rational.rs`
+- Later modify: `amari-surreal/src/lib.rs`
+- Later modify: `amari-surreal/src/prelude.rs`
+- Later modify: `amari-surreal/Cargo.toml`
+- Later modify: root `Cargo.toml` workspace dependencies if `num-rational` is moved to workspace
+
+**Step 1: Write failing tests**
+
+Create tests covering construction, normalization, arithmetic, ordering, and dyadic conversion:
+
+```rust
+use amari_surreal::{Dyadic, RationalSurreal, ShortSurreal, SurrealError};
+
+#[test]
+fn rational_surreal_normalizes_and_displays() {
+    let value = RationalSurreal::from_ratio(2, 4).unwrap();
+    assert_eq!(value.to_string(), "1/2");
+    assert_eq!(value.numer().to_string(), "1");
+    assert_eq!(value.denom().to_string(), "2");
+}
+
+#[test]
+fn rational_surreal_supports_exact_field_arithmetic() {
+    let third = RationalSurreal::from_ratio(1, 3).unwrap();
+    let sixth = RationalSurreal::from_ratio(1, 6).unwrap();
+    assert_eq!((third.clone() + sixth.clone()).to_string(), "1/2");
+    assert_eq!((third.clone() * sixth.clone()).to_string(), "1/18");
+    assert_eq!(third.checked_div(&sixth).unwrap().to_string(), "2");
+}
+
+#[test]
+fn rational_surreal_converts_to_short_only_when_dyadic() {
+    let half = RationalSurreal::from_ratio(1, 2).unwrap();
+    assert_eq!(half.to_short_if_dyadic().unwrap().to_dyadic(), Dyadic::new(1, 1));
+
+    let third = RationalSurreal::from_ratio(1, 3).unwrap();
+    assert!(third.to_short_if_dyadic().is_none());
+}
+
+#[test]
+fn rational_surreal_embeds_short_surreal() {
+    let short = ShortSurreal::from_dyadic(Dyadic::new(3, 2));
+    let rational = RationalSurreal::from_short(short);
+    assert_eq!(rational.to_string(), "3/4");
+}
+
+#[test]
+fn rational_surreal_rejects_zero_denominator_and_division_by_zero() {
+    assert_eq!(
+        RationalSurreal::from_ratio(1, 0),
+        Err(SurrealError::DivisionByZero)
+    );
+    assert_eq!(
+        RationalSurreal::one().checked_div(&RationalSurreal::zero()),
+        Err(SurrealError::DivisionByZero)
+    );
+}
+```
+
+**Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test -p amari-surreal --test rationals --quiet
+```
+
+Expected: fails because `RationalSurreal` does not exist.
+
+---
+
+## Task 2: Implement `RationalSurreal`
+
+**Files:**
+- Create: `amari-surreal/src/rational.rs`
+- Modify: `amari-surreal/src/lib.rs`
+- Modify: `amari-surreal/src/prelude.rs`
+- Modify: `amari-surreal/Cargo.toml`
+- Modify: root `Cargo.toml` if promoting `num-rational` to workspace dependency
+
+**Step 1: Add dependency**
+
+Preferred workspace-level dependency:
+
+```toml
+# root Cargo.toml [workspace.dependencies]
+num-rational = "0.4"
+```
+
+Then in `amari-surreal/Cargo.toml`:
+
+```toml
+num-rational = { workspace = true }
+```
+
+**Step 2: Implement minimal type**
+
+```rust
+use crate::error::{Result, SurrealError};
+use crate::{Dyadic, ShortSurreal};
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::{One, Signed, Zero};
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Mul, Neg, Sub};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RationalSurreal {
+    value: BigRational,
+}
+
+impl RationalSurreal {
+    pub fn zero() -> Self { Self { value: BigRational::zero() } }
+    pub fn one() -> Self { Self { value: BigRational::one() } }
+
+    pub fn from_integer<N: Into<BigInt>>(n: N) -> Self {
+        Self { value: BigRational::from_integer(n.into()) }
+    }
+
+    pub fn from_ratio<N: Into<BigInt>, D: Into<BigInt>>(numer: N, denom: D) -> Result<Self> {
+        let denom = denom.into();
+        if denom.is_zero() {
+            return Err(SurrealError::DivisionByZero);
+        }
+        Ok(Self { value: BigRational::new(numer.into(), denom) })
+    }
+
+    pub fn from_short(value: ShortSurreal) -> Self {
+        let dyadic = value.to_dyadic();
+        let denom = BigInt::one() << dyadic.exponent();
+        Self { value: BigRational::new(dyadic.numer().clone(), denom) }
+    }
+
+    pub fn numer(&self) -> &BigInt { self.value.numer() }
+    pub fn denom(&self) -> &BigInt { self.value.denom() }
+    pub fn is_zero(&self) -> bool { self.value.is_zero() }
+    pub fn is_positive(&self) -> bool { self.value.is_positive() }
+    pub fn is_negative(&self) -> bool { self.value.is_negative() }
+    pub fn abs(&self) -> Self { Self { value: self.value.abs() } }
+
+    pub fn checked_reciprocal(&self) -> Result<Self> {
+        if self.is_zero() { return Err(SurrealError::DivisionByZero); }
+        Ok(Self { value: self.value.clone().recip() })
+    }
+
+    pub fn checked_div(&self, rhs: &Self) -> Result<Self> {
+        Ok(self.clone() * rhs.checked_reciprocal()?)
+    }
+
+    pub fn to_short_if_dyadic(&self) -> Option<ShortSurreal> {
+        // denominator must be a positive power of two after BigRational normalization.
+        // Reuse/relocate Dyadic power-of-two detection or implement a private helper here.
+        todo!("convert only when denom is power of two")
+    }
+}
+```
+
+Implement `Ord`, `Hash`, `Display`, `Add`, `Sub`, `Mul`, `Neg` using `BigRational` semantics.
+
+**Step 3: Export it**
+
+```rust
+pub mod rational;
+pub use rational::RationalSurreal;
+```
+
+Add to prelude.
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p amari-surreal --test rationals --quiet
+cargo test -p amari-surreal --quiet
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml amari-surreal/Cargo.toml amari-surreal/src/rational.rs amari-surreal/src/lib.rs amari-surreal/src/prelude.rs amari-surreal/tests/rationals.rs
+git commit -m "Add rational surreal scalar layer"
+```
+
+---
+
+## Task 3: Add experimental epsilon tests first
+
+**Files:**
+- Create: `amari-surreal/tests/epsilon.rs`
+- Later create: `amari-surreal/src/epsilon.rs`
+- Later modify: `amari-surreal/src/lib.rs`
+- Later modify: `amari-surreal/src/prelude.rs`
+- Later modify: `amari-surreal/Cargo.toml`
+
+**Step 1: Add feature-gated tests**
+
+```rust
+#![cfg(feature = "experimental-epsilon")]
+
+use amari_surreal::epsilon::{EpsilonPolynomial, EpsilonRational};
+use amari_surreal::RationalSurreal;
+
+#[test]
+fn epsilon_is_positive_infinitesimal() {
+    let eps = EpsilonRational::epsilon();
+    assert!(eps > EpsilonRational::zero());
+    assert!(eps < EpsilonRational::from_scalar(RationalSurreal::from_ratio(1, 1_000_000).unwrap()));
+}
+
+#[test]
+fn inverse_epsilon_is_larger_than_any_test_integer() {
+    let inv = EpsilonRational::one().checked_div(&EpsilonRational::epsilon()).unwrap();
+    assert!(inv > EpsilonRational::from_scalar(RationalSurreal::from_integer(1_000_000)));
+}
+
+#[test]
+fn epsilon_rational_arithmetic_is_exact() {
+    let eps = EpsilonRational::epsilon();
+    let one = EpsilonRational::one();
+    let expr = (one.clone() + eps.clone()).checked_div(&(one.clone() - eps.clone())).unwrap();
+    assert_eq!(expr.denom().degree(), Some(1));
+}
+```
+
+**Step 2: Run and verify failure**
+
+```bash
+cargo test -p amari-surreal --features experimental-epsilon --test epsilon --quiet
+```
+
+Expected: fails because feature/module/types do not exist.
+
+---
+
+## Task 4: Implement experimental epsilon rational functions
+
+**Files:**
+- Create: `amari-surreal/src/epsilon.rs`
+- Modify: `amari-surreal/Cargo.toml`
+- Modify: `amari-surreal/src/lib.rs`
+- Modify: `amari-surreal/src/prelude.rs`
+- Modify: `amari-surreal/src/error.rs` if a dedicated zero-polynomial denominator error is needed
+
+**Step 1: Add feature**
+
+```toml
+[features]
+default = ["std"]
+std = []
+serialize = ["dep:serde"]
+experimental-epsilon = []
+```
+
+**Step 2: Add module gate**
+
+```rust
+#[cfg(feature = "experimental-epsilon")]
+pub mod epsilon;
+```
+
+**Step 3: Implement finite integer-exponent polynomials**
+
+Use a wrapper exponent type to preserve future extension room:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EpsilonExponent(pub i32);
+```
+
+Use finite support:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EpsilonPolynomial {
+    terms: BTreeMap<EpsilonExponent, RationalSurreal>,
+}
+```
+
+Core behavior:
+- normalize by removing zero coefficients
+- `zero`, `one`, `epsilon`, `monomial`
+- `degree()` and `valuation()` helpers
+- add/sub/mul/neg
+- leading term for asymptotic comparison as `ε -> 0+` should use the smallest exponent with nonzero coefficient
+
+**Step 4: Implement rational functions**
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EpsilonRational {
+    numer: EpsilonPolynomial,
+    denom: EpsilonPolynomial,
+}
+```
+
+Core behavior:
+- denominator cannot be zero
+- `zero`, `one`, `epsilon`, `from_scalar`, `monomial`
+- add/sub/mul/neg
+- checked reciprocal/division
+- comparison by sign of `self - rhs`, using leading asymptotic term after cross multiplication
+
+Do not attempt full polynomial GCD normalization in v0.23 unless needed. Normalize zero and denominator monomial factors enough to keep display/testing stable.
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p amari-surreal --features experimental-epsilon --test epsilon --quiet
+cargo test -p amari-surreal --features experimental-epsilon --quiet
+```
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```bash
+git add amari-surreal/Cargo.toml amari-surreal/src/epsilon.rs amari-surreal/src/lib.rs amari-surreal/src/prelude.rs amari-surreal/src/error.rs amari-surreal/tests/epsilon.rs
+git commit -m "Add experimental epsilon rational functions"
+```
+
+---
+
+## Task 5: Scaffold `amari-surcomplex`
+
+**Files:**
+- Create: `amari-surcomplex/Cargo.toml`
+- Create: `amari-surcomplex/README.md`
+- Create: `amari-surcomplex/src/lib.rs`
+- Create: `amari-surcomplex/src/error.rs`
+- Create: `amari-surcomplex/src/rational.rs`
+- Create: `amari-surcomplex/src/prelude.rs`
+- Create: `amari-surcomplex/tests/arithmetic.rs`
+- Modify: root `Cargo.toml` workspace members/dependencies/features
+- Modify: `.github/workflows/publish.yml`
+- Modify: `scripts/verify-workflow-crates.sh` if it maintains explicit expectations
+
+**Step 1: Add failing tests**
+
+```rust
+use amari_surcomplex::RationalSurcomplex;
+use amari_surreal::RationalSurreal;
+
+#[test]
+fn rational_surcomplex_multiplies_i_squared_to_minus_one() {
+    let i = RationalSurcomplex::i();
+    assert_eq!(i.clone() * i, RationalSurcomplex::from_integer(-1));
+}
+
+#[test]
+fn rational_surcomplex_division_produces_non_dyadic_coefficients() {
+    let one = RationalSurreal::one();
+    let half = RationalSurreal::from_ratio(1, 2).unwrap();
+    let z = RationalSurcomplex::from_parts(one.clone(), half);
+    let quotient = RationalSurcomplex::one().checked_div(&z).unwrap();
+    assert_eq!(quotient.real().to_string(), "4/5");
+    assert_eq!(quotient.imag().to_string(), "-2/5");
+}
+
+#[test]
+fn rational_surcomplex_norm_and_conjugate_identity() {
+    let z = RationalSurcomplex::from_parts(
+        RationalSurreal::from_ratio(3, 2).unwrap(),
+        RationalSurreal::from_ratio(-5, 3).unwrap(),
+    );
+    let product = z.clone() * z.conjugate();
+    assert_eq!(product.imag(), &RationalSurreal::zero());
+    assert_eq!(product.real(), &z.norm_sq());
+}
+```
+
+Run:
+
+```bash
+cargo test -p amari-surcomplex --test arithmetic --quiet
+```
+
+Expected: package does not exist yet.
+
+**Step 2: Add workspace crate**
+
+Root `Cargo.toml`:
+
+```toml
+members = [..., "amari-cgt", "amari-surreal", "amari-surcomplex"]
+
+[workspace.dependencies]
+amari-surcomplex = { path = "amari-surcomplex", version = "0.23.0" }
+```
+
+Root dependencies/features:
+
+```toml
+amari-surcomplex = { workspace = true, optional = true }
+surcomplex = ["dep:amari-surcomplex", "surreal"]
+full = [..., "surcomplex"]
+```
+
+**Step 3: Add crate manifest**
+
+```toml
+[package]
+name = "amari-surcomplex"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Exact rational surcomplex numbers for the Amari library"
+repository = "https://github.com/justinelliottcobb/Amari"
+homepage = "https://github.com/justinelliottcobb/Amari"
+keywords = ["mathematics", "surreal", "complex", "exact"]
+categories = ["mathematics", "science", "algorithms"]
+
+[dependencies]
+amari-surreal = { workspace = true }
+thiserror = { workspace = true }
+num-bigint = "0.4"
+
+[dev-dependencies]
+criterion = "0.8"
+```
+
+**Step 4: Implement `RationalSurcomplex`**
+
+```rust
+pub struct RationalSurcomplex {
+    real: RationalSurreal,
+    imag: RationalSurreal,
+}
+```
+
+Implement:
+- `zero`, `one`, `i`
+- `from_integer`, `from_real`, `from_parts`
+- `real`, `imag`
+- `conjugate`, `norm_sq`, `is_zero`
+- `checked_reciprocal`, `checked_div`
+- `Add`, `Sub`, `Mul`, `Neg`, `Display`, equality/hash
+
+Division formula:
+
+```text
+(a + bi) / (c + di) = ((a + bi)(c - di)) / (c² + d²)
+```
+
+Because `RationalSurreal` is a field, `checked_div` should only fail when `c = 0` and `d = 0`.
+
+**Step 5: Run tests**
+
+```bash
+cargo test -p amari-surcomplex --quiet
+cargo test -p amari-surreal -p amari-surcomplex --quiet
+```
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```bash
+git add Cargo.toml amari-surcomplex .github/workflows/publish.yml scripts/verify-workflow-crates.sh
+git commit -m "Add rational surcomplex crate"
+```
+
+---
+
+## Task 6: Add WASM bindings
+
+**Files:**
+- Modify: `amari-wasm/Cargo.toml`
+- Modify: `amari-wasm/src/lib.rs`
+- Create: `amari-wasm/src/surcomplex.rs`
+- Modify: `amari-wasm/src/surreal.rs`
+- Modify: `amari-wasm/README.md`
+
+**Step 1: Add failing WASM tests in Rust where practical**
+
+Add tests for non-wasm logic exposed by wrappers if existing `amari-wasm` test style supports it:
+
+```bash
+cargo test -p amari-wasm --quiet
+```
+
+**Step 2: Add dependencies**
+
+```toml
+amari-surcomplex = { workspace = true }
+amari-surreal = { workspace = true, features = ["experimental-epsilon"] }
+```
+
+Only enable `experimental-epsilon` in `amari-wasm` if we intentionally expose the experimental epsilon API in the npm package. If exposing it, prefix exported classes with `WasmExperimental...`.
+
+**Step 3: Add stable bindings**
+
+Recommended stable exports:
+- `WasmRationalSurreal`
+  - `zero`, `one`, `fromInteger(i32)`
+  - `fromRatio(numer: i32, denom: i32)`
+  - `numeratorString`, `denominatorString`, `toString`
+  - `add`, `sub`, `mul`, `neg`, `checkedDiv`, `checkedReciprocal`
+  - `compare`, `isZero`, `isPositive`, `isNegative`
+  - `toShortIfDyadic() -> WasmShortSurreal | undefined`
+- `WasmRationalSurcomplex`
+  - `zero`, `one`, `i`, `fromReal`, `fromParts`, `fromInteger`
+  - `real`, `imag`, `conjugate`, `normSq`, `isZero`
+  - `add`, `sub`, `mul`, `neg`, `checkedDiv`, `checkedReciprocal`
+
+Experimental exports if included:
+- `WasmExperimentalEpsilonRational`
+  - `zero`, `one`, `epsilon`, `fromScalar`, `monomial`
+  - `add`, `sub`, `mul`, `neg`, `checkedDiv`
+  - `compare`, `toString`
+
+**Step 4: Export module**
+
+```rust
+pub mod surcomplex;
+```
+
+**Step 5: Build package and inspect types**
+
+```bash
+cargo check -p amari-wasm --target wasm32-unknown-unknown --quiet
+cd amari-wasm && wasm-pack build --target web --out-dir /tmp/amari-wasm-v23-pkg --scope justinelliottcobb
+rg "WasmRationalSurreal|WasmRationalSurcomplex|WasmExperimentalEpsilon" /tmp/amari-wasm-v23-pkg/amari_wasm.d.ts
+```
+
+**Step 6: Commit**
+
+```bash
+git add amari-wasm/Cargo.toml amari-wasm/src/lib.rs amari-wasm/src/surreal.rs amari-wasm/src/surcomplex.rs amari-wasm/README.md
+git commit -m "Expose rational surreal and surcomplex WASM bindings"
+```
+
+---
+
+## Task 7: Add examples-suite pages and API reference
+
+**Files:**
+- Create: `examples-suite/src/pages/Surcomplex.tsx`
+- Create: `examples-suite/src/pages/Surcomplex.test.tsx`
+- Modify: `examples-suite/src/pages/APIReference.tsx`
+- Modify: `examples-suite/src/pages/APIReference.test.tsx`
+- Modify: `examples-suite/src/components/Navigation.tsx`
+- Modify: `examples-suite/src/pages/Home.tsx`
+- Modify: `examples-suite/src/main.tsx`
+- Modify: `examples-suite/package.json`
+- Modify: `examples-suite/package-lock.json`
+
+**Step 1: Add failing UI tests**
+
+Test expected page content:
+
+```tsx
+import { render, screen } from '../test/test-utils';
+import Surcomplex from './Surcomplex';
+
+test('documents rational surreal, epsilon, and surcomplex examples', async () => {
+  render(<Surcomplex />);
+  expect(await screen.findByText(/Rational Surreals/i)).toBeInTheDocument();
+  expect(screen.getByText(/Surcomplex Division/i)).toBeInTheDocument();
+  expect(screen.getByText(/Experimental Epsilon/i)).toBeInTheDocument();
+  expect(screen.getByText(/4\/5 - 2\/5i/i)).toBeInTheDocument();
+});
+```
+
+Run:
+
+```bash
+cd examples-suite && npm run test:run -- Surcomplex
+```
+
+Expected: fails until page exists.
+
+**Step 2: Implement examples page**
+
+Show three sections:
+- Rational surreal exact division: `1 / 3`
+- Surcomplex division: `1 / (1 + 1/2 i) = 4/5 - 2/5 i`
+- Experimental epsilon: `0 < ε < 1/n`, `1/ε` as infinite-scale value
+
+Use version-gated dynamic WASM access if published TypeScript bindings are not yet available during development.
+
+**Step 3: Add route/navigation/home/API entries**
+
+Add `/surcomplex` route and API reference entries for:
+- `WasmRationalSurreal`
+- `WasmRationalSurcomplex`
+- experimental epsilon class if exposed
+
+**Step 4: Run examples checks**
+
+```bash
+cd examples-suite
+npm run lint
+npm run build
+npm run test:run
+```
+
+Expected: pass, allowing existing unrelated lint warnings if still present.
+
+**Step 5: Commit**
+
+```bash
+git add examples-suite/package.json examples-suite/package-lock.json examples-suite/src
+git commit -m "Add rational surreal and surcomplex examples"
+```
+
+---
+
+## Task 8: Documentation, roadmap, and release checklist
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `amari-surreal/README.md`
+- Create: `amari-surcomplex/README.md` if not already done
+- Create: `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md`
+- Create: `docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md`
+- Modify: `docs/README.md`
+- Modify: `docs/roadmap/amari-surreal_design.md`
+- Modify: `docs/roadmap/amari-surcomplex_design.md`
+
+**Step 1: Update docs with honest scope**
+
+Docs must clearly state:
+- `ShortSurreal` = finite short/dyadic layer
+- `RationalSurreal` = exact rational scalar field, not all surreal numbers
+- epsilon module = experimental rational functions over a positive infinitesimal
+- Puiseux/Hahn = future extension path
+- `amari-surcomplex` = exact complex arithmetic over `RationalSurreal`
+
+**Step 2: Add release checklist**
+
+Checklist should include dependency-order audit:
+
+```bash
+./scripts/version-sync.sh verify 0.23.0
+./scripts/verify-workflow-crates.sh
+cargo package -p amari-surcomplex --allow-dirty
+cargo publish -p amari-surcomplex --dry-run --allow-dirty
+```
+
+And explicit publish order check in `.github/workflows/publish.yml`:
+
+```text
+amari-cgt -> amari-surreal -> amari-surcomplex -> amari-enumerative/downstream -> amari
+```
+
+**Step 3: Commit**
+
+```bash
+git add README.md CHANGELOG.md docs amari-surreal/README.md amari-surcomplex/README.md
+git commit -m "Document v0.23 rational surreal surcomplex roadmap"
+```
+
+---
+
+## Task 9: Final validation before PR
+
+Run the release-focused validation set:
+
+```bash
+cargo fmt --all --check
+git diff --check
+./scripts/version-sync.sh verify 0.23.0
+./scripts/verify-workflow-crates.sh
+cargo test -p amari-surreal -p amari-surcomplex -p amari-wasm --quiet
+cargo test -p amari-surreal --features experimental-epsilon --quiet
+cargo check --examples -p amari-surreal -p amari-surcomplex --quiet
+cargo clippy -p amari-surreal -p amari-surcomplex -p amari-wasm --all-targets --all-features -- -D warnings
+cargo bench -p amari-surreal -p amari-surcomplex --no-run --quiet
+cargo check -p amari-wasm --target wasm32-unknown-unknown --quiet
+cd amari-wasm && wasm-pack build --target web --out-dir /tmp/amari-wasm-v23-pkg --scope justinelliottcobb
+cd ../examples-suite && npm run lint && npm run build && npm run test:run
+```
+
+Also verify generated WASM typings:
+
+```bash
+rg "WasmRationalSurreal|WasmRationalSurcomplex" /tmp/amari-wasm-v23-pkg/amari_wasm.d.ts
+```
+
+Commit any final fixups:
+
+```bash
+git status --short
+git commit -m "Prepare v0.23 rational surreal surcomplex release surface"
+```
+
+---
+
+## Task 10: PR preparation
+
+Open PR against `develop` with summary:
+
+- stable `RationalSurreal` exact rational scalar layer
+- experimental epsilon rational functions in `amari-surreal`
+- new `amari-surcomplex` crate with exact rational complex arithmetic
+- WASM bindings and examples-suite page/API reference
+- docs/roadmap/checklist updates
+- publish-order audit updates
+
+Use local verification evidence from Task 9.
+
+---
+
+## Release Gates for 0.23.0
+
+Do not tag 0.23.0 until all are true:
+
+- All new crates are in workspace and publish workflow in dependency order.
+- `cargo publish --dry-run` has been run for new/changed publish-sensitive crates.
+- `RationalSurreal` handles `1/3` and exact field operations.
+- `ShortSurreal` semantics remain dyadic/short and tests still pass.
+- Epsilon is explicitly feature-gated and documented experimental.
+- `RationalSurcomplex` division works for `1 / (1 + 1/2 i) = 4/5 - 2/5 i`.
+- WASM package builds and generated typings include new release APIs.
+- examples-suite page builds and tests pass.
+- npm publish auth path is known before tag, or manual npm publish is planned explicitly.

--- a/docs/roadmap/amari-surcomplex_design.md
+++ b/docs/roadmap/amari-surcomplex_design.md
@@ -6,18 +6,20 @@
 
 It should be introduced **as a separate crate after `amari-surreal` is mature**, not folded into the initial stable scope of `amari-surreal` itself.
 
-**Status:** Proposed for a later release after `0.22.0`  
-**Immediate prerequisite:** Mature `amari-surreal` short-surreal layer  
-**Primary dependency:** `amari-surreal`  
-**Transitive dependency:** `amari-cgt` via `amari-surreal`  
-**Role in Amari:** Opt-in extension crate for exact and later symbolic surcomplex computation
+**Status:** Implemented in `0.23.0`
+**Target Release:** `0.23.0`
+**Immediate prerequisite:** `RationalSurreal` in `amari-surreal`
+**Primary dependency:** `amari-surreal`
+**Transitive dependency:** `amari-cgt` via `amari-surreal`
+**Role in Amari:** Opt-in extension crate for exact rational surcomplex computation
 
-The crate should begin with a **disciplined short/exact layer**:
+The crate begins with a **disciplined exact rational layer**:
 
-- coefficients in `ShortSurreal`
+- coefficients in `RationalSurreal`
 - exact arithmetic for values of the form `a + b i`
 - conjugation and norm-square operations
 - checked division when the denominator is nonzero
+- `1 / (1 + 1/2 i) = 4/5 - 2/5i` demonstrates why dyadic `ShortSurreal` coefficients are insufficient and rational scalars are needed for surcomplex closure
 
 It should **not** begin by claiming support for the full complexification of the entire surreal proper class, nor a full analytic theory over all future symbolic surreal forms.
 
@@ -30,11 +32,11 @@ It should **not** begin by claiming support for the full complexification of the
    - Avoid expanding the `0.22.0` surreal API into a broader algebra package
 
 2. **Build on a mature surreal scalar layer**
-   - Reuse `ShortSurreal`, `Dyadic`, and later supported symbolic surreal forms
+   - Reuse `RationalSurreal` as the primary coefficient type, with `ShortSurreal`/`Dyadic` available through conversion and later symbolic surreal forms deferred
    - Avoid duplicating coefficient logic inside the complex layer
 
 3. **Start with exact, computationally honest arithmetic**
-   - Short surcomplex numbers over exact short surreal coefficients
+   - Rational surcomplex numbers over exact rational surreal coefficients
    - No hidden float approximation in the stable core
 
 4. **Leave room for later symbolic extensions**
@@ -58,7 +60,7 @@ It should **not** begin by claiming support for the full complexification of the
 - A drop-in replacement for ordinary complex arithmetic across all Amari crates
 - Any claim that `amari-surcomplex` is the algebraic closure of all supported future surreal constructions
 
-The first serious version should be about **correct exact arithmetic for short surcomplex values**, not maximal generality.
+The first serious version should be about **correct exact arithmetic for rational surcomplex values**, not maximal generality.
 
 ---
 
@@ -77,13 +79,13 @@ where:
 - `a` and `b` belong to a supported surreal coefficient domain
 - `i^2 = -1`
 
-For the initial release, the supported coefficient domain should be:
+For the `0.23.0` release, the supported coefficient domain is:
 
 ```text
-a, b ∈ ShortSurreal
+a, b ∈ RationalSurreal
 ```
 
-Since `ShortSurreal` is currently implemented via exact dyadics, the initial surcomplex layer is effectively an exact **Gaussian dyadic** layer with surreal provenance and future surreal extensibility.
+Since `RationalSurreal` supports exact rational arithmetic (not limited to dyadics), the surcomplex layer is an exact **Gaussian rational** layer. The earlier `ShortSurreal` dyadic layer is accessible via conversion but is not the primary coefficient type — dyadic-only coefficients cannot represent all surcomplex division results (e.g., `1 / (1 + 1/2 i) = 4/5 - 2/5i`), which is why `RationalSurreal` was introduced as the scalar foundation.
 
 ## Important Ordering Boundary
 
@@ -107,27 +109,28 @@ Division should be defined by the usual exact formula when the denominator is no
 (a + b i) / (c + d i) = ((a + b i)(c - d i)) / (c^2 + d^2)
 ```
 
-This fits naturally with `ShortSurreal` because:
+This fits naturally with `RationalSurreal` because:
 
-- `c^2 + d^2` is a short surreal
+- `c^2 + d^2` is an exact rational surreal scalar
 - zero-testing is exact
-- division can be delegated to supported exact surreal division when defined
+- division is total for nonzero rational denominators
 
 ---
 
 ## Strategic Scope
 
-## Stage A — Exact Short Surcomplex Layer
+## Stage A — Exact Rational Surcomplex Layer (shipped in v0.23.0)
 
-The first public version of `amari-surcomplex` should promise:
+The first public version of `amari-surcomplex` delivers:
 
-- coefficients in `ShortSurreal`
-- exact construction from integers, dyadics, or short surreal values
+- coefficients in `RationalSurreal`
+- exact construction from integers, rationals, dyadics, or `RationalSurreal` values
 - exact addition, subtraction, negation, multiplication
 - conjugation
 - exact norm-square
-- checked division for nonzero denominators
+- checked division for nonzero denominators (producing exact rational coefficients)
 - formatting and testable algebraic identities
+- `1 / (1 + 1/2 i) = 4/5 - 2/5i` demonstrating rational-closure necessity
 
 ## Stage B — Ergonomic Extensions
 
@@ -158,43 +161,25 @@ This stage should remain explicitly experimental until the coefficient story is 
 
 Instead, it should depend on:
 
-- `amari-surreal::ShortSurreal` for the stable initial coefficient layer
+- `amari-surreal::RationalSurreal` for the stable initial coefficient layer
 - later stable symbolic surreal types if and when they exist
 
 ## Recommended Core Type
 
-### `ShortSurcomplex`
+### `RationalSurcomplex` (shipped in v0.23.0)
 
 ```rust
-pub struct ShortSurcomplex {
-    real: ShortSurreal,
-    imag: ShortSurreal,
+pub struct RationalSurcomplex {
+    real: RationalSurreal,
+    imag: RationalSurreal,
 }
 ```
 
-This type should be the stable first-class value for the initial release.
+This is the stable first-class type for the `0.23.0` release. It uses `RationalSurreal` coefficients rather than `ShortSurreal` to support exact rational division results.
 
-### Why not make it generic immediately?
+### Why `RationalSurreal` rather than `ShortSurreal`?
 
-A generic type such as:
-
-```rust
-pub struct Surcomplex<T> {
-    real: T,
-    imag: T,
-}
-```
-
-is conceptually attractive, but it pushes typeclass/trait design questions too early.
-
-For the first serious version, a concrete `ShortSurcomplex` keeps the API:
-
-- simpler
-- easier to document
-- easier to test
-- tightly aligned with the current exact short-surreal scope
-
-A generic coefficient abstraction can be introduced later if it becomes clearly useful.
+Division in surcomplex arithmetic produces rational (not necessarily dyadic) coefficients: `1 / (1 + 1/2 i) = 4/5 - 2/5i`. The dyadic `ShortSurreal` layer cannot represent `4/5`, so `RationalSurreal` was introduced as the scalar foundation for surcomplex arithmetic. A generic coefficient type is deferred until the need for it becomes clear.
 
 ### Later / Experimental Types
 
@@ -202,7 +187,7 @@ If `amari-surreal` grows a symbolic layer, `amari-surcomplex` may later introduc
 
 ```rust
 pub enum SurcomplexExpr {
-    Short(ShortSurcomplex),
+    Rational(RationalSurcomplex),
     Symbolic {
         real: SurrealExpr,
         imag: SurrealExpr,
@@ -223,7 +208,7 @@ amari-surcomplex/
 ├── src/
 │   ├── lib.rs
 │   ├── error.rs
-│   ├── short.rs          # ShortSurcomplex core type
+│   ├── rational.rs       # RationalSurcomplex core type
 │   ├── arithmetic.rs     # +, -, *, checked_div, conjugation, norm_sq
 │   ├── convert.rs        # integer/dyadic/short-surreal conversions
 │   ├── prelude.rs
@@ -240,7 +225,7 @@ amari-surcomplex/
 
 The actual module layout can be simplified at first, but the main architectural point is:
 
-- exact short layer first
+- exact rational layer first
 - symbolic layer later and explicitly separated
 
 ---
@@ -248,42 +233,40 @@ The actual module layout can be simplified at first, but the main architectural 
 ## Public API Sketch
 
 ```rust
-use amari_surcomplex::ShortSurcomplex;
-use amari_surreal::ShortSurreal;
+use amari_surcomplex::RationalSurcomplex;
+use amari_surreal::RationalSurreal;
 
-let one = ShortSurcomplex::one();
-let i = ShortSurcomplex::i();
+let one = RationalSurcomplex::one();
+let i = RationalSurcomplex::i();
 let z = one.clone() + i.clone();
 let w = z.clone() * z.clone();
 
-assert_eq!(w.real(), ShortSurreal::zero());
-assert_eq!(w.imag(), ShortSurreal::from_integer(2));
+assert_eq!(w.real(), &RationalSurreal::zero());
+assert_eq!(w.imag(), &RationalSurreal::from_integer(2));
 assert_eq!(
     z.conjugate(),
-    ShortSurcomplex::from_parts(ShortSurreal::one(), -ShortSurreal::one())
+    RationalSurcomplex::from_parts(RationalSurreal::one(), -RationalSurreal::one())
 );
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-### Suggested public API
+### Actual public API (v0.23.0)
 
 ```rust
-impl ShortSurcomplex {
+impl RationalSurcomplex {
     pub fn zero() -> Self;
     pub fn one() -> Self;
     pub fn i() -> Self;
 
     pub fn from_integer(n: i64) -> Self;
-    pub fn from_dyadic(real: Dyadic) -> Self;
-    pub fn from_real(real: ShortSurreal) -> Self;
-    pub fn from_parts(real: ShortSurreal, imag: ShortSurreal) -> Self;
+    pub fn from_parts(real: RationalSurreal, imag: RationalSurreal) -> Self;
 
-    pub fn real(&self) -> ShortSurreal;
-    pub fn imag(&self) -> ShortSurreal;
+    pub fn real(&self) -> &RationalSurreal;
+    pub fn imag(&self) -> &RationalSurreal;
     pub fn conjugate(&self) -> Self;
-    pub fn norm_sq(&self) -> ShortSurreal;
+    pub fn norm_sq(&self) -> RationalSurreal;
 
-    pub fn checked_div(&self, rhs: &Self) -> Result<Self>;
+    pub fn checked_div(&self, rhs: &Self) -> Result<Self, SurcomplexError>;
 }
 ```
 
@@ -341,7 +324,7 @@ Keeping `amari-surcomplex` separate:
 
 ## Stable Initial Operations
 
-For `ShortSurcomplex`, the stable initial release should implement:
+For `RationalSurcomplex`, the stable initial release implements:
 
 - addition
 - subtraction
@@ -352,11 +335,11 @@ For `ShortSurcomplex`, the stable initial release should implement:
 - norm-square
 - checked division
 
-These operations can be expressed entirely in terms of `ShortSurreal` arithmetic.
+These operations are expressed in terms of exact `RationalSurreal` arithmetic.
 
 ## Scalar Embedding
 
-A short surreal value should embed naturally as a purely real surcomplex value:
+A rational surreal value embeds naturally as a purely real surcomplex value:
 
 ```text
 a ↦ a + 0i
@@ -383,7 +366,7 @@ A value is invertible exactly when:
 norm_sq(z) ≠ 0
 ```
 
-For the initial short/exact layer, this is an exact and efficiently testable condition.
+For the initial rational/exact layer, this is an exact and efficiently testable condition.
 
 ---
 
@@ -435,8 +418,8 @@ Build a test corpus for:
 ## Identity tests
 
 - `z * conjugate(z) = norm_sq(z)` as a purely real value
-- `norm_sq(z * w) = norm_sq(z) * norm_sq(w)` in the short exact layer
-- purely real embeddings behave like underlying `ShortSurreal` arithmetic
+- `norm_sq(z * w) = norm_sq(z) * norm_sq(w)` in the rational exact layer
+- purely real embeddings behave like underlying `RationalSurreal` arithmetic
 
 ## Failure tests
 
@@ -449,13 +432,13 @@ Build a test corpus for:
 
 Initial benchmark targets:
 
-- short surcomplex addition
+- rational surcomplex addition
 - multiplication
 - division
 - polynomial evaluation on small exact inputs
 - repeated conjugation/norm computations
 
-Benchmarks should stay focused on the exact short layer before any symbolic complexity is introduced.
+Benchmarks should stay focused on the exact rational layer before any symbolic complexity is introduced.
 
 ---
 
@@ -471,18 +454,18 @@ Indirect foundational dependency through `amari-surreal`.
 
 ## `amari-wasm`
 
-Natural later target for:
+Release target covered in v0.23.0 via `WasmRationalSurcomplex`, with later room for:
 
-- visualizing exact Gaussian-dyadic lattices
+- visualizing exact Gaussian-rational lattices
 - interactive multiplication/conjugation demos
-- educational views of exact surreal-complex arithmetic
+- educational views of exact rational-surcomplex arithmetic
 
 ## `amari-enumerative`
 
 Possible later connection for:
 
 - counting bounded exact coefficient families
-- studying distribution of norm values in small short-surcomplex corpora
+- studying distribution of norm values in small rational-surcomplex corpora
 
 These integrations should come only after the core surcomplex arithmetic is stable.
 
@@ -490,30 +473,28 @@ These integrations should come only after the core surcomplex arithmetic is stab
 
 ## Release Strategy
 
-`amari-surcomplex` should be introduced:
+`amari-surcomplex` was introduced in `0.23.0`:
 
 - as a separate workspace crate
 - as an **opt-in** extension
-- only after `amari-surreal` is stable enough to act as a reliable scalar dependency
-- **not** as part of the `0.22.0` CGT/surreal release scope
-
-Recommended umbrella feature later:
+- after `RationalSurreal` provided the exact rational scalar dependency
+- with the umbrella feature:
 
 ```toml
 surcomplex = ["dep:amari-surcomplex", "surreal"]
 ```
 
-No target release number needs to be locked yet. The gating condition is maturity, not calendar pressure.
+`surcomplex` implies `surreal`, which implies `cgt`.
 
 ---
 
 ## Proposed Implementation Phases
 
-## Phase 1 — Exact Short Surcomplex Core
+## Phase 1 — Exact Rational Surcomplex Core
 
 Deliver:
 
-- `ShortSurcomplex`
+- `RationalSurcomplex`
 - exact constructors
 - exact arithmetic
 - conjugation
@@ -552,19 +533,19 @@ Possible later extensions include:
 - visualization and educational tooling via WASM
 - connections to asymptotic or valuation-style abstractions later on
 
-All of these should come only after the exact short layer is unquestionably solid.
+All of these should come only after the exact rational layer is unquestionably solid.
 
 ---
 
 ## Summary
 
-`amari-surcomplex` should be a **separate later-release crate** that depends on a mature `amari-surreal`.
+`amari-surcomplex` is a **separate crate** that depends on the disciplined scalar layers in `amari-surreal`.
 
 Its first stable scope should be:
 
-- exact short surcomplex arithmetic
-- concrete `ShortSurcomplex` values
-- clean dependence on `ShortSurreal`
+- exact rational surcomplex arithmetic
+- concrete `RationalSurcomplex` values
+- clean dependence on `RationalSurreal`
 - mathematically honest boundaries around what is and is not implemented
 
-This keeps `amari-surreal` focused, gives Amari a clean future extension path, and lets surcomplex work arrive when the surreal scalar layer is ready to support it well.
+This keeps `amari-surreal` focused, gives Amari a clean future extension path, and lets future surcomplex work grow only when the surreal scalar layer is ready to support it well.

--- a/docs/roadmap/amari-surreal_design.md
+++ b/docs/roadmap/amari-surreal_design.md
@@ -4,14 +4,27 @@
 
 **`amari-surreal`** is a proposed Amari crate for **computable surreal numbers**, built on top of validated numeric games from `amari-cgt`. Its purpose is to extend Amari into a new algebraic and analytic direction while staying computationally grounded.
 
-**Status:** Planned for `0.22.0`  
-**Target Release:** `0.22.0`  
-**Role in Amari:** Opt-in mathematical extension crate with high-completeness release goals  
-**Primary Dependency:** `amari-cgt`  
-**Primary Goal:** Exact computation with short surreal numbers and a disciplined path toward restricted symbolic surreal extensions  
-**Roadmap:** `docs/roadmap/v0.22.0-cgt-surreal-roadmap.md`
+**Status:** Released in `0.22.0` (ShortSurreal); extended in `0.23.0` (RationalSurreal, experimental epsilon)
+**Target Release:** `0.22.0` (initial), `0.23.0` (rational + epsilon extension)
+**Role in Amari:** Opt-in mathematical extension crate with high-completeness release goals
+**Primary Dependency:** `amari-cgt`
+**Primary Goal:** Exact computation with short surreal numbers (dyadic layer), exact rational surreal scalars, and a disciplined path toward restricted symbolic surreal extensions
+**Roadmap:** `docs/roadmap/v0.22.0-cgt-surreal-roadmap.md`, `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md`
 
-The crate should begin with **short surreals** and only later expand toward carefully chosen symbolic subclasses. It should not begin by claiming support for the full class of all surreal numbers.
+The crate began with **short surreals** in `0.22.0` and expanded to **exact rational surreal scalars** in `0.23.0`. It should only later expand toward carefully chosen symbolic subclasses. It should not begin by claiming support for the full class of all surreal numbers.
+
+### What shipped in v0.22.0
+
+- `ShortSurreal` — finite short/dyadic layer (not arbitrary rationals, not the full surreal universe)
+- `Dyadic` — exact dyadic arithmetic backend
+- Numeric-game validation bridge from `amari-cgt`
+- Simplest-number construction for finite cuts
+
+### What shipped in v0.23.0
+
+- `RationalSurreal` — exact rational scalar field backed by `BigRational`, bridging the gap between the dyadic `ShortSurreal` layer and full surreal generality
+- `experimental-epsilon` feature — polynomials and rational functions in a formal positive infinitesimal `ε`, ordered by asymptotic behaviour as `ε → 0⁺`. This is **not** a nilpotent-dual-number system.
+- Puiseux series, Hahn series, and generalized ordered-series fields remain a future extension path, not implemented in v0.23.
 
 ---
 

--- a/docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md
+++ b/docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md
@@ -1,0 +1,397 @@
+# Amari v0.23.0 Checklist / Milestone Tracker
+
+## Purpose
+
+This document is the execution checklist for the `0.23.0` release cycle focused on:
+
+- `RationalSurreal` exact rational scalar layer in `amari-surreal`
+- Experimental epsilon rational functions in `amari-surreal`
+- `amari-surcomplex` exact rational complex crate
+
+It operationalizes:
+
+- `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md`
+- `docs/roadmap/amari-surreal_design.md`
+- `docs/roadmap/amari-surcomplex_design.md`
+
+Use this file as the working milestone tracker during implementation.
+
+---
+
+## Release Context
+
+- `0.20.0` — `amari-gpu` refactor
+- `0.21.0` — `amari-tropical` and `amari-dual` extension cycle
+- `0.22.0` — `amari-cgt` and `amari-surreal` (ShortSurreal dyadic layer)
+- `0.23.0` — `RationalSurreal`, epsilon rational, and `amari-surcomplex`
+
+### `0.23.0` release definition
+
+This release is complete when:
+
+- `RationalSurreal` is a stable exact rational scalar field in `amari-surreal`
+- Epsilon rational functions are available behind `experimental-epsilon` in `amari-surreal`
+- `amari-surcomplex` is a usable exact rational complex crate over `RationalSurreal`
+- WASM bindings cover all new types
+- Examples suite includes surcomplex interactive page and WASM version-gating
+- All crates are documented, tested, and integrated into the workspace
+- No crate exposes placeholder public APIs in its declared `0.23.0` scope
+- Scope boundaries are documented honestly (no overclaims)
+
+---
+
+## Status Summary
+
+- [x] M0 — Planning freeze
+- [x] M1 — `RationalSurreal` core complete
+- [x] M2 — Experimental epsilon module complete
+- [x] M3 — `amari-surcomplex` core complete
+- [x] M4 — WASM bindings complete
+- [x] M5 — Examples suite complete
+- [x] M6 — Documentation complete
+- [ ] M7 — `0.23.0` release readiness gates
+
+---
+
+## M0 — Planning Freeze
+
+### Goals
+- lock names, dependency direction, and release scope
+- establish roadmap docs as the controlling planning set
+
+### Checklist
+- [x] `RationalSurreal` name and scope frozen
+- [x] Epsilon module scope frozen (experimental, not nilpotent dual numbers, Puiseux/Hahn deferred)
+- [x] `amari-surcomplex` crate name and coefficient type (`RationalSurreal`) frozen
+- [x] Dependency direction frozen: `amari-cgt → amari-surreal → amari-surcomplex`
+- [x] `0.23.0` in-scope features explicitly defined
+- [x] `0.23.0` out-of-scope topics explicitly defined
+- [x] Formal roadmap written
+- [x] Checklist/tracker written
+
+### Deliverables
+- [x] `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md`
+- [x] `docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md`
+
+### Exit Criteria
+- [x] All planning docs agree on scope and target version
+- [x] No unresolved naming or architecture disputes remain
+
+---
+
+## M1 — `RationalSurreal` Core Complete
+
+### Goals
+- Deliver exact rational scalar field backed by `BigRational`
+- Provide conversion bridges to/from `Dyadic` and `ShortSurreal`
+
+### `RationalSurreal` type
+- [x] `RationalSurreal` struct backed by `BigRational`
+- [x] `from_ratio(numer, denom)` constructor
+- [x] `from_integer(n)` constructor
+- [x] `one()` and `zero()` constructors
+- [x] `is_zero()`, `is_positive()`, `is_negative()` methods
+- [x] `is_zero()`, `is_positive()`, `is_negative()`, and `abs()` methods
+- [x] Checked reciprocal/division helpers for field arithmetic
+- [x] Exact comparison (`Eq`, `Ord`)
+- [x] Exact addition, subtraction, multiplication
+- [x] Checked division
+
+### Conversion bridges
+- [x] `from_short()` — embeds `ShortSurreal` into `RationalSurreal`
+- [x] `to_short_if_dyadic()` — partial conversion back to `ShortSurreal` for dyadic rational values
+- [x] Conversion is lossy when the value is non-dyadic (documented)
+
+### Tests
+- [x] Construction and normalization tests
+- [x] Arithmetic correctness tests
+- [x] Comparison and ordering tests
+- [x] Conversion round-trip tests for dyadic values
+- [x] Non-dyadic conversion behaviour tests
+
+### Exit Criteria
+- [x] `RationalSurreal` arithmetic is correct for all supported operations
+- [x] Conversion bridges work correctly for both dyadic and non-dyadic values
+- [x] `ShortSurreal` documentation clearly states it's the dyadic layer only
+
+---
+
+## M2 — Experimental Epsilon Module Complete
+
+### Goals
+- Deliver epsilon polynomials and rational functions behind `experimental-epsilon`
+- Clearly distinguish from nilpotent dual numbers
+- Establish exponent type for future Puiseux/Hahn extensibility
+
+### Core types
+- [x] `EpsilonExponent` — newtype wrapper for integer exponents
+- [x] `EpsilonRational` — single epsilon power with rational coefficient
+- [x] `EpsilonPolynomial` — sum of `EpsilonRational` terms
+- [x] `EpsilonRational` — rational function represented by numerator/denominator `EpsilonPolynomial` values
+
+### Operations
+- [x] Polynomial addition, subtraction, multiplication
+- [x] Rational function arithmetic
+- [x] Asymptotic ordering (ε → 0⁺ comparison)
+- [x] Evaluation at finite ε values
+- [x] Denominator sign normalization
+- [x] Leading-term extraction
+
+### Design properties
+- [x] ε² is a positive infinitesimal (not zero — not nilpotent dual numbers)
+- [x] Exponent type is a newtype for future Puiseux/Hahn compatibility
+- [x] Feature-gated behind `experimental-epsilon`
+- [x] No polynomial GCD normalization (documented)
+
+### Tests
+- [x] Polynomial arithmetic correctness tests
+- [x] Rational function arithmetic tests
+- [x] Ordering/comparison tests for different ε powers
+- [x] Evaluation tests
+
+### Exit Criteria
+- [x] Epsilon module is functional and correctly gated
+- [x] No nilpotent-dual-number confusion in docs or behaviour
+- [x] Future Puiseux/Hahn path is noted but not implemented
+
+---
+
+## M3 — `amari-surcomplex` Core Complete
+
+### Goals
+- Deliver exact rational complex arithmetic over `RationalSurreal`
+- Demonstrate rational-closure necessity via `1/(1 + 1/2 i)` example
+
+### Core type
+- [x] `RationalSurcomplex` struct with `RationalSurreal` real and imag parts
+- [x] `zero()`, `one()`, `i()` constructors
+- [x] `from_integer(n)`, `from_parts(real, imag)` constructors
+
+### Operations
+- [x] Exact addition, subtraction, negation, multiplication
+- [x] Conjugation (`conjugate()`)
+- [x] Norm-square (`norm_sq()`)
+- [x] Checked division (`checked_div()`) with `DivisionByZero` error
+- [x] **Dividing `1 / (1 + 1/2 i)` yields `4/5 - 2/5i`** — demonstrating non-dyadic rational coefficients
+
+### Trait implementations
+- [x] `Clone`, `Debug`, `Display`
+- [x] `PartialEq`, `Eq`, `Hash`
+- [x] `Add`, `Sub`, `Mul`, `Neg`
+
+### Tests
+- [x] Basic construction tests (0, 1, i)
+- [x] Arithmetic correctness tests
+- [x] `i * i = -1` identity
+- [x] Conjugation involution test
+- [x] Norm-square tests
+- [x] Division round-trip tests
+- [x] Zero-division error test
+- [x] Non-dyadic rational coefficient test (`1/(1 + 1/2 i)`)
+
+### Exit Criteria
+- [x] Exact rational complex arithmetic is correct
+- [x] Division produces exact rational coefficients (including non-dyadic)
+- [x] Crate is separate from `amari-surreal`
+- [x] `RationalSurreal` is the coefficient type (not `ShortSurreal`)
+
+---
+
+## M4 — WASM Bindings Complete
+
+### Goals
+- Expose all new v0.23 types to TypeScript
+
+### Bindings
+- [x] `WasmRationalSurreal`
+  - Construction from integer ratio
+  - Arithmetic operations
+  - Comparison and sign utilities
+  - Conversion to/from `WasmDyadic` and `WasmShortSurreal`
+- [x] `WasmRationalSurcomplex`
+  - Construction from parts
+  - Arithmetic operations
+  - Checked division
+  - Component accessors
+- [x] `WasmExperimentalEpsilonRational` (behind `experimental-epsilon` feature)
+  - Epsilon polynomial construction
+  - Epsilon rational function construction
+  - Evaluation
+
+### Tests
+- [x] WASM binding tests for all new types
+- [x] Feature-gating tests for experimental epsilon bindings
+
+### Exit Criteria
+- [x] All new types accessible from TypeScript
+- [x] Feature gating works correctly in WASM context
+- [x] `amari-wasm` builds with new bindings
+
+---
+
+## M5 — Examples Suite Complete
+
+### Goals
+- Add surcomplex interactive page
+- Add WASM version-gating for new types
+- Update API reference
+
+### Examples suite deliverables
+- [x] Surcomplex interactive page with arithmetic, division, and identity demonstrations
+- [x] WASM version-gating for `WasmRationalSurreal`, `WasmRationalSurcomplex`, and `WasmExperimentalEpsilonRational`
+- [x] API reference entries for new types
+- [x] Navigation and home page entries for surcomplex page
+- [x] Tests for new page components
+
+### Exit Criteria
+- [x] Examples suite builds and deploys with new pages
+- [x] WASM version checks prevent crashes on pre-v0.23 WASM modules
+- [x] API reference is accurate for all new types
+
+---
+
+## M6 — Documentation Complete
+
+### Goals
+- Update all project documentation for v0.23.0
+
+### Crate documentation
+- [x] `amari-surreal/README.md` updated with `RationalSurreal` and epsilon module
+- [x] `amari-surcomplex/README.md` present and accurate
+- [x] Scope boundaries documented in both crate READMEs
+
+### Project documentation
+- [x] Root `README.md` updated with v0.23.0 highlights and installation examples
+- [x] `CHANGELOG.md` entry for `0.23.0`
+- [x] `docs/README.md` updated with v0.23 roadmap links
+- [x] `docs/roadmap/amari-surreal_design.md` updated
+- [x] `docs/roadmap/amari-surcomplex_design.md` updated
+- [x] `docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md` created
+- [x] `docs/roadmap/v0.23.0-rational-surreal-surcomplex-checklist.md` created
+
+### Documentation requirements
+- [x] `ShortSurreal` clearly documented as finite short/dyadic layer
+- [x] `RationalSurreal` clearly documented as exact rational scalar field
+- [x] Epsilon module clearly documented as experimental (not nilpotent dual numbers)
+- [x] Puiseux/Hahn/generalized series documented as future path, not implemented
+- [x] `amari-surcomplex` documented as separate crate over `RationalSurreal`
+- [x] `1/(1 + 1/2 i) = 4/5 - 2/5i` example present demonstrating rational-closure necessity
+- [x] Publish order documented
+- [x] `publish.yml` error-handling expectations documented (fail, don't swallow)
+
+### Optional fixes
+- [x] Epsilon.rs rustdoc redundant link target fixed
+
+### Exit Criteria
+- [x] All docs reflect actual implemented scope
+- [x] No overclaiming beyond what is actually shipped
+- [x] All scope boundaries are explicit
+
+---
+
+## M7 — `0.23.0` Release Readiness Gates
+
+### Code quality gates
+
+```bash
+cargo fmt --all --check
+git diff --check
+./scripts/version-sync.sh verify 0.23.0
+./scripts/verify-workflow-crates.sh
+```
+
+- [ ] `cargo fmt --all --check` passes
+- [ ] `git diff --check` passes
+- [ ] `./scripts/version-sync.sh verify 0.23.0` passes
+- [ ] `./scripts/verify-workflow-crates.sh` passes
+
+### Test gates
+
+```bash
+cargo test -p amari-surreal -p amari-surcomplex -p amari-wasm --quiet
+cargo test -p amari-surreal --features experimental-epsilon --quiet
+cargo check --examples -p amari-surreal -p amari-surcomplex --quiet
+cargo clippy -p amari-surreal -p amari-surcomplex -p amari-wasm --all-targets --all-features -- -D warnings
+```
+
+- [ ] Focused crate tests pass
+- [ ] Experimental epsilon tests pass
+- [ ] Examples build check passes
+- [ ] Clippy passes with `-D warnings`
+
+### Publish dry-run gates
+
+```bash
+cargo package -p amari-surcomplex --allow-dirty
+cargo publish -p amari-surcomplex --dry-run --allow-dirty
+cd amari-wasm && wasm-pack build --target web --out-dir /tmp/amari-wasm-v23-pkg --scope justinelliottcobb
+```
+
+- [ ] `cargo package` succeeds for `amari-surcomplex`
+- [ ] `cargo publish --dry-run` succeeds for `amari-surcomplex`
+- [ ] `wasm-pack build` produces publishable WASM package
+
+### Examples suite gates
+
+```bash
+cd ../examples-suite && npm run lint && npm run build && npm run test:run
+```
+
+- [ ] Examples suite lint passes
+- [ ] Examples suite build succeeds
+- [ ] Examples suite tests pass
+
+### Publish order verification
+
+The publish order must be:
+
+1. `amari-cgt`
+2. `amari-surreal`
+3. `amari-surcomplex`
+4. Downstream crates (`amari-enumerative`, `amari-flynn`, `amari-flynn-macros`, `amari-measure`, `amari-calculus`, `amari-functional`, `amari-topology`, `amari-probabilistic`, `amari-dynamics`, `amari-optimization`)
+5. Root `amari` umbrella crate
+
+And separately: `amari-wasm` → npm publish (not crates.io)
+
+- [ ] Publish order in `publish.yml` CRATES array is correct
+- [ ] `publish.yml` uses `set -e` or equivalent (no `|| echo "continuing..."` after publish commands)
+- [ ] npm publish step for `amari-wasm` is correct
+
+### npm publish notes (manual)
+
+```bash
+npm login --scope=@justinelliottcobb
+cd amari-wasm/pkg
+npm publish --access=public
+```
+
+- [ ] npm authentication confirmed for `@justinelliottcobb` scope
+- [ ] Package name verified as `@justinelliottcobb/amari-wasm`
+
+### Final decision gate
+
+- [ ] `RationalSurreal` qualifies as a stable exact rational scalar field
+- [ ] Epsilon module is correctly gated and experimentally scoped
+- [ ] `amari-surcomplex` qualifies as a correct exact rational complex crate
+- [ ] `0.23.0` can be announced without caveats that undermine the declared scope
+
+---
+
+## Notes / Progress Log
+
+### Current status notes
+- [x] Planning complete
+- [x] `RationalSurreal` implemented
+- [x] Experimental epsilon module implemented
+- [x] `amari-surcomplex` implemented
+- [x] WASM bindings implemented
+- [x] Examples suite updated
+- [x] Documentation updated
+
+### Freeform notes
+
+- Implementation landed for `RationalSurreal` exact rational scalar field backed by `BigRational`
+- Conversion bridges (`from_short`, `to_short_if_dyadic`) properly handle dyadic/non-dyadic boundary
+- Epsilon module is gated behind `experimental-epsilon` and clearly documented as formal positive infinitesimal (not nilpotent dual numbers)
+- `amari-surcomplex` uses `RationalSurreal` coefficients to support division closure (`4/5` not dyadic)
+- Release gates will run after docs are finalized

--- a/docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md
+++ b/docs/roadmap/v0.23.0-rational-surreal-surcomplex-roadmap.md
@@ -1,0 +1,187 @@
+# Amari v0.23.0 Roadmap: Rational Surreal & Surcomplex
+
+## Executive Summary
+
+This roadmap formalizes the `0.23.0` release cycle, which extends the `amari-surreal` crate with an exact rational scalar layer and introduces the new `amari-surcomplex` crate for exact rational complex arithmetic.
+
+This roadmap assumes the following broader release sequence:
+
+- **`0.20.0`** — `amari-gpu` refactor and stabilization
+- **`0.21.0`** — `amari-tropical` and `amari-dual` extension cycle
+- **`0.22.0`** — `amari-cgt` and `amari-surreal` (ShortSurreal dyadic layer)
+- **`0.23.0`** — `RationalSurreal`, epsilon rational functions, and `amari-surcomplex`
+
+The purpose of `0.23.0` is to:
+
+- Bridge the gap between the dyadic `ShortSurreal` layer and the full surreal universe with an exact rational scalar field (`RationalSurreal`)
+- Provide experimental epsilon rational functions as a first step toward formal infinitesimal arithmetic
+- Ship `amari-surcomplex` as a separate crate providing exact rational complex arithmetic over `RationalSurreal`
+
+---
+
+## Release Positioning
+
+### Strategic Role in Amari
+
+`0.23.0` strengthens Amari's exact-algebraic foundations in three ways:
+
+1. **`RationalSurreal`** — moves beyond dyadics to exact rationals, enabling algebraic closure for surcomplex division
+2. **`amari-surcomplex`** — introduces a new exact algebraic domain (complex numbers) building on the surreal scalar foundation
+3. **Epsilon module** — opens a carefully scoped path toward infinitesimal calculus within the exact algebraic framework
+
+### Scope Boundaries
+
+#### In scope for `0.23.0`
+
+- `RationalSurreal` — exact rational scalar field with `BigRational` backing
+- Conversion between `RationalSurreal`, `Dyadic`, and `ShortSurreal`
+- Sign, ordering, absolute-value, and checked division utilities for `RationalSurreal`
+- `experimental-epsilon` — epsilon polynomials and rational functions in a formal positive infinitesimal `ε` (not nilpotent dual numbers)
+- `amari-surcomplex` — exact rational complex arithmetic with checked division
+- WASM bindings for all new types (`WasmRationalSurreal`, `WasmRationalSurcomplex`, `WasmExperimentalEpsilonRational`)
+- Examples suite updates with surcomplex interactive page and WASM version-gating
+
+#### Out of scope for `0.23.0`
+
+- Full symbolic surreal universe (infinite values, transfinite recursion)
+- Puiseux series, Hahn series, or generalized ordered-series fields (future extension path only)
+- Polynomial GCD normalization in the epsilon module
+- Complex analytic functions (exp, log, trigonometric) over surcomplex values
+- Generic coefficient abstraction for `Surcomplex<T>`
+
+---
+
+## Key Design Decisions
+
+### Why `RationalSurreal` rather than extending `ShortSurreal`?
+
+The dyadic `ShortSurreal` layer (values of the form `m / 2^n`) cannot represent all rational coefficients produced by surcomplex division. For example:
+
+```
+1 / (1 + 1/2 i) = 4/5 - 2/5i
+```
+
+The coefficient `4/5` is not dyadic, so a broader rational scalar type was necessary. `RationalSurreal` (backed by `BigRational`) was introduced as a separate type to keep the `ShortSurreal` dyadic API clean and backwards-compatible.
+
+### Why `amari-surcomplex` as a separate crate?
+
+Keeping surcomplex separate from `amari-surreal`:
+
+- Preserves a clean scalar-layer story in `amari-surreal`
+- Makes later coefficient generalization easier
+- Prevents complex-specific APIs from cluttering the surreal core
+- Follows the established pattern from the design documents
+
+### Why `RationalSurreal` rather than `ShortSurreal` coefficients in `amari-surcomplex`?
+
+If `amari-surcomplex` used `ShortSurreal` coefficients, division would fail on values like `1 + 1/2 i` because the result would require non-dyadic coefficients. Using `RationalSurreal` coefficients ensures surcomplex arithmetic is closed under division (except division by zero).
+
+### Epsilon module design principles
+
+- `ε` is a formal positive infinitesimal ordered by asymptotic behaviour as `ε → 0⁺`
+- This is **not** a nilpotent-dual-number system (`ε² ≠ 0`)
+- The exponent type (`EpsilonExponent`) is a newtype wrapper to permit future Puiseux / Hahn extensions without API breakage
+- No polynomial GCD normalization — zero removal and denominator-sign normalization suffice for the current feature set
+
+---
+
+## Dependency Direction
+
+The intended architecture is:
+
+```text
+amari-cgt         → foundational short-game engine
+amari-surreal     → validated surreal scalar layer (dyadic + exact rational + experimental epsilon)
+amari-surcomplex  → exact rational complex arithmetic over RationalSurreal
+```
+
+`amari-surcomplex` depends on `amari-surreal` (for `RationalSurreal`), which depends on `amari-cgt`. The umbrella features follow:
+
+```toml
+[features]
+cgt = ["dep:amari-cgt"]
+surreal = ["dep:amari-surreal", "cgt"]
+surcomplex = ["dep:amari-surcomplex", "surreal"]
+```
+
+---
+
+## Publish Order
+
+The publish order for `0.23.0` must be:
+
+1. `amari-cgt`
+2. `amari-surreal`
+3. `amari-surcomplex`
+4. Downstream crates (`amari-enumerative`, `amari-flynn`, etc.)
+5. Root `amari` umbrella crate
+
+`publish.yml` must fail on `cargo publish` errors — swallowed-error patterns (e.g., `|| echo "continuing..."`) are prohibited.
+
+---
+
+## Release Components
+
+### `amari-surreal` — `RationalSurreal`
+
+- Exact rational arithmetic backed by `BigRational`
+- Construction from integer ratios (`from_ratio`)
+- Exact comparison, addition, subtraction, multiplication, checked division
+- Sign/ordering utilities
+- Conversion to/from `Dyadic` and `ShortSurreal`
+
+### `amari-surreal` — experimental epsilon
+
+- Feature-gated behind `experimental-epsilon`
+- `EpsilonExponent`, `EpsilonPolynomial`, and `EpsilonRational`
+- Formal positive infinitesimal `ε` with asymptotic ordering
+- Not nilpotent dual numbers; Puiseux/Hahn/generalized series deferred
+
+### `amari-surcomplex`
+
+- `RationalSurcomplex` type
+- Exact arithmetic with `RationalSurreal` coefficients
+- `1 / (1 + 1/2 i) = 4/5 - 2/5i` demonstrating rational-closure necessity
+- Checked division, conjugation, norm-square
+- Separate crate from `amari-surreal`
+
+### WASM bindings (`amari-wasm`)
+
+- `WasmRationalSurreal`
+- `WasmRationalSurcomplex`
+- `WasmExperimentalEpsilonRational` (behind `experimental-epsilon` feature)
+
+### Examples suite
+
+- Surcomplex interactive page
+- WASM version-gating for new types
+- API reference coverage
+
+---
+
+## Success Criteria for `0.23.0`
+
+The `0.23.0` release is successful if:
+
+### `amari-surreal`
+- `RationalSurreal` provides exact rational arithmetic that correctly bridges the dyadic/general gap
+- `ShortSurreal` remains the finite short/dyadic layer — no scope confusion
+- Epsilon module is correctly marked experimental and clearly distinguished from dual numbers
+- Scope boundaries (no Puiseux/Hahn/generalized series) are documented
+
+### `amari-surcomplex`
+- Exact rational complex arithmetic is correct and well-tested
+- Division produces exact rational coefficients (including non-dyadic results)
+- The crate is separate from `amari-surreal` and appropriately scoped
+
+### At the project level
+- All new types have WASM bindings
+- Examples suite covers the new surface
+- Docs are honest about what is and is not implemented
+- Release checklist is complete and publish order is audited
+
+---
+
+## Summary
+
+`0.23.0` extends Amari's exact algebraic foundations with a rational surreal scalar layer, experimental epsilon rational functions, and a new exact surcomplex crate. These additions follow the architectural decisions in the design documents and keep all scope boundaries explicit and honest.

--- a/examples-suite/package-lock.json
+++ b/examples-suite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amari-examples-suite",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@justinelliottcobb/amari-wasm": "latest",
         "@mantine/code-highlight": "^8.3.16",

--- a/examples-suite/package.json
+++ b/examples-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Interactive API examples for the Amari Mathematical Computing Library",
   "private": true,
   "type": "module",

--- a/examples-suite/src/components/Navigation.test.tsx
+++ b/examples-suite/src/components/Navigation.test.tsx
@@ -24,6 +24,7 @@ describe('Navigation', () => {
     expect(screen.getByText('Geometric Algebra')).toBeInTheDocument();
     expect(screen.getByText('Tropical Algebra')).toBeInTheDocument();
     expect(screen.getByText('Dual Numbers')).toBeInTheDocument();
+    expect(screen.getByText('Rational Surcomplex')).toBeInTheDocument();
     expect(screen.getByText('Information Geometry')).toBeInTheDocument();
     expect(screen.getByText('Enumerative Geometry')).toBeInTheDocument();
     expect(screen.getByText('Calculus')).toBeInTheDocument();
@@ -87,5 +88,8 @@ describe('Navigation', () => {
 
     const tropicalLink = screen.getByText('Tropical Algebra').closest('a');
     expect(tropicalLink).toHaveAttribute('href', '/tropical-algebra');
+
+    const surcomplexLink = screen.getByText('Rational Surcomplex').closest('a');
+    expect(surcomplexLink).toHaveAttribute('href', '/surcomplex');
   });
 });

--- a/examples-suite/src/components/Navigation.tsx
+++ b/examples-suite/src/components/Navigation.tsx
@@ -37,6 +37,11 @@ const navigationSections: NavSection[] = [
         description: "Short games, nimbers, and exact dyadics"
       },
       {
+        title: "Rational Surcomplex",
+        href: "/surcomplex",
+        description: "Exact rational surreals and surcomplex division"
+      },
+      {
         title: "Information Geometry",
         href: "/information-geometry",
         description: "Statistical manifolds and Fisher metrics"

--- a/examples-suite/src/main.tsx
+++ b/examples-suite/src/main.tsx
@@ -11,6 +11,7 @@ import App from './App'
 import { GeometricAlgebra } from './pages/GeometricAlgebra'
 import { TropicalAlgebra } from './pages/TropicalAlgebra'
 import { CgtSurreal } from './pages/CgtSurreal'
+import { Surcomplex } from './pages/Surcomplex'
 import { DualNumbers } from './pages/DualNumbers'
 import { InformationGeometry } from './pages/InformationGeometry'
 import { WebGPU } from './pages/WebGPU'
@@ -81,6 +82,10 @@ const router = createBrowserRouter([
       {
         path: "cgt-surreal",
         element: <CgtSurreal />,
+      },
+      {
+        path: "surcomplex",
+        element: <Surcomplex />,
       },
       {
         path: "dual-numbers",

--- a/examples-suite/src/pages/APIReference.test.tsx
+++ b/examples-suite/src/pages/APIReference.test.tsx
@@ -25,6 +25,21 @@ describe('APIReference page', () => {
     expect(screen.getByText('foldOtimes')).toBeInTheDocument();
   });
 
+  it('lists the 0.23.0 rational surreal and surcomplex WASM APIs', () => {
+    render(<APIReference />);
+
+    fireEvent.click(screen.getByText('Rational Surreal & Surcomplex'));
+
+    expect(screen.getByText('WasmRationalSurreal')).toBeInTheDocument();
+    expect(screen.getByText('WasmRationalSurcomplex')).toBeInTheDocument();
+    expect(screen.getByText('WasmExperimentalEpsilonRational')).toBeInTheDocument();
+    expect(screen.getByText('fromRatio')).toBeInTheDocument();
+    expect(screen.getByText('fromParts')).toBeInTheDocument();
+    expect(screen.getByText('fromScalar')).toBeInTheDocument();
+    expect(screen.getByText('checkedReciprocal')).toBeInTheDocument();
+    expect(screen.getAllByText('checkedDiv').length).toBe(2);
+  });
+
   it('lists the 0.21.0 dual WASM branch policy and static multi-dual APIs', () => {
     render(<APIReference />);
 

--- a/examples-suite/src/pages/APIReference.tsx
+++ b/examples-suite/src/pages/APIReference.tsx
@@ -746,6 +746,157 @@ console.log(composed); // 10`
     ]
   },
   {
+    id: "surcomplex",
+    title: "Rational Surreal & Surcomplex",
+    description: "Exact rational surreal arithmetic, rational surcomplex division, and experimental epsilon infinitesimal ordering for v0.23.0",
+    icon: "ℂ",
+    classes: [
+      {
+        name: "WasmRationalSurreal",
+        description: "Exact rational surreal number backed by arbitrary-precision rational arithmetic. Supports fromRatio, add, and checkedDiv.",
+        methods: [
+          {
+            name: "fromRatio",
+            signature: "static fromRatio(numerator: number, denominator: number): WasmRationalSurreal",
+            description: "Create a rational surreal from a numerator and denominator.",
+            isStatic: true,
+            parameters: [
+              { name: "numerator", type: "number", description: "Rational numerator" },
+              { name: "denominator", type: "number", description: "Non-zero rational denominator" }
+            ],
+            returns: "WasmRationalSurreal representing the exact rational",
+            example: `const third = WasmRationalSurreal.fromRatio(1, 3);
+console.log(third.format()); // 1/3`
+          },
+          {
+            name: "add",
+            signature: "add(other: WasmRationalSurreal): WasmRationalSurreal",
+            description: "Exact rational surreal addition.",
+            parameters: [{ name: "other", type: "WasmRationalSurreal", description: "Addend" }],
+            returns: "Sum as a WasmRationalSurreal",
+            example: `const a = WasmRationalSurreal.fromRatio(1, 3);
+const b = WasmRationalSurreal.fromRatio(1, 6);
+console.log(a.add(b).format()); // 1/2`
+          },
+          {
+            name: "checkedDiv",
+            signature: "checkedDiv(other: WasmRationalSurreal): WasmRationalSurreal",
+            description: "Checked exact division that returns an error if the result falls outside the rational surreal layer.",
+            parameters: [{ name: "other", type: "WasmRationalSurreal", description: "Non-zero divisor" }],
+            returns: "Quotient as a WasmRationalSurreal"
+          },
+          {
+            name: "format",
+            signature: "format(): string",
+            description: "Format the rational surreal as a human-readable rational string.",
+            returns: "Formatted rational (e.g. '1/3' or '17/42')"
+          }
+        ]
+      },
+      {
+        name: "WasmRationalSurcomplex",
+        description: "Exact rational surcomplex number a + bi with a, b ∈ rational surreals. Supports pair construction and checked division.",
+        methods: [
+          {
+            name: "fromParts",
+            signature: "static fromParts(real: WasmRationalSurreal, imag: WasmRationalSurreal): WasmRationalSurcomplex",
+            description: "Create a rational surcomplex number from its real and imaginary parts.",
+            isStatic: true,
+            parameters: [
+              { name: "real", type: "WasmRationalSurreal", description: "Real part" },
+              { name: "imag", type: "WasmRationalSurreal", description: "Imaginary part" }
+            ],
+            returns: "WasmRationalSurcomplex representing real + imag·i",
+            example: `const one = WasmRationalSurreal.fromRatio(1, 1);
+const half = WasmRationalSurreal.fromRatio(1, 2);
+const z = WasmRationalSurcomplex.fromParts(one, half);
+console.log(z.format()); // 1 + 1/2i`
+          },
+          {
+            name: "add",
+            signature: "add(other: WasmRationalSurcomplex): WasmRationalSurcomplex",
+            description: "Component-wise exact rational surcomplex addition.",
+            parameters: [{ name: "other", type: "WasmRationalSurcomplex", description: "Addend" }],
+            returns: "Sum as a WasmRationalSurcomplex"
+          },
+          {
+            name: "checkedDiv",
+            signature: "checkedDiv(other: WasmRationalSurcomplex): WasmRationalSurcomplex",
+            description: "Checked exact complex division using the conjugate, returning 4/5 - 2/5i from 1 / (1 + 1/2i).",
+            parameters: [{ name: "other", type: "WasmRationalSurcomplex", description: "Non-zero divisor" }],
+            returns: "Exact quotient",
+            example: `const zero = WasmRationalSurreal.fromRatio(0, 1);
+const one = WasmRationalSurreal.fromRatio(1, 1);
+const half = WasmRationalSurreal.fromRatio(1, 2);
+const num = WasmRationalSurcomplex.fromParts(one, zero);
+const den = WasmRationalSurcomplex.fromParts(one, half);
+console.log(num.checkedDiv(den).format()); // 4/5 - 2/5i`
+          },
+          {
+            name: "format",
+            signature: "format(): string",
+            description: "Format the rational surcomplex as a + bi string.",
+            returns: "Formatted complex (e.g. '4/5 - 2/5i')"
+          }
+        ]
+      },
+      {
+        name: "WasmExperimentalEpsilonRational",
+        description: "Experimental infinitesimal rational surreal ε satisfying 0 < ε < 1/n for every finite positive n. ε² < ε and 1/ε is infinite-scale.",
+        methods: [
+          {
+            name: "epsilon",
+            signature: "static epsilon(): WasmExperimentalEpsilonRational",
+            description: "Return the fundamental infinitesimal ε.",
+            isStatic: true,
+            returns: "The infinitesimal ε value"
+          },
+          {
+            name: "fromScalar",
+            signature: "static fromScalar(value: WasmRationalSurreal): WasmExperimentalEpsilonRational",
+            description: "Embed a rational surreal scalar into the epsilon layer.",
+            isStatic: true,
+            parameters: [{ name: "value", type: "WasmRationalSurreal", description: "Rational surreal to embed" }],
+            returns: "WasmExperimentalEpsilonRational wrapping the rational"
+          },
+          {
+            name: "add",
+            signature: "add(other: WasmExperimentalEpsilonRational): WasmExperimentalEpsilonRational",
+            description: "Add two epsilon-layer values.",
+            parameters: [{ name: "other", type: "WasmExperimentalEpsilonRational", description: "Addend" }],
+            returns: "Sum"
+          },
+          {
+            name: "mul",
+            signature: "mul(other: WasmExperimentalEpsilonRational): WasmExperimentalEpsilonRational",
+            description: "Multiply two epsilon-layer values.",
+            parameters: [{ name: "other", type: "WasmExperimentalEpsilonRational", description: "Multiplier" }],
+            returns: "Product"
+          },
+          {
+            name: "compare",
+            signature: "compare(other: WasmExperimentalEpsilonRational): string",
+            description: "Compare two epsilon-layer values, returning 'less', 'equal', or 'greater'.",
+            parameters: [{ name: "other", type: "WasmExperimentalEpsilonRational", description: "Value to compare against" }],
+            returns: "Comparison result"
+          },
+          {
+            name: "checkedReciprocal",
+            signature: "checkedReciprocal(): WasmExperimentalEpsilonRational",
+            description: "Compute the checked multiplicative inverse. 1/ε is infinite-scale.",
+            returns: "Multiplicative inverse"
+          },
+          {
+            name: "format",
+            signature: "format(): string",
+            description: "Format the epsilon-layer value.",
+            returns: "Human-readable string"
+          }
+        ]
+      }
+    ]
+  },
+  {
     id: "dual",
     title: "Dual Numbers & Autodiff",
     description: "Automatic differentiation using dual numbers for exact gradients",

--- a/examples-suite/src/pages/Home.test.tsx
+++ b/examples-suite/src/pages/Home.test.tsx
@@ -25,6 +25,9 @@ describe('Home Page', () => {
 
     const tropicalElements = screen.getAllByText(/Tropical/i);
     expect(tropicalElements.length).toBeGreaterThan(0);
+
+    const surcomplexElements = screen.getAllByText(/Rational Surcomplex/i);
+    expect(surcomplexElements.length).toBeGreaterThan(0);
   });
 
   it('renders quick start section', () => {

--- a/examples-suite/src/pages/Home.tsx
+++ b/examples-suite/src/pages/Home.tsx
@@ -23,7 +23,8 @@ export function Home() {
                 <List.Item>Geometric Algebra (Clifford Algebra)</List.Item>
                 <List.Item>Tropical Algebra (Max-Plus Semiring)</List.Item>
                 <List.Item>Dual Number Automatic Differentiation</List.Item>
-                <List.Item>CGT & Short Surreals</List.Item>
+                <List.Item>CGT &amp; Short Surreals</List.Item>
+                <List.Item>Rational Surcomplex (v0.23)</List.Item>
                 <List.Item>Information Geometry</List.Item>
               </List>
               <Button component={Link} to="/geometric-algebra">

--- a/examples-suite/src/pages/Surcomplex.test.tsx
+++ b/examples-suite/src/pages/Surcomplex.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../test/test-utils';
+import { Surcomplex } from './Surcomplex';
+
+describe('Surcomplex page', () => {
+  it('documents rational surreal, epsilon, and surcomplex examples', async () => {
+    render(<Surcomplex />);
+
+    expect(screen.getByRole('heading', { name: /Rational Surreal & Surcomplex/i })).toBeInTheDocument();
+    expect(await screen.findByText(/Rational Surreals/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Surcomplex Division/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Experimental Epsilon/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/4\/5 - 2\/5i/i).length).toBeGreaterThan(0);
+  });
+});

--- a/examples-suite/src/pages/Surcomplex.tsx
+++ b/examples-suite/src/pages/Surcomplex.tsx
@@ -1,0 +1,237 @@
+import { Title, Text, Card, Container, Stack, List } from "@mantine/core";
+import { ExampleCard } from "../components/ExampleCard";
+import { useAmariWasm } from "../hooks/useAmariWasm";
+
+type WasmRationalSurrealInstance = {
+  add(other: WasmRationalSurrealInstance): WasmRationalSurrealInstance;
+  checkedDiv(other: WasmRationalSurrealInstance): WasmRationalSurrealInstance;
+  format(): string;
+};
+
+type WasmRationalSurrealStatic = {
+  fromRatio(numerator: number, denominator: number): WasmRationalSurrealInstance;
+};
+
+type WasmRationalSurcomplexInstance = {
+  add(other: WasmRationalSurcomplexInstance): WasmRationalSurcomplexInstance;
+  checkedDiv(other: WasmRationalSurcomplexInstance): WasmRationalSurcomplexInstance;
+  format(): string;
+};
+
+type WasmRationalSurcomplexStatic = {
+  fromParts(
+    real: WasmRationalSurrealInstance,
+    imag: WasmRationalSurrealInstance
+  ): WasmRationalSurcomplexInstance;
+};
+
+type WasmExperimentalEpsilonRationalInstance = {
+  add(other: WasmExperimentalEpsilonRationalInstance): WasmExperimentalEpsilonRationalInstance;
+  mul(other: WasmExperimentalEpsilonRationalInstance): WasmExperimentalEpsilonRationalInstance;
+  compare(other: WasmExperimentalEpsilonRationalInstance): string;
+  format(): string;
+  checkedReciprocal(): WasmExperimentalEpsilonRationalInstance;
+};
+
+type WasmExperimentalEpsilonRationalStatic = {
+  epsilon(): WasmExperimentalEpsilonRationalInstance;
+  fromScalar(
+    value: WasmRationalSurrealInstance
+  ): WasmExperimentalEpsilonRationalInstance;
+};
+
+type AmariWasmModule = Record<string, unknown> & {
+  WasmRationalSurreal?: WasmRationalSurrealStatic;
+  WasmRationalSurcomplex?: WasmRationalSurcomplexStatic;
+  WasmExperimentalEpsilonRational?: WasmExperimentalEpsilonRationalStatic;
+};
+
+function missingWasmExports(wasm: AmariWasmModule, names: string[]) {
+  return names.filter((name) => wasm[name] === undefined || wasm[name] === null);
+}
+
+export function Surcomplex() {
+  const { ready, error, amari } = useAmariWasm();
+
+  const wasmExample = (operation: (wasm: AmariWasmModule) => string) => {
+    return async () => {
+      if (error) {
+        throw new Error(`WASM initialization error: ${error}`);
+      }
+
+      if (!ready || !amari) {
+        return "WASM module is still loading. Try again in a moment.";
+      }
+
+      try {
+        return operation(amari as unknown as AmariWasmModule);
+      } catch (err) {
+        throw new Error(`WASM example error: ${err}`);
+      }
+    };
+  };
+
+  const examples = [
+    {
+      title: "Exact Rational Surreal Arithmetic",
+      description:
+        "Use WasmRationalSurreal to compute 1/3 + 1/6 = 1/2 with exact rational arithmetic.",
+      category: "WASM 0.23.0",
+      code: `import init, { WasmRationalSurreal } from '@justinelliottcobb/amari-wasm';
+
+await init();
+
+const a = WasmRationalSurreal.fromRatio(1, 3);
+const b = WasmRationalSurreal.fromRatio(1, 6);
+const sum = a.add(b);
+
+console.log(sum.format()); // 1/2`,
+      onRun: wasmExample((wasm) => {
+        const missing = missingWasmExports(wasm, ["WasmRationalSurreal"]);
+        const RationalSurreal = wasm.WasmRationalSurreal;
+        if (missing.length > 0 || !RationalSurreal?.fromRatio) {
+          return "This example requires amari-wasm v0.23.0 WasmRationalSurreal bindings.";
+        }
+
+        const a = RationalSurreal.fromRatio(1, 3);
+        const b = RationalSurreal.fromRatio(1, 6);
+        const sum = a.add(b);
+
+        return [
+          `1/3 format = ${a.format()}`,
+          `1/6 format = ${b.format()}`,
+          `1/3 + 1/6 = ${sum.format()}`
+        ].join('\n');
+      })
+    },
+    {
+      title: "Exact Surcomplex Division",
+      description:
+        "Use WasmRationalSurcomplex for exact division: 1 / (1 + 1/2 i) = 4/5 - 2/5i.",
+      category: "WASM 0.23.0",
+      code: `import init, { WasmRationalSurreal, WasmRationalSurcomplex } from '@justinelliottcobb/amari-wasm';
+
+await init();
+
+const zero = WasmRationalSurreal.fromRatio(0, 1);
+const one = WasmRationalSurreal.fromRatio(1, 1);
+const half = WasmRationalSurreal.fromRatio(1, 2);
+
+const numerator = WasmRationalSurcomplex.fromParts(one, zero);
+const denominator = WasmRationalSurcomplex.fromParts(one, half);
+const result = numerator.checkedDiv(denominator);
+
+console.log(result.format()); // 4/5 - 2/5i`,
+      onRun: wasmExample((wasm) => {
+        const missing = missingWasmExports(wasm, ["WasmRationalSurreal", "WasmRationalSurcomplex"]);
+        const RationalSurreal = wasm.WasmRationalSurreal;
+        const RationalSurcomplex = wasm.WasmRationalSurcomplex;
+        if (missing.length > 0 || !RationalSurreal?.fromRatio || !RationalSurcomplex?.fromParts) {
+          return "This example requires amari-wasm v0.23.0 surcomplex bindings.";
+        }
+
+        const zero = RationalSurreal.fromRatio(0, 1);
+        const one = RationalSurreal.fromRatio(1, 1);
+        const half = RationalSurreal.fromRatio(1, 2);
+
+        const numerator = RationalSurcomplex.fromParts(one, zero);
+        const denominator = RationalSurcomplex.fromParts(one, half);
+        const result = numerator.checkedDiv(denominator);
+
+        return [
+          `numerator = ${numerator.format()}`,
+          `denominator = ${denominator.format()}`,
+          `1 / (1 + 1/2i) = ${result.format()}`
+        ].join('\n');
+      })
+    },
+    {
+      title: "Experimental Epsilon Infinitesimal Ordering",
+      description:
+        "Use WasmExperimentalEpsilonRational to verify 0 < ε, ε² < ε, and 1/ε is infinite-scale.",
+      category: "WASM 0.23.0",
+      code: `import init, { WasmRationalSurreal, WasmExperimentalEpsilonRational } from '@justinelliottcobb/amari-wasm';
+
+await init();
+
+const zero = WasmExperimentalEpsilonRational.fromScalar(
+  WasmRationalSurreal.fromRatio(0, 1)
+);
+const epsilon = WasmExperimentalEpsilonRational.epsilon();
+const epsilonSquared = epsilon.mul(epsilon);
+const oneOverEpsilon = epsilon.checkedReciprocal();
+
+console.log(epsilon.compare(zero));           // greater
+console.log(epsilon.compare(epsilonSquared)); // greater
+console.log(epsilon.format());
+console.log(oneOverEpsilon.format());`,
+      onRun: wasmExample((wasm) => {
+        const missing = missingWasmExports(wasm, [
+          "WasmRationalSurreal",
+          "WasmExperimentalEpsilonRational"
+        ]);
+        const RationalSurreal = wasm.WasmRationalSurreal;
+        const EpsilonRational = wasm.WasmExperimentalEpsilonRational;
+        if (missing.length > 0 || !RationalSurreal?.fromRatio || !EpsilonRational?.epsilon || !EpsilonRational?.fromScalar) {
+          return "This example requires amari-wasm v0.23.0 experimental epsilon bindings.";
+        }
+
+        const zero = EpsilonRational.fromScalar(RationalSurreal.fromRatio(0, 1));
+        const epsilon = EpsilonRational.epsilon();
+        const epsilonSquared = epsilon.mul(epsilon);
+        const oneOverEpsilon = epsilon.checkedReciprocal();
+
+        return [
+          `ε = ${epsilon.format()}`,
+          `ε² = ${epsilonSquared.format()}`,
+          `ε compared with 0 = ${epsilon.compare(zero)}`,
+          `ε compared with ε² = ${epsilon.compare(epsilonSquared)}`,
+          `1/ε = ${oneOverEpsilon.format()}`
+        ].join('\n');
+      })
+    }
+  ];
+
+  return (
+    <Container size="lg" py="xl">
+      <Stack gap="lg">
+        <div>
+          <Title order={1}>Rational Surreal &amp; Surcomplex</Title>
+          <Text size="lg" c="dimmed">
+            Version 0.23.0 exposes exact rational surreal arithmetic, rational surcomplex division, and experimental epsilon infinitesimal ordering through amari-wasm.
+          </Text>
+        </div>
+
+        <Card withBorder>
+          <Card.Section withBorder inheritPadding py="sm">
+            <Title order={3}>Release Scope</Title>
+          </Card.Section>
+          <Card.Section inheritPadding py="md">
+            <Text mb="sm">
+              The 0.23.0 browser surface adds three new WASM classes that work with exact rational arithmetic
+              at arbitrary precision, extending beyond the short dyadic layer:
+            </Text>
+            <List size="sm" spacing="xs">
+              <List.Item>
+                <strong>Rational Surreals</strong>: exact rational surreal numbers via WasmRationalSurreal, supporting
+                addition, checked division, and canonical formatting.
+              </List.Item>
+              <List.Item>
+                <strong>Surcomplex Division</strong>: exact rational surcomplex numbers via WasmRationalSurcomplex,
+                with pair-based construction and checked division yielding results like 4/5 - 2/5i.
+              </List.Item>
+              <List.Item>
+                <strong>Experimental Epsilon</strong>: infinitesimal ordering via
+                WasmExperimentalEpsilonRational, confirming 0 &lt; ε, ε² &lt; ε, and that 1/ε is on an infinite scale.
+              </List.Item>
+            </List>
+          </Card.Section>
+        </Card>
+
+        {examples.map((example) => (
+          <ExampleCard key={example.title} {...example} />
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-typescript-example",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Example TypeScript project using the Amari mathematical computing library",
   "main": "dist/example.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.22.0"
+    "@justinelliottcobb/amari-wasm": "^0.23.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/web/interactive-demos/package.json
+++ b/examples/web/interactive-demos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-interactive-demos",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Interactive web demonstrations of Amari mathematical computing library",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "wasm-pack": "wasm-pack build --target web --out-dir pkg ../../../amari-wasm"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.22.0",
+    "@justinelliottcobb/amari-wasm": "^0.23.0",
     "three": "^0.158.0",
     "dat.gui": "^0.7.9",
     "katex": "^0.16.8",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "High-performance Geometric Algebra/Clifford Algebra library with TypeScript bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prepare the Amari v0.23.0 rational surreal / surcomplex release surface:

- Add stable `RationalSurreal` exact rational scalar arithmetic to `amari-surreal`
- Add experimental epsilon rational functions behind `experimental-epsilon`
- Add new `amari-surcomplex` crate with exact `RationalSurcomplex = a + bi` arithmetic over `RationalSurreal`
- Bump workspace/package versions to `0.23.0`
- Add `amari-surcomplex` to workspace features and publish workflow order
- Expose v0.23 WASM bindings:
  - `WasmRationalSurreal`
  - `WasmRationalSurcomplex`
  - `WasmExperimentalEpsilonRational`
- Add examples-suite `/surcomplex` page and API reference entries
- Add v0.23 roadmap/checklist docs and release-publish gates

## Mathematical scope

- `ShortSurreal` remains the finite short-game / dyadic layer.
- `RationalSurreal` is an exact rational scalar field, not the full surreal universe.
- Experimental epsilon models rational functions over a formal positive infinitesimal `ε`; it is not nilpotent dual-number semantics.
- Puiseux/Hahn/generalized series remain future extension paths.
- `amari-surcomplex` is separate from `amari-surreal` and uses `RationalSurreal` so division can produce non-dyadic coefficients such as:
  - `1 / (1 + 1/2 i) = 4/5 - 2/5i`

## Validation

Passed locally:

```bash
cargo fmt --all --check
git diff --check
./scripts/version-sync.sh verify 0.23.0
./scripts/verify-workflow-crates.sh
cargo test -p amari-surreal -p amari-surcomplex -p amari-wasm --quiet
cargo test -p amari-surreal --features experimental-epsilon --quiet
cargo check --examples -p amari-surreal -p amari-surcomplex --quiet
cargo clippy -p amari-surreal -p amari-surcomplex -p amari-wasm --all-targets --all-features -- -D warnings
cargo bench -p amari-surreal -p amari-surcomplex --no-run --quiet
cargo check -p amari-wasm --target wasm32-unknown-unknown --quiet
cd amari-wasm && wasm-pack build --target web --out-dir /tmp/amari-wasm-v23-pkg --scope justinelliottcobb
rg "WasmRationalSurreal|WasmRationalSurcomplex|WasmExperimentalEpsilonRational" /tmp/amari-wasm-v23-pkg/amari_wasm.d.ts
cd ../examples-suite && npm run lint && npm run build && npm run test:run
```

Additional release-package preflight:

```bash
cargo package -p amari-cgt --allow-dirty
```

`cargo package -p amari-surreal --allow-dirty` and `cargo package -p amari-surcomplex --allow-dirty` currently fail before release because `amari-cgt@0.23.0` / `amari-surreal@0.23.0` are not yet on crates.io. This is expected and documented in the v0.23 checklist; package/publish dry-runs must be retried in dependency order during release.

Known environment notes:

- Headless GPU-related warnings may appear in broader pre-commit hooks (`XDG_RUNTIME_DIR`, EGL `/dev/dri` permission warnings); guarded tests still pass.
- `examples-suite` lint has pre-existing warnings, but no errors.
