### PR TITLE
feat: recommend Amari integrations for Rust projects

### DIFF
--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -7,7 +7,7 @@ use std::{io, path::PathBuf};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::inspect::{inspect_project_envelope, InspectionLimits};
-use crate::{commands, render, Capabilities, Catalog, DiscoveryError, DiscoveryResult};
+use crate::{commands, render, Capabilities, Catalog, DiscoveryError, DiscoveryResult, GoalSpec};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -51,6 +51,9 @@ enum Command {
         /// Path to a typed goal JSON document.
         #[arg(long, conflicts_with = "goal")]
         goal_file: Option<PathBuf>,
+        /// Path to a bounded JSON array of saved probe results.
+        #[arg(long, value_name = "FILE")]
+        probe_results: Option<PathBuf>,
     },
     /// Normalize a saved recommendation candidate into a replayable plan.
     Plan {
@@ -153,8 +156,9 @@ impl Command {
                 path,
                 goal,
                 goal_file,
+                probe_results,
             } => {
-                let _ = (path, goal, goal_file);
+                let _ = (path, goal, goal_file, probe_results);
                 "recommend"
             }
             Self::Plan {
@@ -245,6 +249,12 @@ pub fn run() -> DiscoveryResult<()> {
             run_discover(&catalog, command, cli.json)
         }
         Command::Inspect { path } => run_inspect(path, cli.json),
+        Command::Recommend {
+            path,
+            goal,
+            goal_file,
+            probe_results,
+        } => run_recommend(path, goal, goal_file, probe_results, cli.json),
         command => Err(DiscoveryError::NotImplemented(format!(
             "{} is not implemented in this build",
             command.unavailable_name()
@@ -264,6 +274,49 @@ fn run_inspect(path: Option<PathBuf>, json: bool) -> DiscoveryResult<()> {
         render::write_json(&mut stdout, &envelope)
     } else {
         render::write_inspection_human(&mut stdout, &envelope)
+    }
+}
+
+/// Runs deterministic recommendation for a Rust/Cargo project.
+fn run_recommend(
+    path: Option<PathBuf>,
+    goal: Option<String>,
+    goal_file: Option<PathBuf>,
+    probe_results: Option<PathBuf>,
+    json: bool,
+) -> DiscoveryResult<()> {
+    if goal_file.is_some() {
+        return Err(DiscoveryError::NotImplemented(
+            "recommend --goal-file is added in the TypeScript parity slice".to_owned(),
+        ));
+    }
+    let statement = goal.ok_or_else(|| {
+        DiscoveryError::InvalidInput("recommend requires an inline --goal".to_owned())
+    })?;
+    let root = match path {
+        Some(path) => path,
+        None => std::env::current_dir()?,
+    };
+    let saved_probes = match probe_results {
+        Some(path) => commands::recommend::read_probe_results(&path)?,
+        None => Vec::new(),
+    };
+    let catalog = Catalog::embedded()?;
+    let envelope = commands::recommend::recommend_rust_envelope(
+        &catalog,
+        &root,
+        GoalSpec {
+            statement,
+            constraints: Vec::new(),
+        },
+        saved_probes,
+        &InspectionLimits::default(),
+    )?;
+    let mut stdout = io::stdout().lock();
+    if json {
+        render::write_json(&mut stdout, &envelope)
+    } else {
+        render::write_recommendation_human(&mut stdout, &envelope)
     }
 }
 

--- a/amari-discovery/src/commands/mod.rs
+++ b/amari-discovery/src/commands/mod.rs
@@ -7,3 +7,4 @@
 //! in the render module.
 
 pub mod discover;
+pub mod recommend;

--- a/amari-discovery/src/commands/recommend.rs
+++ b/amari-discovery/src/commands/recommend.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed Rust-project recommendation pipeline.
+
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use crate::inspect::{
+    inspect_rust_project, nofollow_open_readonly, snapshot_compatibility, InspectionLimits,
+    NofollowResult,
+};
+use crate::{
+    CandidateRanker, CandidateRetriever, CapabilityGraphExpander, Catalog, CatalogIdentity,
+    DiscoveryError, DiscoveryOutcome, DiscoveryResult, Envelope, Evidence, GoalSpec,
+    GraphConstraints, GraphExpansionState, PlanCompatibility, PlanGenerator, PlanStep,
+    PlanningContext, ProbeId, ProbeResult, ProjectKind, RankedCandidate, RankingContext,
+    RecallConfig, Recommendation, RecommendationScore, RecommendationScoreComponents,
+    ReplayMetadata, SnapshotState, SCHEMA_V1,
+};
+
+const MAX_PROBE_RESULTS_BYTES: u64 = 1_048_576;
+const MAX_PROBE_RESULTS: usize = 256;
+const MAX_ALTERNATIVES: usize = 7;
+
+/// Reads a bounded JSON array of saved [`ProbeResult`] values.
+///
+/// The selected path must be a regular file no larger than one mebibyte.
+/// Project files are never modified and probe code is never executed.
+///
+/// # Errors
+///
+/// Returns [`DiscoveryError::InvalidInput`] for non-regular or oversized
+/// inputs, an I/O error when the file cannot be read, or a serialization error
+/// for malformed JSON.
+pub fn read_probe_results(path: &Path) -> DiscoveryResult<Vec<ProbeResult>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(DiscoveryError::InvalidInput(
+            "probe-results input must be a regular file".to_owned(),
+        ));
+    }
+    if metadata.len() > MAX_PROBE_RESULTS_BYTES {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "probe-results bytes {} exceed limit {MAX_PROBE_RESULTS_BYTES}",
+            metadata.len()
+        )));
+    }
+    let mut file = match nofollow_open_readonly(path)? {
+        NofollowResult::Opened(file) => file,
+        NofollowResult::SymlinkOrRace => {
+            return Err(DiscoveryError::InvalidInput(
+                "probe-results input must not be a symlink or replaced file".to_owned(),
+            ));
+        }
+    };
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take(MAX_PROBE_RESULTS_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_PROBE_RESULTS_BYTES {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "probe-results bytes {} exceed limit {MAX_PROBE_RESULTS_BYTES}",
+            bytes.len()
+        )));
+    }
+    let results: Vec<ProbeResult> = serde_json::from_slice(&bytes)?;
+    if results.len() > MAX_PROBE_RESULTS {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "probe-results count {} exceeds limit {MAX_PROBE_RESULTS}",
+            results.len()
+        )));
+    }
+    Ok(results)
+}
+
+/// Runs the deterministic Rust inspect → recall → graph → rank → plan pipeline.
+///
+/// The operation is read-only and offline. It does not invoke Cargo, rustc,
+/// build scripts, project code, a shell, providers, probes, or the network.
+/// Saved probe results are treated only as provenance-checked typed evidence.
+///
+/// # Errors
+///
+/// Returns a typed inspection, planner, catalog, or normalization error. npm-only
+/// and unknown project roots are rejected until their dedicated vertical slice.
+pub fn recommend_rust_envelope(
+    catalog: &Catalog,
+    project_root: &Path,
+    goal: GoalSpec,
+    probe_results: Vec<ProbeResult>,
+    limits: &InspectionLimits,
+) -> DiscoveryResult<Envelope<DiscoveryOutcome<Recommendation>>> {
+    if goal.statement.trim().is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "recommendation goal must not be empty".to_owned(),
+        ));
+    }
+
+    let snapshot = inspect_rust_project(project_root, limits)?;
+    if !matches!(
+        snapshot.project_kind,
+        ProjectKind::RustCargo | ProjectKind::Mixed
+    ) {
+        return Err(DiscoveryError::InvalidInput(
+            "recommend currently requires a Rust/Cargo project".to_owned(),
+        ));
+    }
+    let compatibility = snapshot_compatibility(&snapshot);
+    let planning_context = PlanningContext {
+        snapshot,
+        goal: goal.clone(),
+        probe_results,
+    };
+    let plan_compatibility = PlanCompatibility::from_context(catalog, &planning_context)?;
+    let recall_config = RecallConfig::default();
+    let recalled = CandidateRetriever::new(recall_config).retrieve(
+        catalog,
+        &planning_context.snapshot,
+        &goal.statement,
+    )?;
+
+    if recalled.is_empty() {
+        return Ok(outcome_envelope(
+            catalog,
+            &planning_context,
+            compatibility,
+            plan_compatibility.input_hash.clone(),
+            recall_config.seed,
+            Vec::new(),
+            DiscoveryOutcome::InsufficientEvidence {
+                missing: vec!["goal and project evidence matched no catalog capability".to_owned()],
+            },
+        ));
+    }
+
+    let seeds = recalled
+        .iter()
+        .map(|candidate| candidate.capability_id.clone())
+        .collect::<Vec<_>>();
+    let graph =
+        CapabilityGraphExpander::default().expand(catalog, &seeds, &GraphConstraints::default())?;
+    let ranking = CandidateRanker::default().rank(
+        catalog,
+        &graph,
+        &recalled,
+        &planning_context.snapshot,
+        &RankingContext {
+            probe_results: planning_context.probe_results.clone(),
+            ..RankingContext::default()
+        },
+    )?;
+
+    let Some(preferred_ranked) = ranking.preferred.as_ref() else {
+        let warnings = ranking.warnings;
+        let outcome = if ranking.blocked.is_empty() {
+            DiscoveryOutcome::NoApplicableCapability {
+                evidence: recalled
+                    .iter()
+                    .map(|candidate| Evidence {
+                        kind: "candidate_recall".to_owned(),
+                        summary: format!(
+                            "{} recall score {:.12}",
+                            candidate.capability_id, candidate.retrieval_score
+                        ),
+                        source: Some(candidate.capability_id.to_string()),
+                        weight: candidate.retrieval_score,
+                    })
+                    .collect(),
+            }
+        } else {
+            DiscoveryOutcome::Blocked {
+                reasons: ranking
+                    .blocked
+                    .iter()
+                    .flat_map(|candidate| {
+                        candidate
+                            .reasons
+                            .iter()
+                            .map(|reason| format!("{}:{reason}", candidate.capability_id))
+                    })
+                    .collect(),
+            }
+        };
+        return Ok(outcome_envelope(
+            catalog,
+            &planning_context,
+            compatibility,
+            plan_compatibility.input_hash.clone(),
+            recall_config.seed,
+            warnings,
+            outcome,
+        ));
+    };
+
+    let generator = PlanGenerator::default();
+    let preferred = generator.generate(catalog, &planning_context, preferred_ranked)?;
+    let alternative_ranked = ranking
+        .pareto
+        .iter()
+        .filter(|candidate| candidate.capability_id != preferred_ranked.capability_id)
+        .take(MAX_ALTERNATIVES)
+        .collect::<Vec<_>>();
+    let alternatives = alternative_ranked
+        .iter()
+        .map(|candidate| generator.generate(catalog, &planning_context, candidate))
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+
+    let mut selected_ranked = vec![preferred_ranked];
+    selected_ranked.extend(alternative_ranked);
+    let scores = selected_ranked
+        .into_iter()
+        .map(recommendation_score)
+        .collect();
+    let suggested_probes = preferred
+        .steps
+        .iter()
+        .filter_map(|step| match step {
+            PlanStep::Probe { probe_id, .. } => Some(probe_id.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let suggested_tests = preferred
+        .steps
+        .iter()
+        .filter(|step| matches!(step, PlanStep::Test { .. }))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_information = missing_information(
+        catalog,
+        &planning_context,
+        preferred_ranked,
+        &suggested_probes,
+        &graph.state,
+    );
+    let evidence = preferred_ranked.evidence.clone();
+    let mut warnings = planning_context.snapshot.warnings.clone();
+    warnings.extend(ranking.warnings.clone());
+    if ranking.pareto.len().saturating_sub(1) > MAX_ALTERNATIVES {
+        warnings.push(format!(
+            "pareto alternatives truncated to {MAX_ALTERNATIVES}"
+        ));
+    }
+    warnings.sort();
+    warnings.dedup();
+
+    let input_hash = plan_compatibility.input_hash;
+    let recommendation = Recommendation {
+        goal,
+        preferred,
+        alternatives,
+        scores,
+        evidence,
+        missing_information,
+        suggested_probes,
+        suggested_tests,
+        warnings: warnings.clone(),
+    };
+    Ok(outcome_envelope(
+        catalog,
+        &planning_context,
+        compatibility,
+        input_hash,
+        recall_config.seed,
+        warnings,
+        DiscoveryOutcome::Recommended(recommendation),
+    ))
+}
+
+fn recommendation_score(candidate: &RankedCandidate) -> RecommendationScore {
+    RecommendationScore {
+        capability_id: candidate.capability_id.clone(),
+        components: RecommendationScoreComponents {
+            applicability: candidate.components.applicability,
+            evidence: candidate.components.evidence,
+            effort: candidate.components.effort,
+            maturity: candidate.components.maturity,
+            runtime: candidate.components.runtime,
+            platform: candidate.components.platform,
+            verification: candidate.components.verification,
+            risk: candidate.components.risk,
+        },
+        objectives: candidate.objectives,
+        confidence: candidate.confidence,
+        evidence: candidate.evidence.clone(),
+        validated_assumptions: candidate.validated_assumptions.clone(),
+    }
+}
+
+fn missing_information(
+    catalog: &Catalog,
+    context: &PlanningContext,
+    preferred: &RankedCandidate,
+    probes: &[ProbeId],
+    graph_state: &GraphExpansionState,
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    if !matches!(context.snapshot.state, SnapshotState::Complete) {
+        missing.push("project_inspection_partial".to_owned());
+    }
+    if !matches!(graph_state, GraphExpansionState::Complete) {
+        missing.push("capability_graph_partial".to_owned());
+    }
+    for probe_id in probes {
+        let matched = context.probe_results.iter().any(|result| {
+            result.probe_id == *probe_id
+                && result.catalog_hash == catalog.content_hash()
+                && result.project_hash.as_deref() == Some(context.snapshot.project_hash.as_str())
+        });
+        if !matched {
+            missing.push(format!("missing_probe_result:{probe_id}"));
+        }
+    }
+    if preferred.components.verification < 1.0 {
+        missing.push(format!("verification_partial:{}", preferred.capability_id));
+    }
+    missing.sort();
+    missing.dedup();
+    missing
+}
+
+fn outcome_envelope<T>(
+    catalog: &Catalog,
+    context: &PlanningContext,
+    compatibility: crate::Compatibility,
+    input_hash: String,
+    seed: u64,
+    mut warnings: Vec<String>,
+    data: T,
+) -> Envelope<T> {
+    warnings.sort();
+    warnings.dedup();
+    Envelope {
+        schema_version: SCHEMA_V1.to_owned(),
+        provenance: crate::Provenance {
+            tool_version: env!("CARGO_PKG_VERSION").to_owned(),
+            catalog: CatalogIdentity {
+                version: catalog.version().to_owned(),
+                hash: catalog.content_hash().to_owned(),
+            },
+            compatibility,
+            replay: ReplayMetadata {
+                replayable: true,
+                required_hashes: vec![
+                    "catalog_hash".to_owned(),
+                    "project_hash".to_owned(),
+                    "input_hash".to_owned(),
+                    "probe_results".to_owned(),
+                ],
+                reasons: Vec::new(),
+            },
+            project_hash: Some(context.snapshot.project_hash.clone()),
+            input_hash: Some(input_hash),
+            seed: Some(seed),
+        },
+        warnings,
+        data,
+    }
+}

--- a/amari-discovery/src/inspect/mod.rs
+++ b/amari-discovery/src/inspect/mod.rs
@@ -98,7 +98,7 @@ pub(super) fn is_env_secret_name(name: &str) -> bool {
 
 /// Result of opening a file with [`nofollow_open_readonly`].
 #[derive(Debug)]
-pub(super) enum NofollowResult {
+pub(crate) enum NofollowResult {
     /// The file was opened successfully and is a regular file.
     Opened(fs::File),
     /// The path was a symlink (or a replacement race was detected) —
@@ -125,7 +125,7 @@ pub(super) enum NofollowResult {
 /// The caller is responsible for path-based containment checks before
 /// calling this function. Errors from this function never expose external
 /// symlink targets or absolute paths.
-pub(super) fn nofollow_open_readonly(path: &Path) -> std::io::Result<NofollowResult> {
+pub(crate) fn nofollow_open_readonly(path: &Path) -> std::io::Result<NofollowResult> {
     #[cfg(unix)]
     {
         use rustix::fs::{open, Mode, OFlags};
@@ -1049,7 +1049,7 @@ pub fn inspect_project_envelope(
 }
 
 /// Aggregate dependency compatibility into one project-level verdict.
-fn snapshot_compatibility(snapshot: &ProjectSnapshot) -> Compatibility {
+pub(crate) fn snapshot_compatibility(snapshot: &ProjectSnapshot) -> Compatibility {
     let mut saw_dependency = false;
     let mut saw_unknown_version = false;
     let mut reasons = Vec::new();

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -84,5 +84,6 @@ pub use protocol::{
     CandidatePlan, CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope,
     Evidence, GoalSpec, NormalizationTrace, PlanCompatibility, PlanNormalization, PlanStep,
     PlanTestTarget, PlanningContext, ProbeBackend, ProbeId, ProbeReplayHash, ProbeResult,
-    Provenance, Recommendation, ReplayMetadata, ResourceObservations, SchemaVersion, SCHEMA_V1,
+    Provenance, Recommendation, RecommendationScore, RecommendationScoreComponents, ReplayMetadata,
+    ResourceObservations, SchemaVersion, SCHEMA_V1,
 };

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -119,7 +119,7 @@ impl PlanGenerator {
             }
         }
 
-        let compatibility = compatibility(catalog, context)?;
+        let compatibility = PlanCompatibility::from_context(catalog, context)?;
         let draft = CandidatePlan {
             capability_id: candidate.capability_id.clone(),
             prerequisite_order,
@@ -129,6 +129,21 @@ impl PlanGenerator {
             plan_hash: String::new(),
         };
         self.normalizer.normalize(&draft)
+    }
+}
+
+impl PlanCompatibility {
+    /// Computes canonical catalog, project, goal, and saved-probe replay hashes.
+    ///
+    /// This constructor is shared by recommendation envelopes and generated
+    /// plans so every outcome uses one stable `input_hash` definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error if typed goal or probe evidence cannot be
+    /// encoded for deterministic hashing.
+    pub fn from_context(catalog: &Catalog, context: &PlanningContext) -> DiscoveryResult<Self> {
+        compatibility(catalog, context)
     }
 }
 

--- a/amari-discovery/src/protocol.rs
+++ b/amari-discovery/src/protocol.rs
@@ -455,6 +455,45 @@ pub struct CandidatePlan {
     pub plan_hash: String,
 }
 
+/// Transparent normalized score components for one recommended capability.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RecommendationScoreComponents {
+    /// Project and prerequisite applicability; higher is better.
+    pub applicability: f64,
+    /// Recall, project, and probe evidence strength; higher is better.
+    pub evidence: f64,
+    /// Relative integration effort; lower is better.
+    pub effort: f64,
+    /// API maturity; higher is better.
+    pub maturity: f64,
+    /// Relative runtime cost; lower is better.
+    pub runtime: f64,
+    /// Project platform compatibility; higher is better.
+    pub platform: f64,
+    /// Matching bounded verification strength; higher is better.
+    pub verification: f64,
+    /// Uncertainty and integration risk; lower is better.
+    pub risk: f64,
+}
+
+/// Score, evidence, and assumptions for one recommendation candidate.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RecommendationScore {
+    /// Stable catalog capability ID.
+    pub capability_id: CapabilityId,
+    /// Human-facing normalized score components.
+    pub components: RecommendationScoreComponents,
+    /// Canonical all-minimization Pareto objective vector.
+    pub objectives: [f64; 8],
+    /// Deterministic confidence summary.
+    pub confidence: f64,
+    /// Typed evidence contributing to this score.
+    pub evidence: Vec<Evidence>,
+    /// Probe assumptions validated for this candidate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validated_assumptions: Vec<String>,
+}
+
 /// A preferred replayable plan and its Pareto alternatives.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Recommendation {
@@ -462,12 +501,23 @@ pub struct Recommendation {
     pub goal: GoalSpec,
     /// Deterministically preferred plan.
     pub preferred: CandidatePlan,
-    /// Other retained Pareto plans.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Other retained Pareto plans (empty when the front is a singleton).
+    #[serde(default)]
     pub alternatives: Vec<CandidatePlan>,
-    /// Evidence shared by the recommendation.
+    /// Transparent scores for the preferred plan and emitted alternatives.
+    pub scores: Vec<RecommendationScore>,
+    /// Evidence supporting the preferred recommendation.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<Evidence>,
+    /// Evidence or validation still needed for the preferred plan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_information: Vec<String>,
+    /// Registered probes suggested for the preferred plan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggested_probes: Vec<ProbeId>,
+    /// Static package tests suggested for the preferred plan.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suggested_tests: Vec<PlanStep>,
     /// Non-fatal planner warnings.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -8,7 +8,8 @@ use serde::Serialize;
 
 use crate::{
     commands::discover::{ExampleResult, GraphResult, SearchResults},
-    Capabilities, CapabilityRecord, DiscoveryResult, Envelope, ProjectKind, ProjectSnapshot,
+    Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope, PlanStep,
+    ProjectKind, ProjectSnapshot, Recommendation,
 };
 
 pub(crate) fn write_json<T: Serialize>(
@@ -168,6 +169,104 @@ pub(crate) fn write_inspection_human(
         )?;
     }
     writeln!(writer, "  Warnings: {}", envelope.warnings.len())?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Recommend
+// ---------------------------------------------------------------------------
+
+pub(crate) fn write_recommendation_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<DiscoveryOutcome<Recommendation>>,
+) -> DiscoveryResult<()> {
+    match &envelope.data {
+        DiscoveryOutcome::Recommended(recommendation) => {
+            writeln!(
+                writer,
+                "Recommendation for: {}",
+                recommendation.goal.statement
+            )?;
+            writeln!(
+                writer,
+                "Preferred: {}",
+                recommendation.preferred.capability_id
+            )?;
+            writeln!(writer, "Plan hash: {}", recommendation.preferred.plan_hash)?;
+            if let Some(score) = recommendation
+                .scores
+                .iter()
+                .find(|score| score.capability_id == recommendation.preferred.capability_id)
+            {
+                writeln!(writer, "Confidence: {:.12}", score.confidence)?;
+                writeln!(writer, "Scores:")?;
+                writeln!(
+                    writer,
+                    "  applicability: {:.12}",
+                    score.components.applicability
+                )?;
+                writeln!(writer, "  evidence: {:.12}", score.components.evidence)?;
+                writeln!(writer, "  effort: {:.12}", score.components.effort)?;
+                writeln!(writer, "  maturity: {:.12}", score.components.maturity)?;
+                writeln!(writer, "  runtime: {:.12}", score.components.runtime)?;
+                writeln!(writer, "  platform: {:.12}", score.components.platform)?;
+                writeln!(
+                    writer,
+                    "  verification: {:.12}",
+                    score.components.verification
+                )?;
+                writeln!(writer, "  risk: {:.12}", score.components.risk)?;
+            }
+            writeln!(writer, "Evidence:")?;
+            for evidence in &recommendation.evidence {
+                writeln!(writer, "  {}", evidence.summary)?;
+            }
+            writeln!(writer, "Missing information:")?;
+            for missing in &recommendation.missing_information {
+                writeln!(writer, "  {missing}")?;
+            }
+            writeln!(writer, "Suggested probes:")?;
+            for probe_id in &recommendation.suggested_probes {
+                writeln!(writer, "  {probe_id}")?;
+            }
+            writeln!(writer, "Suggested tests:")?;
+            for step in &recommendation.suggested_tests {
+                if let PlanStep::Test {
+                    package, target, ..
+                } = step
+                {
+                    let target = match target {
+                        crate::PlanTestTarget::AllTargets => "all targets",
+                    };
+                    writeln!(writer, "  {package}: {target}")?;
+                }
+            }
+            if !recommendation.alternatives.is_empty() {
+                writeln!(writer, "Alternatives:")?;
+                for alternative in &recommendation.alternatives {
+                    writeln!(writer, "  {}", alternative.capability_id)?;
+                }
+            }
+        }
+        DiscoveryOutcome::NoApplicableCapability { evidence } => {
+            writeln!(writer, "No applicable Amari capability.")?;
+            for item in evidence {
+                writeln!(writer, "  {}", item.summary)?;
+            }
+        }
+        DiscoveryOutcome::InsufficientEvidence { missing } => {
+            writeln!(writer, "Insufficient evidence for a recommendation.")?;
+            for item in missing {
+                writeln!(writer, "  {item}")?;
+            }
+        }
+        DiscoveryOutcome::Blocked { reasons } => {
+            writeln!(writer, "Recommendation blocked.")?;
+            for reason in reasons {
+                writeln!(writer, "  {reason}")?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -201,7 +201,15 @@ fn help_exposes_the_approved_command_families() {
 fn unavailable_commands_use_a_typed_non_internal_failure() {
     Command::cargo_bin("amari")
         .unwrap()
-        .args(["recommend", "--goal", "test goal", "--json"])
+        .args([
+            "plan",
+            "amari:amari-dual:autodiff:forward-derivative",
+            "--recommendation",
+            "missing.json",
+            "--project",
+            ".",
+            "--json",
+        ])
         .assert()
         .code(69)
         .stdout(predicate::str::is_empty())

--- a/amari-discovery/tests/cli_recommend_rust.rs
+++ b/amari-discovery/tests/cli_recommend_rust.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end Rust recommendation through the installed `amari` binary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use amari_discovery::{
+    inspect_rust_project, Catalog, GoalSpec, InspectionLimits, PlanCompatibility, PlanningContext,
+    ProbeBackend, ProbeResult, RecallConfig, ResourceObservations,
+};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::{NamedTempFile, TempDir};
+use walkdir::WalkDir;
+
+const GOAL: &str = "differentiate a scalar polynomial with forward dual numbers";
+const DUAL_CAPABILITY: &str = "amari:amari-dual:autodiff:forward-derivative";
+const DUAL_PROBE: &str = "amari-probe:dual:polynomial-derivative:v1";
+
+fn fixture_source() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/rust-project"
+    ))
+}
+
+fn materialize_fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    copy_and_transform(fixture_source(), temp.path(), &version);
+    temp
+}
+
+fn copy_and_transform(src: &Path, dst: &Path, version: &str) {
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let text = name.to_string_lossy();
+        let source = entry.path();
+        if source.is_dir() {
+            let target = dst.join(&name);
+            fs::create_dir_all(&target).unwrap();
+            copy_and_transform(&source, &target, version);
+        } else if text.ends_with(".in") {
+            let target = dst.join(text.trim_end_matches(".in"));
+            let contents = fs::read_to_string(source).unwrap();
+            fs::write(target, contents.replace("__AMARI_VERSION__", version)).unwrap();
+        } else if (text == "Cargo.toml" || text == "Cargo.lock")
+            && src.join(format!("{text}.in")).exists()
+        {
+            continue;
+        } else {
+            fs::copy(source, dst.join(name)).unwrap();
+        }
+    }
+}
+
+fn tree_contents(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut entries = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| {
+            (
+                entry.path().strip_prefix(root).unwrap().to_owned(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    entries
+}
+
+fn recommend_output(root: &Path, probe_results: Option<&Path>, json_output: bool) -> Vec<u8> {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command.arg("recommend").arg(root).args(["--goal", GOAL]);
+    if let Some(path) = probe_results {
+        command.arg("--probe-results").arg(path);
+    }
+    if json_output {
+        command.arg("--json");
+    }
+    command
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone()
+}
+
+fn recommend_json(root: &Path, probe_results: Option<&Path>) -> Value {
+    serde_json::from_slice(&recommend_output(root, probe_results, true)).unwrap()
+}
+
+fn recommendation(value: &Value) -> &Value {
+    assert_eq!(value["data"]["status"], "recommended");
+    &value["data"]["data"]
+}
+
+fn score<'a>(recommendation: &'a Value, capability_id: &str) -> &'a Value {
+    recommendation["scores"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|score| score["capability_id"] == capability_id)
+        .unwrap()
+}
+
+#[test]
+fn rust_recommendation_contains_preferred_alternatives_scores_and_actions() {
+    let fixture = materialize_fixture();
+    let value = recommend_json(fixture.path(), None);
+    let recommendation = recommendation(&value);
+    let preferred = &recommendation["preferred"];
+
+    assert_eq!(value["schema_version"], "amari.discovery/v1");
+    assert_eq!(preferred["capability_id"], DUAL_CAPABILITY);
+    assert_eq!(preferred["normalization"]["normalized"], true);
+    assert_eq!(preferred["plan_hash"].as_str().unwrap().len(), 64);
+    assert!(recommendation["alternatives"].is_array());
+
+    let preferred_score = score(recommendation, DUAL_CAPABILITY);
+    assert!(preferred_score["confidence"].as_f64().is_some());
+    assert!(preferred_score["components"]["applicability"]
+        .as_f64()
+        .is_some());
+    assert_eq!(preferred_score["objectives"].as_array().unwrap().len(), 8);
+    assert!(preferred_score["evidence"]
+        .as_array()
+        .is_some_and(|evidence| !evidence.is_empty()));
+
+    assert!(recommendation["missing_information"]
+        .as_array()
+        .is_some_and(|missing| !missing.is_empty()));
+    assert!(recommendation["suggested_probes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|probe| probe == DUAL_PROBE));
+    assert!(recommendation["suggested_tests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|step| step["kind"] == "test" && step["package"] == "amari-dual"));
+
+    assert_eq!(
+        value["provenance"]["project_hash"],
+        preferred["compatibility"]["project_hash"]
+    );
+    assert_eq!(
+        value["provenance"]["input_hash"],
+        preferred["compatibility"]["input_hash"]
+    );
+    assert_eq!(value["provenance"]["replay"]["replayable"], true);
+    assert_eq!(
+        value["provenance"]["seed"],
+        json!(RecallConfig::default().seed)
+    );
+    let snapshot = inspect_rust_project(fixture.path(), &InspectionLimits::default()).unwrap();
+    let expected_compatibility = PlanCompatibility::from_context(
+        &Catalog::embedded().unwrap(),
+        &PlanningContext {
+            snapshot,
+            goal: GoalSpec {
+                statement: GOAL.to_owned(),
+                constraints: Vec::new(),
+            },
+            probe_results: Vec::new(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        value["provenance"]["input_hash"],
+        expected_compatibility.input_hash
+    );
+    assert!(!serde_json::to_string(&value)
+        .unwrap()
+        .contains(fixture.path().to_str().unwrap()));
+}
+
+#[test]
+fn matching_saved_probe_improves_the_same_candidate_score() {
+    let fixture = materialize_fixture();
+    let baseline = recommend_json(fixture.path(), None);
+    let baseline_recommendation = recommendation(&baseline);
+    let baseline_verification = score(baseline_recommendation, DUAL_CAPABILITY)["components"]
+        ["verification"]
+        .as_f64()
+        .unwrap();
+
+    let catalog = Catalog::embedded().unwrap();
+    let snapshot = inspect_rust_project(fixture.path(), &InspectionLimits::default()).unwrap();
+    let probe = ProbeResult {
+        probe_id: DUAL_PROBE.parse().unwrap(),
+        backend: ProbeBackend::Cpu,
+        duration_micros: 10,
+        resources: ResourceObservations {
+            operations: 3,
+            nodes: 0,
+            iterations: 1,
+            bytes: 64,
+        },
+        seed: Some(7),
+        project_hash: Some(snapshot.project_hash),
+        catalog_hash: catalog.content_hash().to_owned(),
+        input_hash: "saved-dual-input".to_owned(),
+        validated_assumptions: vec!["derivative_matches".to_owned()],
+        refuted_assumptions: Vec::new(),
+        warnings: Vec::new(),
+        output: json!({"matches": true}),
+    };
+    let probe_file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(probe_file.as_file(), &vec![probe]).unwrap();
+
+    let with_probe = recommend_json(fixture.path(), Some(probe_file.path()));
+    let with_probe_recommendation = recommendation(&with_probe);
+    let probe_score = score(with_probe_recommendation, DUAL_CAPABILITY);
+
+    assert!(probe_score["components"]["verification"].as_f64().unwrap() > baseline_verification);
+    assert!(probe_score["validated_assumptions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|assumption| assumption == "derivative_matches"));
+    assert!(!with_probe_recommendation["missing_information"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|missing| missing
+            .as_str()
+            .is_some_and(|text| text.contains(DUAL_PROBE))));
+}
+
+#[test]
+fn fixed_seed_recommendation_is_byte_deterministic_and_read_only() {
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+
+    let first = recommend_output(fixture.path(), None, true);
+    let second = recommend_output(fixture.path(), None, true);
+
+    assert_eq!(first, second);
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn human_output_is_a_projection_of_the_json_recommendation() {
+    let fixture = materialize_fixture();
+    let value = recommend_json(fixture.path(), None);
+    let recommendation = recommendation(&value);
+    let human = String::from_utf8(recommend_output(fixture.path(), None, false)).unwrap();
+
+    assert!(human.contains(GOAL));
+    assert!(human.contains(
+        recommendation["preferred"]["capability_id"]
+            .as_str()
+            .unwrap()
+    ));
+    assert!(human.contains(recommendation["preferred"]["plan_hash"].as_str().unwrap()));
+    assert!(human.contains(DUAL_PROBE));
+    assert!(human.contains("amari-dual: all targets"));
+    for evidence in recommendation["evidence"].as_array().unwrap() {
+        assert!(human.contains(evidence["summary"].as_str().unwrap()));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_probe_result_file_is_rejected_without_project_mutation() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+    let probe_file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(probe_file.as_file(), &Vec::<ProbeResult>::new()).unwrap();
+    let link_dir = TempDir::new().unwrap();
+    let link = link_dir.path().join("probe-results.json");
+    symlink(probe_file.path(), &link).unwrap();
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .args(["--goal", GOAL, "--probe-results"])
+        .arg(link)
+        .arg("--json")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::starts_with("invalid_input:"));
+
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn malformed_probe_result_file_is_rejected_without_project_mutation() {
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+    let probe_file = NamedTempFile::new().unwrap();
+    fs::write(probe_file.path(), b"not-json").unwrap();
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .args(["--goal", GOAL, "--probe-results"])
+        .arg(probe_file.path())
+        .arg("--json")
+        .assert()
+        .code(9)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::starts_with("serialization:"));
+
+    assert_eq!(tree_contents(fixture.path()), before);
+}


### PR DESCRIPTION
## Summary

- implement the Rust/Cargo `amari recommend` vertical slice with inline `--goal`
- wire bounded read-only inspection through holographic recall, capability graph expansion, Pareto ranking, and normalized plan generation
- emit preferred plans, explicit Pareto alternatives, transparent scores/evidence, missing information, suggested registered probes, and static package tests
- accept optional bounded saved `--probe-results <file>` evidence without executing probes
- render human and JSON output from the same typed recommendation envelope

## Determinism and safety

- use the frozen default recall seed and report it in provenance
- derive one canonical goal/probe `input_hash` through `PlanCompatibility::from_context` for every outcome
- cap probe-result files at 1 MiB and 256 typed results using actual bounded reads
- reject symlinked/replaced and non-regular probe-result inputs
- cap emitted Pareto alternatives deterministically
- never execute Cargo, rustc, build scripts, project code, probes, shells, providers, or network operations
- never modify the inspected project or expose its absolute root

## Test plan

- [x] materialized Rust fixture with exact preferred dual-number capability
- [x] preferred plan, alternatives field, transparent score vector, evidence, and missing information
- [x] suggested registered probe and static package-test steps
- [x] provenance project/catalog/input hashes and fixed seed
- [x] matching saved probe improves the same candidate's verification score
- [x] malformed and symlinked probe-result inputs fail without project mutation
- [x] repeated fixed-seed output is byte-identical
- [x] human output projects the same typed JSON result
- [x] full `amari-discovery` all-feature matrix
- [x] full `amari-discovery` no-default-feature matrix
- [x] scoped Clippy and rustdoc for both feature configurations with warnings denied
- [x] formatting and diff checks
- [x] independent DeepSeek production-readiness review

Implements Task 14A from `docs/plans/2026-07-09-amari-discovery-implementation-plan.md`.

Task 14B remains responsible for TypeScript parity and `--goal-file`; Task 14C remains responsible for saved recommendation-to-plan replay.
