### PR TITLE
feat: add additive holographic superposition

### DIFF
--- a/amari-discovery/catalog/semantic/core.toml
+++ b/amari-discovery/catalog/semantic/core.toml
@@ -115,12 +115,12 @@ cost = "moderate"
 [[capabilities]]
 id = "amari:amari-holographic:algebra:superposition"
 name = "Additive holographic superposition"
-description = "Planned for Amari 0.24; no public API is available in this catalog version. The capability will accumulate holographic candidates additively without attention-style normalization."
+description = "Accumulate holographic candidates additively without attention-style normalization, with scalar weighting for memory traces."
 aliases = ["VSA superposition", "additive bundling"]
 concepts = ["vector symbolic architecture", "superposition"]
 crate_refs = ["amari-holographic"]
 feature_refs = ["amari-holographic:std"]
-symbol_refs = []
+symbol_refs = ["amari_holographic::BindingAlgebra::scale", "amari_holographic::BindingAlgebra::superpose"]
 example_refs = []
 probe_refs = ["amari-probe:holographic:superposition:v1"]
 stability = "experimental"

--- a/amari-discovery/tests/catalog_integrity.rs
+++ b/amari-discovery/tests/catalog_integrity.rs
@@ -24,7 +24,7 @@ fn embedded_catalog_has_unique_valid_capabilities() {
 }
 
 #[test]
-fn semantic_capabilities_distinguish_planned_surfaces_from_current_examples() {
+fn semantic_capabilities_distinguish_planned_and_implemented_surfaces() {
     let catalog = Catalog::embedded().unwrap();
     assert!(catalog.capabilities().iter().all(|capability| {
         !capability.symbol_refs.is_empty()
@@ -41,12 +41,18 @@ fn semantic_capabilities_distinguish_planned_surfaces_from_current_examples() {
         .find(|capability| {
             capability.id.to_string() == "amari:amari-holographic:algebra:superposition"
         })
-        .expect("planned superposition capability must remain discoverable");
-    assert!(superposition
+        .expect("implemented superposition capability must be discoverable");
+    assert!(!superposition
         .description
         .to_ascii_lowercase()
         .contains("planned"));
-    assert!(superposition.symbol_refs.is_empty());
+    assert_eq!(
+        superposition.symbol_refs,
+        [
+            "amari_holographic::BindingAlgebra::scale",
+            "amari_holographic::BindingAlgebra::superpose",
+        ]
+    );
 
     let rational = catalog
         .capabilities()

--- a/amari-holographic/README.md
+++ b/amari-holographic/README.md
@@ -420,10 +420,22 @@ pub trait BindingAlgebra: Clone + Send + Sync {
     fn random_versor(num_factors: usize) -> Self;
 
     // Provided methods
+    fn superpose(&self, other: &Self) -> AlgebraResult<Self>;
+    fn scale(&self, factor: f64) -> AlgebraResult<Self>;
     fn bundle_all(items: &[Self], beta: f64) -> AlgebraResult<Self>;
     fn estimate_snr(&self, num_items: usize) -> f64;
     fn theoretical_capacity(&self) -> usize;
 }
+```
+
+Use `superpose` for additive accumulation such as a holographic memory trace
+`T = Σ keyᵢ ⊛ valueᵢ`; its magnitude grows as evidence is added. Use `bundle`
+for attention or cleanup, where softmax weighting keeps the result bounded.
+Weighted accumulation composes `scale` and `superpose`:
+
+```rust
+let weighted = BindingAlgebra::scale(&binding, weight)?;
+trace = BindingAlgebra::superpose(&trace, &weighted)?;
 ```
 
 ### AlgebraConfig

--- a/amari-holographic/src/algebra/fhrr.rs
+++ b/amari-holographic/src/algebra/fhrr.rs
@@ -405,6 +405,18 @@ impl<const D: usize> BindingAlgebra for FHRRAlgebra<D> {
         }
     }
 
+    fn superpose(&self, other: &Self) -> AlgebraResult<Self> {
+        // FHRR's public coefficient representation intentionally exposes only
+        // real parts, so use the complete complex representation here.
+        Ok(FHRRAlgebra::add(self, other))
+    }
+
+    fn scale(&self, factor: f64) -> AlgebraResult<Self> {
+        // Preserve both real and imaginary components; the coefficient default
+        // cannot reconstruct FHRR's imaginary parts.
+        Ok(FHRRAlgebra::scale(self, factor))
+    }
+
     fn similarity(&self, other: &Self) -> f64 {
         let self_norm = self.compute_norm();
         let other_norm = other.compute_norm();

--- a/amari-holographic/src/algebra/mod.rs
+++ b/amari-holographic/src/algebra/mod.rs
@@ -16,7 +16,8 @@
 //! The key insight is that all these algebras share common operations:
 //!
 //! - **Binding** (`⊛`): Associate two representations (like key-value pairs)
-//! - **Bundling** (`⊕`): Superpose multiple representations
+//! - **Superposition** (`+`): Accumulate representations additively
+//! - **Bundling** (`⊕`): Select or clean up representations with bounded magnitude
 //! - **Inverse** (`⁻¹`): Enable unbinding to retrieve associated values
 //! - **Similarity**: Measure closeness between representations
 //!
@@ -182,7 +183,7 @@ pub trait BindingAlgebra: Sized + Clone + Send + Sync {
 
     /// Create the additive zero element.
     ///
-    /// This is the element `0` such that `x.bundle(&0, _) ≈ x` for bundling.
+    /// This is the element `0` such that `x.superpose(&0)? = x`.
     fn zero() -> Self;
 
     /// Bind two elements (association/structure-creation).
@@ -222,7 +223,12 @@ pub trait BindingAlgebra: Sized + Clone + Send + Sync {
         Ok(inv.bind(other))
     }
 
-    /// Bundle two elements (superposition/aggregation).
+    /// Bundle two elements for attention or cleanup.
+    ///
+    /// Bundling keeps magnitude bounded and may normalize or select between
+    /// candidates. Use [`superpose`](Self::superpose) instead when building an
+    /// additive holographic trace whose magnitude must grow with accumulated
+    /// evidence.
     ///
     /// The `beta` parameter controls soft vs hard bundling:
     /// - `beta = 1.0`: Soft bundling (weighted average / logsumexp)
@@ -230,6 +236,67 @@ pub trait BindingAlgebra: Sized + Clone + Send + Sync {
     ///
     /// The result should be similar to both inputs.
     fn bundle(&self, other: &Self, beta: f64) -> AlgebraResult<Self>;
+
+    /// Additively superpose two elements for holographic accumulation.
+    ///
+    /// This operation represents coefficient-wise addition and is intended for
+    /// memory traces such as `T = Σ keyᵢ ⊛ valueᵢ`. Unlike
+    /// [`bundle`](Self::bundle), it does not normalize or apply attention
+    /// weights, so repeated superposition preserves earlier contributions and
+    /// allows the trace magnitude to grow.
+    ///
+    /// The provided implementation reconstructs `Self` from the sum of its
+    /// coefficient representations. Existing implementors therefore receive
+    /// additive behavior without defining another required trait method.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlgebraError::DimensionMismatch`] when the operands or their
+    /// coefficient representations have different dimensions. Other errors are
+    /// propagated from [`from_coefficients`](Self::from_coefficients).
+    fn superpose(&self, other: &Self) -> AlgebraResult<Self> {
+        if self.dimension() != other.dimension() {
+            return Err(AlgebraError::DimensionMismatch {
+                expected: self.dimension(),
+                actual: other.dimension(),
+            });
+        }
+
+        let left = self.to_coefficients();
+        let right = other.to_coefficients();
+        if left.len() != right.len() {
+            return Err(AlgebraError::DimensionMismatch {
+                expected: left.len(),
+                actual: right.len(),
+            });
+        }
+        let coefficients: Vec<f64> = left
+            .into_iter()
+            .zip(right)
+            .map(|(left, right)| left + right)
+            .collect();
+        Self::from_coefficients(&coefficients)
+    }
+
+    /// Multiply every coefficient by `factor` for weighted superposition.
+    ///
+    /// Weighted accumulation composes this helper with
+    /// [`superpose`](Self::superpose). Trait-qualified calls such as
+    /// `<A as BindingAlgebra>::scale(binding, weight)` avoid shadowing by
+    /// concrete types that already expose an infallible inherent `scale`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates coefficient reconstruction errors from
+    /// [`from_coefficients`](Self::from_coefficients).
+    fn scale(&self, factor: f64) -> AlgebraResult<Self> {
+        let coefficients: Vec<f64> = self
+            .to_coefficients()
+            .into_iter()
+            .map(|coefficient| coefficient * factor)
+            .collect();
+        Self::from_coefficients(&coefficients)
+    }
 
     /// Bundle multiple elements efficiently.
     ///

--- a/amari-holographic/tests/superposition.rs
+++ b/amari-holographic/tests/superposition.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Additive superposition semantics for `BindingAlgebra`.
+
+use amari_holographic::{
+    AlgebraError, AlgebraResult, BindingAlgebra, CliffordAlgebra, FHRRAlgebra, MAPAlgebra,
+};
+
+#[derive(Clone, Debug)]
+struct TestAlgebra(Vec<f64>);
+
+impl BindingAlgebra for TestAlgebra {
+    fn dimension(&self) -> usize {
+        self.0.len()
+    }
+
+    fn identity() -> Self {
+        Self(vec![1.0; 4])
+    }
+
+    fn zero() -> Self {
+        Self(vec![0.0; 4])
+    }
+
+    fn bind(&self, other: &Self) -> Self {
+        Self(
+            self.0
+                .iter()
+                .zip(&other.0)
+                .map(|(left, right)| left * right)
+                .collect(),
+        )
+    }
+
+    fn inverse(&self) -> AlgebraResult<Self> {
+        if self.0.iter().any(|value| value.abs() <= f64::EPSILON) {
+            return Err(AlgebraError::NotInvertible {
+                reason: "zero test coefficient".to_string(),
+            });
+        }
+        Ok(Self(self.0.iter().map(|value| value.recip()).collect()))
+    }
+
+    fn bundle(&self, other: &Self, _beta: f64) -> AlgebraResult<Self> {
+        if self.dimension() != other.dimension() {
+            return Err(AlgebraError::DimensionMismatch {
+                expected: self.dimension(),
+                actual: other.dimension(),
+            });
+        }
+        Ok(Self(
+            self.0
+                .iter()
+                .zip(&other.0)
+                .map(|(left, right)| (left + right) / 2.0)
+                .collect(),
+        ))
+    }
+
+    fn similarity(&self, other: &Self) -> f64 {
+        let denominator = self.norm() * other.norm();
+        if denominator <= f64::EPSILON {
+            return 0.0;
+        }
+        self.0
+            .iter()
+            .zip(&other.0)
+            .map(|(left, right)| left * right)
+            .sum::<f64>()
+            / denominator
+    }
+
+    fn norm(&self) -> f64 {
+        self.0.iter().map(|value| value * value).sum::<f64>().sqrt()
+    }
+
+    fn normalize(&self) -> AlgebraResult<Self> {
+        let norm = self.norm();
+        if norm <= f64::EPSILON {
+            return Err(AlgebraError::NormalizationFailed { norm });
+        }
+        Ok(Self(self.0.iter().map(|value| value / norm).collect()))
+    }
+
+    fn permute(&self, _shift: i32) -> Self {
+        self.clone()
+    }
+
+    fn get(&self, index: usize) -> AlgebraResult<f64> {
+        self.0
+            .get(index)
+            .copied()
+            .ok_or(AlgebraError::IndexOutOfBounds {
+                index,
+                size: self.dimension(),
+            })
+    }
+
+    fn set(&mut self, index: usize, value: f64) -> AlgebraResult<()> {
+        let size = self.dimension();
+        let coefficient = self
+            .0
+            .get_mut(index)
+            .ok_or(AlgebraError::IndexOutOfBounds { index, size })?;
+        *coefficient = value;
+        Ok(())
+    }
+
+    fn from_coefficients(coeffs: &[f64]) -> AlgebraResult<Self> {
+        Ok(Self(coeffs.to_vec()))
+    }
+
+    fn to_coefficients(&self) -> Vec<f64> {
+        self.0.clone()
+    }
+
+    fn algebra_name() -> &'static str {
+        "test-algebra"
+    }
+}
+
+fn assert_coefficients_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= 1.0e-12,
+            "coefficient {index}: expected {expected}, got {actual}"
+        );
+    }
+}
+
+#[test]
+fn default_superpose_is_coefficient_wise_addition() {
+    let left = TestAlgebra(vec![1.0, -2.0, 3.5, 0.25]);
+    let right = TestAlgebra(vec![4.0, 2.5, -1.5, 0.75]);
+
+    let sum = left.superpose(&right).unwrap();
+
+    assert_coefficients_close(&sum.to_coefficients(), &[5.0, 0.5, 2.0, 1.0]);
+}
+
+#[test]
+fn default_scale_is_coefficient_wise_scalar_multiplication() {
+    let value = TestAlgebra(vec![1.0, -2.0, 3.5, 0.25]);
+
+    let scaled = value.scale(-2.0).unwrap();
+
+    assert_coefficients_close(&scaled.to_coefficients(), &[-2.0, 4.0, -7.0, -0.5]);
+}
+
+#[test]
+fn superposition_is_commutative_and_has_zero_identity() {
+    let left = TestAlgebra(vec![1.0, -2.0, 3.0, -4.0]);
+    let right = TestAlgebra(vec![-4.0, 3.0, -2.0, 1.0]);
+
+    let left_right = left.superpose(&right).unwrap();
+    let right_left = right.superpose(&left).unwrap();
+    let with_zero = left.superpose(&TestAlgebra::zero()).unwrap();
+
+    assert_coefficients_close(&left_right.to_coefficients(), &right_left.to_coefficients());
+    assert_coefficients_close(&with_zero.to_coefficients(), &left.to_coefficients());
+}
+
+#[test]
+fn dimension_mismatch_is_typed() {
+    let left = TestAlgebra(vec![1.0, 2.0]);
+    let right = TestAlgebra(vec![1.0, 2.0, 3.0]);
+
+    let error = left.superpose(&right).unwrap_err();
+
+    assert_eq!(
+        error,
+        AlgebraError::DimensionMismatch {
+            expected: 2,
+            actual: 3,
+        }
+    );
+}
+
+#[test]
+fn repeated_superposition_grows_while_bundle_remains_attention_like() {
+    let basis = [
+        TestAlgebra(vec![1.0, 0.0, 0.0, 0.0]),
+        TestAlgebra(vec![0.0, 1.0, 0.0, 0.0]),
+        TestAlgebra(vec![0.0, 0.0, 1.0, 0.0]),
+        TestAlgebra(vec![0.0, 0.0, 0.0, 1.0]),
+    ];
+    let mut trace = TestAlgebra::zero();
+    for item in &basis {
+        trace = trace.superpose(item).unwrap();
+    }
+    let mut attention = basis[0].clone();
+    for item in basis.iter().skip(1) {
+        attention = attention.bundle(item, 1.0).unwrap();
+    }
+
+    assert!((trace.norm() - 2.0).abs() <= 1.0e-12);
+    assert!(attention.norm() <= 1.0);
+    assert!(trace.norm() > attention.norm());
+}
+
+#[test]
+fn map_defaults_match_explicit_coefficient_reconstruction() {
+    type Map = MAPAlgebra<4>;
+    let left = Map::from_coefficients(&[1.0, -2.0, 0.5, 4.0]).unwrap();
+    let right = Map::from_coefficients(&[-3.0, 1.0, 2.5, -1.0]).unwrap();
+    let expected_sum = Map::from_coefficients(&[-2.0, -1.0, 3.0, 3.0]).unwrap();
+    let expected_scaled = Map::from_coefficients(&[0.25, -0.5, 0.125, 1.0]).unwrap();
+
+    let sum = <Map as BindingAlgebra>::superpose(&left, &right).unwrap();
+    let scaled = <Map as BindingAlgebra>::scale(&left, 0.25).unwrap();
+
+    assert_coefficients_close(&sum.to_coefficients(), &expected_sum.to_coefficients());
+    assert_coefficients_close(
+        &scaled.to_coefficients(),
+        &expected_scaled.to_coefficients(),
+    );
+}
+
+#[test]
+fn fhrr_superposition_preserves_complex_components() {
+    type Fhrr = FHRRAlgebra<2>;
+    let left = Fhrr::new([1.0, -2.0], [3.0, 4.0]);
+    let right = Fhrr::new([0.5, 2.5], [-1.0, 0.25]);
+
+    let sum = <Fhrr as BindingAlgebra>::superpose(&left, &right).unwrap();
+    let scaled = <Fhrr as BindingAlgebra>::scale(&left, -2.0).unwrap();
+
+    assert_coefficients_close(&[sum.real(0).unwrap(), sum.real(1).unwrap()], &[1.5, 0.5]);
+    assert_coefficients_close(&[sum.imag(0).unwrap(), sum.imag(1).unwrap()], &[2.0, 4.25]);
+    assert_coefficients_close(
+        &[scaled.real(0).unwrap(), scaled.real(1).unwrap()],
+        &[-2.0, 4.0],
+    );
+    assert_coefficients_close(
+        &[scaled.imag(0).unwrap(), scaled.imag(1).unwrap()],
+        &[-6.0, -8.0],
+    );
+}
+
+#[test]
+fn clifford_defaults_match_explicit_coefficient_reconstruction() {
+    type Cl2 = CliffordAlgebra<2, 0, 0>;
+    let left = Cl2::from_coefficients(&[1.0, 2.0, -1.0, 0.5]).unwrap();
+    let right = Cl2::from_coefficients(&[-0.5, 1.0, 3.0, -2.0]).unwrap();
+    let expected_sum = Cl2::from_coefficients(&[0.5, 3.0, 2.0, -1.5]).unwrap();
+    let expected_scaled = Cl2::from_coefficients(&[-2.0, -4.0, 2.0, -1.0]).unwrap();
+
+    let sum = <Cl2 as BindingAlgebra>::superpose(&left, &right).unwrap();
+    let scaled = <Cl2 as BindingAlgebra>::scale(&left, -2.0).unwrap();
+
+    assert_coefficients_close(&sum.to_coefficients(), &expected_sum.to_coefficients());
+    assert_coefficients_close(
+        &scaled.to_coefficients(),
+        &expected_scaled.to_coefficients(),
+    );
+}

--- a/docs/plans/2026-06-21-additive-superpose-binding-algebra.md
+++ b/docs/plans/2026-06-21-additive-superpose-binding-algebra.md
@@ -1,0 +1,292 @@
+# Additive Superposition on `BindingAlgebra` — Handoff for v0.24.0
+
+**Date:** 2026-06-21
+**Target:** Amari **v0.24.0** (workspace crate `amari-holographic`)
+**Status:** Accepted — implemented on `feature/amari-superposition-0.24`. Surfaced by the Minuet Kagome-readiness sprint (WS 6).
+**Scope:** Non-breaking, additive trait change. One new method (plus a scalar helper) on `BindingAlgebra`, each with a default implementation, so existing consumers compile unchanged. FHRR overrides both methods for correctness because its coefficient view omits imaginary components; optimized overrides are otherwise deferred until benchmarks demonstrate a need.
+**Origin:** `docs/HANDOFF-kagome-readiness.md` §6 (Minuet); the `DenseTrace::add` recall-decay bug. This document is the upstream home for the fix, since the root cause is an Amari trait gap, not Minuet code.
+
+---
+
+## TL;DR
+
+`BindingAlgebra::bundle` is the trait's only superposition method, and it does a
+**softmax-weighted average**, not an additive sum. That is correct for *attention/cleanup*
+(the resonator selecting among codebook items) but **wrong for accumulation** — building a
+holographic memory trace `T = Σ keyᵢ ⊛ valueᵢ`. Used for accumulation, `bundle` normalises away
+the growing trace: each successive item geometrically decays the earlier ones.
+
+**Fix (additive, fits a 0.24.0 minor):** add a `superpose` (additive) method — and a `scale`
+helper — to `BindingAlgebra`, each with a default implementation expressed via the existing
+`to_coefficients`/`from_coefficients` trait methods. `bundle` stays as-is (it is the attention
+op). Downstream, Minuet's `DenseTrace::add` switches from `bundle` to `superpose`, which
+repairs a confirmed recall-quality regression (item 1 of 5 recalled as the wrong symbol at
+confidence 0.11).
+
+---
+
+## 1. The problem (verified in Minuet)
+
+Minuet's `DenseTrace::add` (`src/store/trace.rs`) accumulates bound pairs into a trace via:
+
+```rust
+fn add(&mut self, item: &A, weight: f64) {
+    let scaled = scale_element(item, weight);
+    *trace = trace.bundle(&scaled, self.beta).unwrap_or_else(|_| trace.clone());
+    // ...
+}
+```
+
+`bundle(beta=1.0)` on `ProductCliffordAlgebra` computes softmax weights from the operand norms
+and returns `self.scale(w1) ⊕ other.scale(w2)` with `w1 + w2 = 1` — i.e. a **weighted average**.
+So the trace does not grow; each `add` dilutes everything already in it:
+
+- after 1 add: `item₁`
+- after 2: `avg(item₁, item₂)` (≈ 50/50)
+- after 3: `avg(avg(item₁,item₂), item₃)` → **25/25/50**
+- after *n*: the first binding's weight is ≈ (½)ⁿ⁻¹
+
+**Probe (Minuet, `ProductCliffordAlgebra<32>`, 5 stores):**
+
+| query | stored | recall returns | confidence |
+|-------|--------|----------------|------------|
+| `"france"`   | 1st  | **`"spain"`** (wrong) | 0.114 |
+| `"portugal"` | last | `"lisbon"` (correct)  | 0.450 |
+
+The 2-item unit test passes; the failure appears only at ≥3 items — which is why it hid for the
+whole sprint behind a CI discovery gap (Minuet's `tests/integration/` was not auto-discovered;
+fixed in Minuet WS 6, PR #18). This is the **third** place the "bundle averages, not sums" fact
+has bitten downstream work this sprint (also: Minuet WS 4b gradient-attribution test
+construction; Minuet WS 5 `optical_store` accumulation).
+
+---
+
+## 2. The semantic conflation (root cause)
+
+`BindingAlgebra` conflates two distinct operations under one method:
+
+| Role | Operation wanted | What `bundle` does | Correct? |
+|------|------------------|--------------------|----------|
+| **Attention / cleanup** (resonator selecting among codebook candidates) | softmax-weighted average, bounded magnitude | softmax-weighted average | ✅ |
+| **Accumulation** (building a memory trace / superposition) | additive sum, magnitude grows | softmax-weighted average | ❌ |
+
+The two have opposite magnitude semantics: attention keeps magnitude ~constant (select among
+peers); accumulation grows magnitude (the trace *is* the sum). No single operation can serve
+both. The trait needs an explicit additive path.
+
+---
+
+## 3. Proposed trait additions
+
+Additive only — `bundle`, `bundle_all`, and all existing methods are unchanged.
+
+```rust
+pub trait BindingAlgebra: Sized + Clone + Send + Sync {
+    // ... existing methods unchanged ...
+
+    /// Additive superposition: `self + other`, magnitude-preserving (sum grows).
+    ///
+    /// This is the *accumulation* operation for holographic memory traces:
+    /// `T = Σ keyᵢ ⊛ valueᵢ`. Contrast with [`bundle`](Self::bundle), which is the
+    /// softmax-weighted *average* used for attention/cleanup. Using `bundle` for
+    /// accumulation silently decays earlier items (see the Minuet handoff).
+    ///
+    /// The default implementation is element-wise coefficient addition and works for
+    /// any algebra whose coefficient representation is additive (all current impls).
+    /// Types with a faster inherent path should override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlgebraError::DimensionMismatch`] when operands or coefficient
+    /// representations differ in dimension, and otherwise propagates coefficient
+    /// reconstruction failures.
+    fn superpose(&self, other: &Self) -> AlgebraResult<Self> {
+        if self.dimension() != other.dimension() {
+            return Err(AlgebraError::DimensionMismatch {
+                expected: self.dimension(),
+                actual: other.dimension(),
+            });
+        }
+        let a = self.to_coefficients();
+        let b = other.to_coefficients();
+        if a.len() != b.len() {
+            return Err(AlgebraError::DimensionMismatch {
+                expected: a.len(),
+                actual: b.len(),
+            });
+        }
+        let sum: Vec<f64> = a.into_iter().zip(b).map(|(x, y)| x + y).collect();
+        Self::from_coefficients(&sum)
+    }
+
+    /// Scalar multiply: `factor * self`. Used for *weighted* superposition
+    /// (`trace.superpose(&binding.scale(weight)?)?`). Default impl via coefficients.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`superpose`](Self::superpose).
+    fn scale(&self, factor: f64) -> AlgebraResult<Self> {
+        let scaled: Vec<f64> = self.to_coefficients().iter().map(|c| c * factor).collect();
+        Self::from_coefficients(&scaled)
+    }
+}
+```
+
+**Why these two:** they compose to give weighted accumulation
+(`a.superpose(&b.scale(w)?)?`), which is exactly what `DenseTrace::add(item, weight)` needs. No
+`superpose_all` is strictly required (it is a trivial fold over `superpose`); add one later only
+if a caller wants a single-allocation batch.
+
+### Naming
+
+`superpose` is recommended over `add`:
+
+- It is the **VSA-literature term** for additive bundling (Kanerva: superposition = sum), so it
+  reads correctly in holographic-memory contexts.
+- It is unambiguously distinct from `bundle` (attention) and from the `Add` trait
+  (which is about numeric addition, not algebra superposition).
+- It matches the inherent `add`/`scale` primitives each type already has, without colliding
+  with the `std::ops::Add` name.
+
+If `add` is preferred for brevity, that is acceptable — the semantics are what matter. Pick one
+and use it consistently; do **not** add both.
+
+---
+
+## 4. Per-type implementation status
+
+Every `BindingAlgebra` implementation receives the documented coefficient-based defaults.
+FHRR is the one correctness exception: its coefficient view intentionally exposes only real
+parts, so it overrides both methods to preserve the complete complex representation. Several
+other types have inherent primitives that could support optimized overrides later, but v0.24
+keeps the defaults until benchmarks demonstrate that specialization is needed.
+
+| Type | Inherent `add` | Inherent `scale` | Action for 0.24.0 |
+|------|----------------|------------------|--------------------|
+| `ProductCliffordAlgebra<K>` | `component_add` | `component_scale` | use trait defaults; benchmark before overriding |
+| `CliffordAlgebra<P,Q,R>` | (via `inner: Multivector`) | (via `inner`) | use trait defaults |
+| `Cl3` | `add` | `scale` | use trait defaults; benchmark before overriding |
+| `FHRRAlgebra<D>` | `add` | `scale` | correctness override preserving real and imaginary parts |
+| `MAPAlgebra<D>` | `add` | `scale` | use unbounded trait defaults — **see §5 (MAP)** |
+
+---
+
+## 5. MAP: bounded vs unbounded superposition (design note)
+
+`MAPAlgebra`'s inherent `add` is pure element-wise addition (unbounded), but its `bundle`
+applies `sign()`/`soft_sign(beta)` to keep the result bipolar (bounded). This is the one place
+where "what is the right superposition" has a real choice:
+
+- **Unbounded `superpose`** (matching the other algebras): the MAP trace grows in magnitude,
+  retrieval re-normalises. Consistent across the trait; matches holographic-memory semantics.
+  **Recommended** — keeps the trait uniform.
+- **Bounded `superpose`** (apply `sign`): stays bipolar, no magnitude growth. Diverges from the
+  other algebras and breaks the "trace = Σ" invariant the Minuet `Attribution::compute_gradient`
+  exactness proof relies on (sum-to-1 against the pure-sum superposition).
+
+Recommendation: **unbounded** for `superpose` (override with plain `add`), and document that MAP
+users wanting bounded accumulation should compose `superpose` + `sign` explicitly. This keeps
+the trait's accumulation semantics uniform and preserves Minuet's gradient-attribution
+exactness guarantee.
+
+---
+
+## 6. Non-breaking analysis
+
+- **Default implementations** via `to_coefficients`/`from_coefficients` mean no existing `impl
+  BindingAlgebra` block fails to compile. New methods appear on every type immediately, with
+  correct (if not maximally fast) behaviour.
+- **SemVer:** additive method on a non-sealed trait = minor bump. v0.23.0 → v0.24.0 is correct.
+  (A new *required* method would be breaking; the defaults avoid that.)
+- **Blast radius:** 12 files reference `BindingAlgebra` across `amari-holographic` + `amari-gpu`.
+  None require source changes to keep compiling. `amari-gpu`'s GPU kernels operate on the
+  holographic ops; if it accelerates `bundle`, a future `superpose` kernel is a natural addition
+  but is **not** required for 0.24.0 (the coefficient default runs on CPU).
+
+---
+
+## 7. Downstream impact
+
+- **Minuet** (`DenseTrace::add`): switch `trace.bundle(&scaled, beta)` →
+  `trace.superpose(&scaled)?`. This directly repairs the recall-decay bug and lets
+  `simple_memory_full_workflow` be un-`#[ignore]`d (Minuet PR #18 left it ignored with an
+  evidence note pointing here). After Minuet bumps its `amari-holographic` floor to `^0.24`.
+- **Minuet** (`optical_store`, WS 5): **verified NOT affected.** It accumulates via
+  `OpticalFieldAlgebra::bundle(&[trace, binding], &[1.0, 1.0])`, and that `bundle` uses the
+  caller-provided weights directly (no softmax) with a per-mode amplitude that *grows*
+  (`amplitude = sqrt(s²+b²)`). Only `bundle_uniform` (the `1/n` variant) averages, and
+  `optical_store` does not use it. So the optical path already accumulates correctly;
+  no change needed there when the floor bumps. (The `BindingAlgebra` bug is specific to
+  its `bundle`, which *forces* softmax weights regardless of the caller's intent.)
+- **Minuet** (`Attribution::compute_gradient`, WS 4b): the exactness proof
+  (`Σ attribᵢ ≈ 1` against the pure-sum superposition) assumes additive accumulation. The
+  current test builds the pure-sum via `ProductCliffordAlgebra::component_add` (inherent);
+  `superpose` on the trait would let it be written generically over `A`.
+- **Kagome:** consumes via Minuet; no direct change. Its `MicrowaveField` delegates to
+  `OpticalRotorField` (see §10).
+- **amari-gpu:** optional future `superpose` kernel; not blocking.
+
+---
+
+## 8. Verification
+
+1. **Unit (per type):** `superpose(a, b)` equals inherent `add` where one exists; `scale(a, w)`
+   then `superpose` equals weighted add; `superpose(x, zero()) == x`;
+   `superpose(a, b) == superpose(b, a)` (commutativity).
+2. **Default reconstruction parity:** for MAP and `CliffordAlgebra`, assert the trait defaults
+   equal explicit coefficient reconstruction. For FHRR, assert the correctness override retains
+   both real and imaginary components. Add optimized override-parity tests only if a future
+   benchmark justifies another override.
+3. **Capacity/SNR:** `superpose` of *n* random unit versors has magnitude ∝ √n (expected for
+   holographic traces); `bundle` stays ~constant. A test asserting this growth distinguishes
+   the two operations and pins the semantic split.
+4. **Integration (Minuet):** after the floor bump, Minuet's `simple_memory_full_workflow` passes
+   un-ignored (recall of the 1st-stored item returns the correct symbol at confidence > 0.3).
+
+---
+
+## 9. Scope for v0.24.0
+
+**In scope:**
+- `superpose` + `scale` on `BindingAlgebra` with coefficient-based defaults and the FHRR correctness override.
+- Doc comments distinguishing `superpose` (accumulation) from `bundle` (attention).
+- The verification suite in §8 (items 1–3).
+- CHANGELOG entry noting the semantic clarification + the Minuet bug it repairs.
+
+**Out of scope (later):**
+- A `superpose_all` batch convenience (trivial fold; add on demand).
+- `amari-gpu` GPU `superpose` kernel.
+- ~~`OpticalFieldAlgebra::superpose`~~ — resolved as **not needed** (§10 q1): its
+  weighted `bundle` already accumulates additively.
+
+---
+
+## 10. Open design questions
+
+1. **`OpticalFieldAlgebra` parity — resolved (no action needed).** `OpticalFieldAlgebra`
+   (in `amari-holographic::optical`) is a *struct* with inherent methods, not a
+   `BindingAlgebra` impl — and unlike `BindingAlgebra::bundle`, its `bundle` uses the
+   caller-provided weights **directly** (no softmax), so `bundle(&xs, &[1.0, …])` is already
+   additive accumulation. Minuet's `optical_store` relies on exactly this. **Conclusion: do
+   not add `superpose` to `OpticalFieldAlgebra`**; its weighted `bundle` is correct as-is.
+   The semantic split this handoff proposes is specific to the `BindingAlgebra` trait, where
+   `bundle` forces softmax averaging. (If, later, callers want a *normalised* optical
+   superposition, `bundle_uniform` already exists for that.)
+2. **`scale` naming.** Some types' inherent scalar-multiply is named `scale`, others
+   `component_scale`. The trait method should be `scale` (shorter, matches the majority);
+   overrides call the inherent one regardless of its local name.
+3. **Fallibility.** Proposed `-> AlgebraResult<Self>` for uniformity with the trait's error model
+   and to accommodate the coefficient default. If every override is provably infallible, a later
+   refactor to `-> Self` is possible but not required for 0.24.0.
+
+---
+
+## 11. Pointers
+
+- Minuet handoff (origin of this work): `Minuet/docs/HANDOFF-kagome-readiness.md` §6, §9 checklist.
+- Minuet WS 6 PR #18 (where the bug was surfaced + `#[ignore]`d with evidence).
+- Minuet WS 4b (PR #15): `Attribution::compute_gradient` — the exactness proof that assumes
+  additive accumulation.
+- Minuet WS 5 (PR #16): `optical_store` — the other latent instance of the same bug.
+- Trait definition: `amari-holographic/src/algebra/mod.rs:170`.
+- Per-type `bundle` impls: `amari-holographic/src/algebra/{product_clifford,clifford,fhrr,map,cl3}.rs`.


### PR DESCRIPTION
## Summary

- add fallible default `BindingAlgebra::superpose` and `BindingAlgebra::scale` operations for additive, weighted holographic accumulation
- preserve FHRR complex components with a correctness override because its public coefficient representation intentionally exposes only real parts
- distinguish additive accumulation from attention-style `bundle` semantics in API docs and the adopted Minuet handoff design
- transition the discovery superposition capability from planned to implemented and regenerate the structural catalog deterministically

## Behavior

- `superpose` performs coefficient-wise addition and reports typed dimension mismatches
- `scale` performs coefficient-wise scalar multiplication
- repeated additive superposition grows trace magnitude while `bundle` remains bounded/attention-like
- MAP remains unbounded under trait-qualified superposition
- existing `BindingAlgebra` implementors remain source-compatible through provided defaults

## Test plan

- [x] RED confirmed before implementation: methods were absent
- [x] `cargo test -p amari-holographic --test superposition` — 8 passed
- [x] `cargo test -p amari-holographic --all-features --quiet` — 155 unit + 8 integration passed
- [x] `cargo clippy -p amari-holographic --all-targets --all-features -- -D warnings`
- [x] deterministic double catalog regeneration
- [x] `cargo test -p amari-discovery --test catalog_generation --test catalog_integrity` — 51 passed
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Existing unrelated checks

- `amari-holographic --no-default-features` already fails in optical modules due missing `alloc::vec` imports and `std::f32` references; this change does not modify those modules
- rustdoc with `-D warnings` reaches four existing broken intra-doc links (`TropicalDual`, `BindingAlgebra` in memory docs, and two indexed-expression links); normal documentation generation succeeds

Supersedes the doc-only design handoff in #176 by incorporating and updating that design alongside the canonical implementation.
