### PR TITLE
feat: generate replayable normalized plans

### DIFF
--- a/amari-discovery/src/error.rs
+++ b/amari-discovery/src/error.rs
@@ -42,6 +42,17 @@ pub enum DiscoveryError {
     #[error("probe failed: {0}")]
     ProbeFailed(String),
 
+    /// A replay-required hash differs from the plan artifact.
+    #[error("replay drift for {field}: expected `{expected}`, found `{actual}`")]
+    ReplayDrift {
+        /// Stable hash field name.
+        field: String,
+        /// Hash stored in the plan artifact.
+        expected: String,
+        /// Hash observed for the replay request.
+        actual: String,
+    },
+
     /// A bounded operation exceeded a declared resource limit.
     #[error("resource limit exceeded: {0}")]
     LimitExceeded(String),
@@ -93,7 +104,7 @@ impl DiscoveryError {
     pub const fn kind(&self) -> &'static str {
         match self {
             Self::InvalidId { .. } => "invalid_id",
-            Self::InvalidInput(_) => "invalid_input",
+            Self::InvalidInput(_) | Self::ReplayDrift { .. } => "invalid_input",
             Self::CatalogCorruption(_) => "catalog_corruption",
             Self::InspectionFailure(_) => "inspection_failure",
             Self::ProbeUnavailable(_) => "probe_unavailable",
@@ -109,7 +120,7 @@ impl DiscoveryError {
     /// Returns the stable process exit code for this failure class.
     pub const fn exit_code(&self) -> u8 {
         match self {
-            Self::InvalidId { .. } | Self::InvalidInput(_) => 2,
+            Self::InvalidId { .. } | Self::InvalidInput(_) | Self::ReplayDrift { .. } => 2,
             Self::CatalogCorruption(_) => 3,
             Self::InspectionFailure(_) => 4,
             Self::ProbeUnavailable(_) => 5,

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -75,12 +75,14 @@ pub use inspect::{
 pub use planner::{
     BlockedCandidate, CandidateRanker, CandidateRetriever, CapabilityGraphExpander,
     GraphConstraints, GraphExpansion, GraphExpansionState, GraphLimit, GraphLimits, GraphPath,
-    GraphStep, RankedCandidate, RankingComponents, RankingContext, RankingProvenance,
-    RankingResult, RankingSignal, RankingSignalKind, RecallConfig, RelationCostPolicy,
-    RetrievalSource, RetrievedCandidate, RANKING_OBJECTIVE_ORDER,
+    GraphStep, NormalizationLimits, PlanGenerator, PlanNormalizer, RankedCandidate,
+    RankingComponents, RankingContext, RankingProvenance, RankingResult, RankingSignal,
+    RankingSignalKind, RecallConfig, RelationCostPolicy, RetrievalSource, RetrievedCandidate,
+    RANKING_OBJECTIVE_ORDER,
 };
 pub use protocol::{
-    CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope, Evidence,
-    ProbeBackend, ProbeId, ProbeResult, Provenance, ReplayMetadata, ResourceObservations,
-    SchemaVersion, SCHEMA_V1,
+    CandidatePlan, CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope,
+    Evidence, GoalSpec, NormalizationTrace, PlanCompatibility, PlanNormalization, PlanStep,
+    PlanTestTarget, PlanningContext, ProbeBackend, ProbeId, ProbeReplayHash, ProbeResult,
+    Provenance, Recommendation, ReplayMetadata, ResourceObservations, SchemaVersion, SCHEMA_V1,
 };

--- a/amari-discovery/src/planner/mod.rs
+++ b/amari-discovery/src/planner/mod.rs
@@ -7,6 +7,8 @@
 //! rank trade-offs, and normalize replayable plans.
 
 mod graph;
+mod normalize;
+mod plan;
 mod rank;
 mod recall;
 
@@ -14,6 +16,8 @@ pub use graph::{
     CapabilityGraphExpander, GraphConstraints, GraphExpansion, GraphExpansionState, GraphLimit,
     GraphLimits, GraphPath, GraphStep, RelationCostPolicy,
 };
+pub use normalize::{NormalizationLimits, PlanNormalizer};
+pub use plan::PlanGenerator;
 pub use rank::{
     BlockedCandidate, CandidateRanker, RankedCandidate, RankingComponents, RankingContext,
     RankingProvenance, RankingResult, RankingSignal, RankingSignalKind, RANKING_OBJECTIVE_ORDER,

--- a/amari-discovery/src/planner/normalize.rs
+++ b/amari-discovery/src/planner/normalize.rs
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded `amari-rewrite` normalization for replayable plans.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use amari_rewrite::trs::{Rule, Term, TermSystem};
+use serde::{Deserialize, Serialize};
+
+use super::plan::compute_plan_hash;
+use crate::{
+    CandidatePlan, CapabilityId, DiscoveryError, DiscoveryResult, NormalizationTrace,
+    PlanNormalization, PlanStep, PlanTestTarget,
+};
+
+const MAX_ENCODED_PLAN_BYTES: usize = 1_048_576;
+
+/// Resource limits for deterministic plan normalization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NormalizationLimits {
+    /// Maximum input plan steps accepted by the normalizer.
+    pub max_plan_steps: usize,
+    /// Maximum successful `TermSystem::apply_once` rewrites retained in trace.
+    pub max_rewrites: usize,
+}
+
+impl Default for NormalizationLimits {
+    fn default() -> Self {
+        Self {
+            max_plan_steps: 64,
+            max_rewrites: 4_096,
+        }
+    }
+}
+
+/// Deterministic bounded plan normalizer backed by `amari-rewrite`.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PlanNormalizer {
+    limits: NormalizationLimits,
+}
+
+impl PlanNormalizer {
+    /// Creates a normalizer with explicit nonzero limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero.
+    pub fn new(limits: NormalizationLimits) -> DiscoveryResult<Self> {
+        if limits.max_plan_steps == 0 || limits.max_rewrites == 0 {
+            return Err(DiscoveryError::InvalidInput(
+                "plan normalization limits must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(Self { limits })
+    }
+
+    /// Canonically orders and deduplicates a candidate plan with a bounded trace.
+    ///
+    /// Plan steps are encoded as first-order [`Term`] values. Explicit adjacent
+    /// swap rules reduce prerequisite/kind inversions, and one repeated-variable
+    /// rule removes adjacent duplicates. Each transition is performed through
+    /// [`TermSystem::apply_once`] and retained as a before/after trace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::LimitExceeded`] when step, encoded-byte, or
+    /// rewrite bounds are exhausted. Invalid plan structure is rejected as
+    /// [`DiscoveryError::InvalidInput`].
+    pub fn normalize(&self, plan: &CandidatePlan) -> DiscoveryResult<CandidatePlan> {
+        validate_plan(plan, self.limits)?;
+        if plan.normalization.normalized
+            && is_canonical(&plan.steps, &plan.prerequisite_order)?
+            && plan.plan_hash == compute_plan_hash(plan)?
+        {
+            return Ok(plan.clone());
+        }
+
+        let system = normalization_system(&plan.steps, &plan.prerequisite_order)?;
+        let mut current = encode_plan(&plan.steps);
+        let mut current_steps = plan.steps.clone();
+        let mut trace = Vec::new();
+
+        for _ in 0..self.limits.max_rewrites {
+            let Some(next) = system.apply_once(&current).map_err(rewrite_error)? else {
+                return finish(plan, current_steps, trace, self.limits.max_rewrites);
+            };
+            let next_steps = decode_plan(&next)?;
+            trace.push(NormalizationTrace {
+                before: current_steps,
+                after: next_steps.clone(),
+            });
+            current = next;
+            current_steps = next_steps;
+        }
+
+        if system
+            .apply_once(&current)
+            .map_err(rewrite_error)?
+            .is_some()
+        {
+            Err(DiscoveryError::LimitExceeded(format!(
+                "plan normalization rewrite limit {} exhausted",
+                self.limits.max_rewrites
+            )))
+        } else {
+            finish(plan, current_steps, trace, self.limits.max_rewrites)
+        }
+    }
+}
+
+fn validate_plan(plan: &CandidatePlan, limits: NormalizationLimits) -> DiscoveryResult<()> {
+    if plan.steps.len() > limits.max_plan_steps {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "plan steps {} exceed limit {}",
+            plan.steps.len(),
+            limits.max_plan_steps
+        )));
+    }
+    let encoded_bytes = serde_json::to_vec(&plan.steps)?.len();
+    if encoded_bytes > MAX_ENCODED_PLAN_BYTES {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "encoded plan bytes {encoded_bytes} exceed limit {MAX_ENCODED_PLAN_BYTES}"
+        )));
+    }
+    if plan.prerequisite_order.is_empty()
+        || plan.prerequisite_order.last() != Some(&plan.capability_id)
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "plan prerequisite order must end at the candidate capability".to_owned(),
+        ));
+    }
+    let known: BTreeSet<_> = plan.prerequisite_order.iter().cloned().collect();
+    if known.len() != plan.prerequisite_order.len() {
+        return Err(DiscoveryError::InvalidInput(
+            "plan prerequisite order contains duplicate capability IDs".to_owned(),
+        ));
+    }
+    if plan
+        .steps
+        .iter()
+        .any(|step| !known.contains(step.capability_id()))
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "plan step references a capability outside prerequisite order".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn normalization_system(
+    steps: &[PlanStep],
+    prerequisite_order: &[CapabilityId],
+) -> DiscoveryResult<TermSystem> {
+    let order = capability_order(prerequisite_order);
+    let mut rules = vec![Rule::new(
+        list(
+            Term::var("duplicate"),
+            list(Term::var("duplicate"), Term::var("tail")),
+        ),
+        list(Term::var("duplicate"), Term::var("tail")),
+    )
+    .map_err(rewrite_error)?];
+
+    let unique: BTreeSet<_> = steps.iter().cloned().collect();
+    for left in &unique {
+        for right in &unique {
+            if compare_steps(left, right, &order)? == Ordering::Greater {
+                rules.push(
+                    Rule::new(
+                        list(
+                            encode_step(left),
+                            list(encode_step(right), Term::var("tail")),
+                        ),
+                        list(
+                            encode_step(right),
+                            list(encode_step(left), Term::var("tail")),
+                        ),
+                    )
+                    .map_err(rewrite_error)?,
+                );
+            }
+        }
+    }
+    Ok(TermSystem::new(rules))
+}
+
+fn finish(
+    original: &CandidatePlan,
+    steps: Vec<PlanStep>,
+    trace: Vec<NormalizationTrace>,
+    max_rewrites: usize,
+) -> DiscoveryResult<CandidatePlan> {
+    if !is_canonical(&steps, &original.prerequisite_order)? {
+        return Err(DiscoveryError::Internal(
+            "plan rewrite system stopped before canonical fixed point".to_owned(),
+        ));
+    }
+    let mut normalized = CandidatePlan {
+        capability_id: original.capability_id.clone(),
+        prerequisite_order: original.prerequisite_order.clone(),
+        steps,
+        compatibility: original.compatibility.clone(),
+        normalization: PlanNormalization {
+            normalized: true,
+            max_rewrites,
+            trace,
+        },
+        plan_hash: String::new(),
+    };
+    normalized.plan_hash = compute_plan_hash(&normalized)?;
+    Ok(normalized)
+}
+
+fn capability_order(capabilities: &[CapabilityId]) -> BTreeMap<CapabilityId, usize> {
+    capabilities
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(index, capability)| (capability, index))
+        .collect()
+}
+
+fn compare_steps(
+    left: &PlanStep,
+    right: &PlanStep,
+    order: &BTreeMap<CapabilityId, usize>,
+) -> DiscoveryResult<Ordering> {
+    let left_rank = order.get(left.capability_id()).ok_or_else(|| {
+        DiscoveryError::InvalidInput(format!(
+            "unknown plan-step capability `{}`",
+            left.capability_id()
+        ))
+    })?;
+    let right_rank = order.get(right.capability_id()).ok_or_else(|| {
+        DiscoveryError::InvalidInput(format!(
+            "unknown plan-step capability `{}`",
+            right.capability_id()
+        ))
+    })?;
+    Ok(left_rank.cmp(right_rank).then_with(|| left.cmp(right)))
+}
+
+fn is_canonical(steps: &[PlanStep], capabilities: &[CapabilityId]) -> DiscoveryResult<bool> {
+    let order = capability_order(capabilities);
+    for pair in steps.windows(2) {
+        if compare_steps(&pair[0], &pair[1], &order)? != Ordering::Less {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn encode_plan(steps: &[PlanStep]) -> Term {
+    Term::sym("plan", [encode_list(steps)])
+}
+
+fn encode_list(steps: &[PlanStep]) -> Term {
+    steps
+        .iter()
+        .rev()
+        .fold(Term::constant("nil"), |tail, step| {
+            list(encode_step(step), tail)
+        })
+}
+
+fn list(head: Term, tail: Term) -> Term {
+    Term::sym("step_list", [head, tail])
+}
+
+fn encode_step(step: &PlanStep) -> Term {
+    match step {
+        PlanStep::Dependency {
+            capability_id,
+            package,
+            version,
+        } => Term::sym(
+            "dependency",
+            [
+                constant(capability_id.to_string()),
+                constant(package),
+                constant(version),
+            ],
+        ),
+        PlanStep::Feature {
+            capability_id,
+            package,
+            feature,
+        } => Term::sym(
+            "feature",
+            [
+                constant(capability_id.to_string()),
+                constant(package),
+                constant(feature),
+            ],
+        ),
+        PlanStep::Symbol {
+            capability_id,
+            path,
+        } => Term::sym(
+            "symbol",
+            [constant(capability_id.to_string()), constant(path)],
+        ),
+        PlanStep::Example {
+            capability_id,
+            package,
+            example,
+        } => Term::sym(
+            "example",
+            [
+                constant(capability_id.to_string()),
+                constant(package),
+                constant(example),
+            ],
+        ),
+        PlanStep::Probe {
+            capability_id,
+            probe_id,
+        } => Term::sym(
+            "probe",
+            [
+                constant(capability_id.to_string()),
+                constant(probe_id.to_string()),
+            ],
+        ),
+        PlanStep::Test {
+            capability_id,
+            package,
+            target: PlanTestTarget::AllTargets,
+        } => Term::sym(
+            "test",
+            [
+                constant(capability_id.to_string()),
+                constant(package),
+                constant("all_targets"),
+            ],
+        ),
+    }
+}
+
+fn constant(value: impl Into<String>) -> Term {
+    Term::constant(value.into())
+}
+
+fn decode_plan(term: &Term) -> DiscoveryResult<Vec<PlanStep>> {
+    let Term::Sym(symbol, args) = term else {
+        return invalid_encoded_plan();
+    };
+    if symbol.as_str() != "plan" || args.len() != 1 {
+        return invalid_encoded_plan();
+    }
+    decode_list(&args[0])
+}
+
+fn decode_list(term: &Term) -> DiscoveryResult<Vec<PlanStep>> {
+    let mut steps = Vec::new();
+    let mut cursor = term;
+    loop {
+        let Term::Sym(symbol, args) = cursor else {
+            return invalid_encoded_plan();
+        };
+        match (symbol.as_str(), args.as_slice()) {
+            ("nil", []) => return Ok(steps),
+            ("step_list", [head, tail]) => {
+                steps.push(decode_step(head)?);
+                cursor = tail;
+            }
+            _ => return invalid_encoded_plan(),
+        }
+    }
+}
+
+fn decode_step(term: &Term) -> DiscoveryResult<PlanStep> {
+    let Term::Sym(symbol, args) = term else {
+        return invalid_encoded_plan();
+    };
+    let strings = args
+        .iter()
+        .map(decode_constant)
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    let capability = |value: &str| {
+        value.parse().map_err(|error| {
+            DiscoveryError::Internal(format!("cannot decode normalized capability ID: {error}"))
+        })
+    };
+    match (symbol.as_str(), strings.as_slice()) {
+        ("dependency", [id, package, version]) => Ok(PlanStep::Dependency {
+            capability_id: capability(id)?,
+            package: (*package).to_owned(),
+            version: (*version).to_owned(),
+        }),
+        ("feature", [id, package, feature]) => Ok(PlanStep::Feature {
+            capability_id: capability(id)?,
+            package: (*package).to_owned(),
+            feature: (*feature).to_owned(),
+        }),
+        ("symbol", [id, path]) => Ok(PlanStep::Symbol {
+            capability_id: capability(id)?,
+            path: (*path).to_owned(),
+        }),
+        ("example", [id, package, example]) => Ok(PlanStep::Example {
+            capability_id: capability(id)?,
+            package: (*package).to_owned(),
+            example: (*example).to_owned(),
+        }),
+        ("probe", [id, probe_id]) => Ok(PlanStep::Probe {
+            capability_id: capability(id)?,
+            probe_id: probe_id.parse().map_err(|error| {
+                DiscoveryError::Internal(format!("cannot decode normalized probe ID: {error}"))
+            })?,
+        }),
+        ("test", [id, package, "all_targets"]) => Ok(PlanStep::Test {
+            capability_id: capability(id)?,
+            package: (*package).to_owned(),
+            target: PlanTestTarget::AllTargets,
+        }),
+        _ => invalid_encoded_plan(),
+    }
+}
+
+fn decode_constant(term: &Term) -> DiscoveryResult<&str> {
+    match term {
+        Term::Sym(symbol, args) if args.is_empty() => Ok(symbol.as_str()),
+        _ => invalid_encoded_plan(),
+    }
+}
+
+fn invalid_encoded_plan<T>() -> DiscoveryResult<T> {
+    Err(DiscoveryError::Internal(
+        "amari-rewrite produced an invalid discovery plan term".to_owned(),
+    ))
+}
+
+fn rewrite_error(error: amari_rewrite::RewriteError) -> DiscoveryError {
+    DiscoveryError::Internal(format!("plan rewrite failure: {error}"))
+}

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic construction and replay validation for candidate plans.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::normalize::{NormalizationLimits, PlanNormalizer};
+use crate::{
+    CandidatePlan, CapabilityId, Catalog, CatalogIdentity, DiscoveryError, DiscoveryResult,
+    GoalSpec, PlanCompatibility, PlanNormalization, PlanStep, PlanTestTarget, PlanningContext,
+    ProbeReplayHash, RankedCandidate,
+};
+
+/// Deterministic catalog-backed candidate-plan generator.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PlanGenerator {
+    normalizer: PlanNormalizer,
+}
+
+impl PlanGenerator {
+    /// Creates a plan generator with explicit normalization limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero.
+    pub fn new(limits: NormalizationLimits) -> DiscoveryResult<Self> {
+        Ok(Self {
+            normalizer: PlanNormalizer::new(limits)?,
+        })
+    }
+
+    /// Generates and normalizes a replayable plan for one ranked candidate.
+    ///
+    /// Every dependency version, feature, symbol, example, and probe comes
+    /// directly from the validated catalog. A static package test step is
+    /// emitted for each referenced crate. No project command is executed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] for an empty goal or malformed
+    /// candidate path, [`DiscoveryError::CatalogCorruption`] for unresolved
+    /// catalog references, and a bounded normalization error when the generated
+    /// plan cannot reach a fixed point within default limits.
+    pub fn generate(
+        &self,
+        catalog: &Catalog,
+        context: &PlanningContext,
+        candidate: &RankedCandidate,
+    ) -> DiscoveryResult<CandidatePlan> {
+        validate_goal(&context.goal)?;
+        let prerequisite_order = prerequisite_order(candidate)?;
+        let capabilities: BTreeMap<_, _> = catalog
+            .capabilities()
+            .iter()
+            .map(|record| (record.id.clone(), record))
+            .collect();
+        let crates: BTreeMap<_, _> = catalog
+            .crates()
+            .iter()
+            .map(|record| (record.name.as_str(), record))
+            .collect();
+
+        let mut steps = Vec::new();
+        for capability_id in &prerequisite_order {
+            let capability = capabilities.get(capability_id).ok_or_else(|| {
+                DiscoveryError::InvalidInput(format!(
+                    "candidate path references unknown capability `{capability_id}`"
+                ))
+            })?;
+            for package in &capability.crate_refs {
+                let record = crates.get(package.as_str()).ok_or_else(|| {
+                    DiscoveryError::CatalogCorruption(format!(
+                        "capability `{capability_id}` references unknown crate `{package}`"
+                    ))
+                })?;
+                steps.push(PlanStep::Dependency {
+                    capability_id: capability_id.clone(),
+                    package: package.clone(),
+                    version: record.version.clone(),
+                });
+            }
+            for reference in &capability.feature_refs {
+                let (package, feature) = split_catalog_reference(reference, "feature")?;
+                steps.push(PlanStep::Feature {
+                    capability_id: capability_id.clone(),
+                    package: package.to_owned(),
+                    feature: feature.to_owned(),
+                });
+            }
+            for path in &capability.symbol_refs {
+                steps.push(PlanStep::Symbol {
+                    capability_id: capability_id.clone(),
+                    path: path.clone(),
+                });
+            }
+            for reference in &capability.example_refs {
+                let (package, example) = split_catalog_reference(reference, "example")?;
+                steps.push(PlanStep::Example {
+                    capability_id: capability_id.clone(),
+                    package: package.to_owned(),
+                    example: example.to_owned(),
+                });
+            }
+            for probe_id in &capability.probe_refs {
+                steps.push(PlanStep::Probe {
+                    capability_id: capability_id.clone(),
+                    probe_id: probe_id.clone(),
+                });
+            }
+            for package in &capability.crate_refs {
+                steps.push(PlanStep::Test {
+                    capability_id: capability_id.clone(),
+                    package: package.clone(),
+                    target: PlanTestTarget::AllTargets,
+                });
+            }
+        }
+
+        let compatibility = compatibility(catalog, context)?;
+        let draft = CandidatePlan {
+            capability_id: candidate.capability_id.clone(),
+            prerequisite_order,
+            steps,
+            compatibility,
+            normalization: PlanNormalization::default(),
+            plan_hash: String::new(),
+        };
+        self.normalizer.normalize(&draft)
+    }
+}
+
+impl CandidatePlan {
+    /// Validates all replay-required hashes against current inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::ReplayDrift`] naming the first mismatched
+    /// catalog, project, input, or saved-probe hash field.
+    pub fn verify_replay(&self, actual: &PlanCompatibility) -> DiscoveryResult<()> {
+        compare_replay(
+            "catalog_version",
+            &self.compatibility.catalog.version,
+            &actual.catalog.version,
+        )?;
+        compare_replay(
+            "catalog_hash",
+            &self.compatibility.catalog.hash,
+            &actual.catalog.hash,
+        )?;
+        compare_replay(
+            "project_hash",
+            &self.compatibility.project_hash,
+            &actual.project_hash,
+        )?;
+        compare_replay(
+            "input_hash",
+            &self.compatibility.input_hash,
+            &actual.input_hash,
+        )?;
+        if self.compatibility.probe_results != actual.probe_results {
+            return Err(DiscoveryError::ReplayDrift {
+                field: "probe_results".to_owned(),
+                expected: hash_serializable(&self.compatibility.probe_results)?,
+                actual: hash_serializable(&actual.probe_results)?,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn prerequisite_order(candidate: &RankedCandidate) -> DiscoveryResult<Vec<CapabilityId>> {
+    if candidate.path.capabilities.is_empty()
+        || candidate.path.target != candidate.capability_id
+        || candidate.path.capabilities.last() != Some(&candidate.capability_id)
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "ranked candidate requires a nonempty path ending at its capability ID".to_owned(),
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    Ok(candidate
+        .path
+        .capabilities
+        .iter()
+        .filter(|capability| seen.insert((*capability).clone()))
+        .cloned()
+        .collect())
+}
+
+fn validate_goal(goal: &GoalSpec) -> DiscoveryResult<()> {
+    if goal.statement.trim().is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "planning goal statement must not be empty".to_owned(),
+        ));
+    }
+    if goal
+        .constraints
+        .iter()
+        .any(|constraint| constraint.trim().is_empty())
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "planning goal constraints must not be empty".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn split_catalog_reference<'a>(
+    reference: &'a str,
+    kind: &str,
+) -> DiscoveryResult<(&'a str, &'a str)> {
+    reference
+        .split_once(':')
+        .filter(|(package, item)| !package.is_empty() && !item.is_empty())
+        .ok_or_else(|| {
+            DiscoveryError::CatalogCorruption(format!("malformed {kind} reference `{reference}`"))
+        })
+}
+
+fn compatibility(
+    catalog: &Catalog,
+    context: &PlanningContext,
+) -> DiscoveryResult<PlanCompatibility> {
+    let mut probe_results = context
+        .probe_results
+        .iter()
+        .map(|result| {
+            Ok(ProbeReplayHash {
+                probe_id: result.probe_id.clone(),
+                input_hash: result.input_hash.clone(),
+                result_hash: hash_serializable(result)?,
+            })
+        })
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    probe_results.sort();
+    probe_results.dedup();
+
+    let mut constraints = context.goal.constraints.clone();
+    constraints.sort();
+    constraints.dedup();
+    let canonical_goal = CanonicalGoal {
+        statement: context.goal.statement.trim(),
+        constraints: &constraints,
+        probe_results: &probe_results,
+    };
+
+    Ok(PlanCompatibility {
+        catalog: CatalogIdentity {
+            version: catalog.version().to_owned(),
+            hash: catalog.content_hash().to_owned(),
+        },
+        project_hash: context.snapshot.project_hash.clone(),
+        input_hash: hash_serializable(&canonical_goal)?,
+        probe_results,
+    })
+}
+
+#[derive(Serialize)]
+struct CanonicalGoal<'a> {
+    statement: &'a str,
+    constraints: &'a [String],
+    probe_results: &'a [ProbeReplayHash],
+}
+
+fn compare_replay(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(DiscoveryError::ReplayDrift {
+            field: field.to_owned(),
+            expected: expected.to_owned(),
+            actual: actual.to_owned(),
+        })
+    }
+}
+
+pub(super) fn hash_serializable(value: &impl Serialize) -> DiscoveryResult<String> {
+    let bytes = serde_json::to_vec(value)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[derive(Serialize)]
+struct PlanHashView<'a> {
+    capability_id: &'a CapabilityId,
+    prerequisite_order: &'a [CapabilityId],
+    steps: &'a [PlanStep],
+    compatibility: &'a PlanCompatibility,
+}
+
+pub(super) fn compute_plan_hash(plan: &CandidatePlan) -> DiscoveryResult<String> {
+    hash_serializable(&PlanHashView {
+        capability_id: &plan.capability_id,
+        prerequisite_order: &plan.prerequisite_order,
+        steps: &plan.steps,
+        compatibility: &plan.compatibility,
+    })
+}

--- a/amari-discovery/src/protocol.rs
+++ b/amari-discovery/src/protocol.rs
@@ -6,7 +6,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 
-use crate::DiscoveryError;
+use crate::{DiscoveryError, ProjectSnapshot};
 
 fn is_canonical_id_segment(segment: &str) -> bool {
     let bytes = segment.as_bytes();
@@ -290,6 +290,187 @@ pub struct Evidence {
     pub source: Option<String>,
     /// Relative evidence weight used by ranking.
     pub weight: f64,
+}
+
+/// A normalized user goal supplied to the discovery planner.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GoalSpec {
+    /// Concise statement of the mathematical or integration goal.
+    pub statement: String,
+    /// Explicit deterministic constraints applied to the goal.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<String>,
+}
+
+/// Typed project, goal, and saved-probe inputs used to construct plans.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PlanningContext {
+    /// Sanitized read-only project snapshot.
+    pub snapshot: ProjectSnapshot,
+    /// Explicit planner goal.
+    pub goal: GoalSpec,
+    /// Saved bounded probe results considered during planning.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probe_results: Vec<ProbeResult>,
+}
+
+/// Replay hash for one saved probe result consumed by planning.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct ProbeReplayHash {
+    /// Registered probe identifier.
+    pub probe_id: ProbeId,
+    /// Canonical probe input hash.
+    pub input_hash: String,
+    /// SHA-256 hash of the serialized saved result.
+    pub result_hash: String,
+}
+
+/// Provenance that must match before a plan can be replayed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PlanCompatibility {
+    /// Catalog version and content hash used to construct the plan.
+    pub catalog: CatalogIdentity,
+    /// Inspected project hash used to construct the plan.
+    pub project_hash: String,
+    /// Canonical hash of the goal and saved probe inputs.
+    pub input_hash: String,
+    /// Canonical saved-probe result hashes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probe_results: Vec<ProbeReplayHash>,
+}
+
+/// Static test scope emitted by a plan.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanTestTarget {
+    /// Run every target belonging to the selected package.
+    AllTargets,
+}
+
+/// One read-only integration instruction in a candidate plan.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PlanStep {
+    /// Add an exact Amari package dependency.
+    Dependency {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Cargo package name.
+        package: String,
+        /// Exact catalog package version.
+        version: String,
+    },
+    /// Enable one exact package feature.
+    Feature {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Cargo package name.
+        package: String,
+        /// Cargo feature name.
+        feature: String,
+    },
+    /// Integrate one exact public symbol.
+    Symbol {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Fully qualified public symbol path.
+        path: String,
+    },
+    /// Consult or reproduce one checked-in example.
+    Example {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Cargo package name.
+        package: String,
+        /// Cargo example target name.
+        example: String,
+    },
+    /// Run one registered bounded probe.
+    Probe {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Registered probe identifier.
+        probe_id: ProbeId,
+    },
+    /// Verify one exact package test scope.
+    Test {
+        /// Capability requiring this step.
+        capability_id: CapabilityId,
+        /// Cargo package name.
+        package: String,
+        /// Static package test scope.
+        target: PlanTestTarget,
+    },
+}
+
+impl PlanStep {
+    /// Returns the capability that requires this integration step.
+    pub const fn capability_id(&self) -> &CapabilityId {
+        match self {
+            Self::Dependency { capability_id, .. }
+            | Self::Feature { capability_id, .. }
+            | Self::Symbol { capability_id, .. }
+            | Self::Example { capability_id, .. }
+            | Self::Probe { capability_id, .. }
+            | Self::Test { capability_id, .. } => capability_id,
+        }
+    }
+}
+
+/// One deterministic rewrite applied during plan normalization.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NormalizationTrace {
+    /// Plan steps immediately before the rewrite.
+    pub before: Vec<PlanStep>,
+    /// Plan steps immediately after the rewrite.
+    pub after: Vec<PlanStep>,
+}
+
+/// Completion and trace metadata for plan normalization.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PlanNormalization {
+    /// Whether the plan reached a rewrite fixed point within its limits.
+    pub normalized: bool,
+    /// Maximum rewrites allowed for this normalization attempt.
+    pub max_rewrites: usize,
+    /// Applied rewrites in deterministic order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace: Vec<NormalizationTrace>,
+}
+
+/// A deterministic replayable plan for one ranked capability path.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CandidatePlan {
+    /// Preferred catalog capability implemented by this plan.
+    pub capability_id: CapabilityId,
+    /// Canonical prerequisite-first capability order.
+    pub prerequisite_order: Vec<CapabilityId>,
+    /// Canonical deduplicated integration instructions.
+    pub steps: Vec<PlanStep>,
+    /// Required replay provenance.
+    pub compatibility: PlanCompatibility,
+    /// Bounded rewrite-normalization metadata.
+    pub normalization: PlanNormalization,
+    /// SHA-256 hash of canonical plan content excluding trace metadata.
+    pub plan_hash: String,
+}
+
+/// A preferred replayable plan and its Pareto alternatives.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Recommendation {
+    /// Goal used to generate the recommendation.
+    pub goal: GoalSpec,
+    /// Deterministically preferred plan.
+    pub preferred: CandidatePlan,
+    /// Other retained Pareto plans.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub alternatives: Vec<CandidatePlan>,
+    /// Evidence shared by the recommendation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<Evidence>,
+    /// Non-fatal planner warnings.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 /// A successful typed domain outcome.

--- a/amari-discovery/tests/plan_normalization.rs
+++ b/amari-discovery/tests/plan_normalization.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use amari_discovery::{
+    CandidatePlan, CapabilityId, Catalog, DiscoveryError, GoalSpec, GraphPath, NormalizationLimits,
+    PlanGenerator, PlanNormalization, PlanNormalizer, PlanStep, PlanTestTarget, PlanningContext,
+    ProjectKind, ProjectSnapshot, RankedCandidate, RankingComponents, SnapshotState,
+};
+
+fn id(value: &str) -> CapabilityId {
+    value.parse().unwrap()
+}
+
+fn snapshot(project_hash: &str) -> ProjectSnapshot {
+    ProjectSnapshot {
+        project_hash: project_hash.to_owned(),
+        project_kind: ProjectKind::RustCargo,
+        signals: Vec::new(),
+        cargo: None,
+        rust: None,
+        platform: None,
+        npm: None,
+        typescript: None,
+        file_count: 0,
+        total_bytes: 0,
+        state: SnapshotState::Complete,
+        warnings: Vec::new(),
+        files: Vec::new(),
+    }
+}
+
+fn context(project_hash: &str) -> PlanningContext {
+    PlanningContext {
+        snapshot: snapshot(project_hash),
+        goal: GoalSpec {
+            statement: "differentiate a scalar polynomial".to_owned(),
+            constraints: vec!["offline".to_owned(), "cpu-only".to_owned()],
+        },
+        probe_results: Vec::new(),
+    }
+}
+
+fn ranked(capabilities: &[CapabilityId]) -> RankedCandidate {
+    let target = capabilities.last().unwrap().clone();
+    RankedCandidate {
+        capability_id: target.clone(),
+        path: GraphPath {
+            target,
+            source_seed: capabilities[0].clone(),
+            capabilities: capabilities.to_vec(),
+            steps: Vec::new(),
+            total_cost: 0.0,
+        },
+        components: RankingComponents {
+            applicability: 1.0,
+            evidence: 0.8,
+            effort: 0.2,
+            maturity: 1.0,
+            runtime: 0.2,
+            platform: 1.0,
+            verification: 0.5,
+            risk: 0.1,
+        },
+        objectives: [0.0, 0.2, 0.2, 0.0, 0.2, 0.0, 0.5, 0.1],
+        confidence: 0.8,
+        evidence: Vec::new(),
+        validated_assumptions: Vec::new(),
+    }
+}
+
+fn generated_dual_plan() -> CandidatePlan {
+    let catalog = Catalog::embedded().unwrap();
+    let target = id("amari:amari-dual:autodiff:forward-derivative");
+    PlanGenerator::default()
+        .generate(&catalog, &context("project-plan"), &ranked(&[target]))
+        .unwrap()
+}
+
+fn pending_with_steps(plan: &CandidatePlan, steps: Vec<PlanStep>) -> CandidatePlan {
+    CandidatePlan {
+        steps,
+        plan_hash: String::new(),
+        normalization: PlanNormalization::default(),
+        ..plan.clone()
+    }
+}
+
+#[test]
+fn generated_plan_contains_exact_catalog_actions_and_replay_hashes() {
+    let catalog = Catalog::embedded().unwrap();
+    let target = id("amari:amari-dual:autodiff:forward-derivative");
+    let plan = PlanGenerator::default()
+        .generate(
+            &catalog,
+            &context("project-exact"),
+            &ranked(std::slice::from_ref(&target)),
+        )
+        .unwrap();
+    let version = catalog
+        .crates()
+        .iter()
+        .find(|record| record.name == "amari-dual")
+        .unwrap()
+        .version
+        .clone();
+
+    assert_eq!(plan.capability_id, target.clone());
+    assert_eq!(plan.prerequisite_order, vec![target.clone()]);
+    assert!(plan.steps.contains(&PlanStep::Dependency {
+        capability_id: target.clone(),
+        package: "amari-dual".to_owned(),
+        version,
+    }));
+    assert!(plan.steps.contains(&PlanStep::Feature {
+        capability_id: target.clone(),
+        package: "amari-dual".to_owned(),
+        feature: "std".to_owned(),
+    }));
+    assert!(plan.steps.contains(&PlanStep::Symbol {
+        capability_id: target.clone(),
+        path: "amari_dual::DualNumber::derivative".to_owned(),
+    }));
+    assert!(plan.steps.contains(&PlanStep::Example {
+        capability_id: target.clone(),
+        package: "amari-dual".to_owned(),
+        example: "gradient_seeding".to_owned(),
+    }));
+    assert!(plan.steps.contains(&PlanStep::Probe {
+        capability_id: target.clone(),
+        probe_id: "amari-probe:dual:polynomial-derivative:v1".parse().unwrap(),
+    }));
+    assert!(plan.steps.contains(&PlanStep::Test {
+        capability_id: target,
+        package: "amari-dual".to_owned(),
+        target: PlanTestTarget::AllTargets,
+    }));
+    assert_eq!(plan.compatibility.catalog.version, catalog.version());
+    assert_eq!(plan.compatibility.catalog.hash, catalog.content_hash());
+    assert_eq!(plan.compatibility.project_hash, "project-exact");
+    assert_eq!(plan.compatibility.input_hash.len(), 64);
+    assert_eq!(plan.plan_hash.len(), 64);
+    assert!(plan.normalization.normalized);
+}
+
+#[test]
+fn duplicate_steps_normalize_once_with_a_bounded_trace() {
+    let generated = generated_dual_plan();
+    let dependency = generated
+        .steps
+        .iter()
+        .find(|step| matches!(step, PlanStep::Dependency { .. }))
+        .unwrap()
+        .clone();
+    let feature = generated
+        .steps
+        .iter()
+        .find(|step| matches!(step, PlanStep::Feature { .. }))
+        .unwrap()
+        .clone();
+    let test = generated
+        .steps
+        .iter()
+        .find(|step| matches!(step, PlanStep::Test { .. }))
+        .unwrap()
+        .clone();
+    let raw = pending_with_steps(
+        &generated,
+        vec![
+            test.clone(),
+            feature.clone(),
+            dependency.clone(),
+            feature.clone(),
+            dependency.clone(),
+        ],
+    );
+    let normalizer = PlanNormalizer::new(NormalizationLimits {
+        max_plan_steps: 16,
+        max_rewrites: 8,
+    })
+    .unwrap();
+
+    let normalized = normalizer.normalize(&raw).unwrap();
+
+    assert_eq!(normalized.steps, vec![dependency, feature, test]);
+    assert!(normalized.normalization.normalized);
+    assert!(!normalized.normalization.trace.is_empty());
+    assert!(normalized.normalization.trace.len() <= 8);
+    assert!(normalized
+        .normalization
+        .trace
+        .iter()
+        .all(|rewrite| rewrite.before != rewrite.after));
+    assert_eq!(normalizer.normalize(&normalized).unwrap(), normalized);
+}
+
+#[test]
+fn prerequisite_capabilities_have_canonical_step_order() {
+    let catalog = Catalog::embedded().unwrap();
+    let prerequisite = id("amari:amari-dual:autodiff:forward-derivative");
+    let target = id("amari:amari-network:paths:geometric-shortest-path");
+    let plan = PlanGenerator::default()
+        .generate(
+            &catalog,
+            &context("project-order"),
+            &ranked(&[prerequisite.clone(), target.clone()]),
+        )
+        .unwrap();
+
+    assert_eq!(
+        plan.prerequisite_order,
+        vec![prerequisite.clone(), target.clone()]
+    );
+    let last_prerequisite = plan
+        .steps
+        .iter()
+        .rposition(|step| step.capability_id() == &prerequisite)
+        .unwrap();
+    let first_target = plan
+        .steps
+        .iter()
+        .position(|step| step.capability_id() == &target)
+        .unwrap();
+    assert!(last_prerequisite < first_target);
+}
+
+#[test]
+fn normalization_rejects_step_and_rewrite_limit_exhaustion() {
+    let generated = generated_dual_plan();
+    let mut reversed = generated.steps.clone();
+    reversed.reverse();
+    let raw = pending_with_steps(&generated, reversed);
+
+    let step_limited = PlanNormalizer::new(NormalizationLimits {
+        max_plan_steps: generated.steps.len() - 1,
+        max_rewrites: 128,
+    })
+    .unwrap();
+    assert!(matches!(
+        step_limited.normalize(&raw),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("plan steps")
+    ));
+
+    let rewrite_limited = PlanNormalizer::new(NormalizationLimits {
+        max_plan_steps: 64,
+        max_rewrites: 1,
+    })
+    .unwrap();
+    assert!(matches!(
+        rewrite_limited.normalize(&raw),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("rewrite")
+    ));
+}
+
+#[test]
+fn replay_rejects_project_catalog_and_input_drift_with_typed_errors() {
+    let plan = generated_dual_plan();
+
+    for (field, replacement) in [
+        ("project_hash", "different-project"),
+        ("catalog_hash", "different-catalog"),
+        ("input_hash", "different-input"),
+    ] {
+        let mut actual = plan.compatibility.clone();
+        match field {
+            "project_hash" => actual.project_hash = replacement.to_owned(),
+            "catalog_hash" => actual.catalog.hash = replacement.to_owned(),
+            "input_hash" => actual.input_hash = replacement.to_owned(),
+            _ => unreachable!(),
+        }
+        assert!(matches!(
+            plan.verify_replay(&actual),
+            Err(DiscoveryError::ReplayDrift { field: drifted, .. }) if drifted == field
+        ));
+    }
+
+    assert!(plan.verify_replay(&plan.compatibility).is_ok());
+}
+
+#[test]
+fn generator_threads_explicit_normalization_limits() {
+    let catalog = Catalog::embedded().unwrap();
+    let target = id("amari:amari-dual:autodiff:forward-derivative");
+    let generator = PlanGenerator::new(NormalizationLimits {
+        max_plan_steps: 1,
+        max_rewrites: 8,
+    })
+    .unwrap();
+
+    assert!(matches!(
+        generator.generate(
+            &catalog,
+            &context("project-generator-limit"),
+            &ranked(&[target]),
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("plan steps")
+    ));
+}
+
+#[test]
+fn generation_and_normalization_are_byte_deterministic() {
+    let first = generated_dual_plan();
+    let second = generated_dual_plan();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        serde_json::to_vec(&first).unwrap(),
+        serde_json::to_vec(&second).unwrap()
+    );
+}


### PR DESCRIPTION
## Summary

- add typed `GoalSpec`, `PlanningContext`, `CandidatePlan`, `PlanStep`, `Recommendation`, normalization trace, and replay-compatibility protocol records
- generate exact catalog-backed dependency, feature, symbol, example, probe, and package-test steps for ranked capability paths
- normalize plans through explicit discovery-local `amari-rewrite` terms and rules, with deterministic prerequisite ordering and duplicate elimination
- hash canonical plan, goal, project, catalog, and saved-probe inputs for replay validation
- reject project/catalog/input/probe drift with typed `ReplayDrift` errors

## Determinism and bounds

- plan normalization is bounded by configurable plan-step and rewrite limits
- encoded public input is capped at 1 MiB
- every `TermSystem::apply_once` transition retains a typed before/after trace
- normalized plans are byte deterministic and repeated normalization is idempotent
- generator limits are configurable through `PlanGenerator::new`
- no project command, build script, provider, network operation, or project code is executed

## Test plan

- [x] exact catalog crates, versions, features, symbols, examples, probes, and tests
- [x] duplicate dependency and feature elimination
- [x] canonical prerequisite-first ordering
- [x] bounded step/rewrite exhaustion
- [x] project, catalog, and input drift rejection
- [x] byte-deterministic generation and normalization idempotence
- [x] configurable generator limits
- [x] full `amari-discovery` all-feature matrix
- [x] full `amari-discovery` no-default-feature matrix
- [x] scoped Clippy for both feature configurations with warnings denied
- [x] rustdoc for both feature configurations with warnings denied
- [x] formatting and diff checks
- [x] independent DeepSeek production-readiness review

Implements Task 13 from `docs/plans/2026-07-09-amari-discovery-implementation-plan.md`.
