### PR TITLE
feat: recommend Amari integrations for TypeScript projects

### DIFF
--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -277,7 +277,7 @@ fn run_inspect(path: Option<PathBuf>, json: bool) -> DiscoveryResult<()> {
     }
 }
 
-/// Runs deterministic recommendation for a Rust/Cargo project.
+/// Runs deterministic recommendation for a supported project.
 fn run_recommend(
     path: Option<PathBuf>,
     goal: Option<String>,
@@ -285,14 +285,18 @@ fn run_recommend(
     probe_results: Option<PathBuf>,
     json: bool,
 ) -> DiscoveryResult<()> {
-    if goal_file.is_some() {
-        return Err(DiscoveryError::NotImplemented(
-            "recommend --goal-file is added in the TypeScript parity slice".to_owned(),
-        ));
-    }
-    let statement = goal.ok_or_else(|| {
-        DiscoveryError::InvalidInput("recommend requires an inline --goal".to_owned())
-    })?;
+    let goal = match (goal, goal_file) {
+        (Some(statement), None) => GoalSpec {
+            statement,
+            constraints: Vec::new(),
+        },
+        (None, Some(path)) => commands::recommend::read_goal_spec(&path)?,
+        _ => {
+            return Err(DiscoveryError::InvalidInput(
+                "recommend requires exactly one of --goal or --goal-file".to_owned(),
+            ));
+        }
+    };
     let root = match path {
         Some(path) => path,
         None => std::env::current_dir()?,
@@ -302,13 +306,10 @@ fn run_recommend(
         None => Vec::new(),
     };
     let catalog = Catalog::embedded()?;
-    let envelope = commands::recommend::recommend_rust_envelope(
+    let envelope = commands::recommend::recommend_project_envelope(
         &catalog,
         &root,
-        GoalSpec {
-            statement,
-            constraints: Vec::new(),
-        },
+        goal,
         saved_probes,
         &InspectionLimits::default(),
     )?;

--- a/amari-discovery/src/commands/recommend.rs
+++ b/amari-discovery/src/commands/recommend.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Typed Rust-project recommendation pipeline.
+//! Typed Rust/Cargo and npm/TypeScript recommendation pipeline.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::Read;
 use std::path::Path;
 
 use crate::inspect::{
-    inspect_rust_project, nofollow_open_readonly, snapshot_compatibility, InspectionLimits,
+    inspect_supported_project, nofollow_open_readonly, snapshot_compatibility, InspectionLimits,
     NofollowResult,
 };
 use crate::{
@@ -15,12 +16,13 @@ use crate::{
     DiscoveryError, DiscoveryOutcome, DiscoveryResult, Envelope, Evidence, GoalSpec,
     GraphConstraints, GraphExpansionState, PlanCompatibility, PlanGenerator, PlanStep,
     PlanningContext, ProbeId, ProbeResult, ProjectKind, RankedCandidate, RankingContext,
-    RecallConfig, Recommendation, RecommendationScore, RecommendationScoreComponents,
-    ReplayMetadata, SnapshotState, SCHEMA_V1,
+    RankingSignal, RankingSignalKind, RecallConfig, Recommendation, RecommendationScore,
+    RecommendationScoreComponents, ReplayMetadata, SnapshotState, SCHEMA_V1,
 };
 
 const MAX_PROBE_RESULTS_BYTES: u64 = 1_048_576;
 const MAX_PROBE_RESULTS: usize = 256;
+const MAX_GOAL_BYTES: u64 = 65_536;
 const MAX_ALTERNATIVES: usize = 7;
 
 /// Reads a bounded JSON array of saved [`ProbeResult`] values.
@@ -34,36 +36,7 @@ const MAX_ALTERNATIVES: usize = 7;
 /// inputs, an I/O error when the file cannot be read, or a serialization error
 /// for malformed JSON.
 pub fn read_probe_results(path: &Path) -> DiscoveryResult<Vec<ProbeResult>> {
-    let metadata = fs::symlink_metadata(path)?;
-    if !metadata.file_type().is_file() {
-        return Err(DiscoveryError::InvalidInput(
-            "probe-results input must be a regular file".to_owned(),
-        ));
-    }
-    if metadata.len() > MAX_PROBE_RESULTS_BYTES {
-        return Err(DiscoveryError::LimitExceeded(format!(
-            "probe-results bytes {} exceed limit {MAX_PROBE_RESULTS_BYTES}",
-            metadata.len()
-        )));
-    }
-    let mut file = match nofollow_open_readonly(path)? {
-        NofollowResult::Opened(file) => file,
-        NofollowResult::SymlinkOrRace => {
-            return Err(DiscoveryError::InvalidInput(
-                "probe-results input must not be a symlink or replaced file".to_owned(),
-            ));
-        }
-    };
-    let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.by_ref()
-        .take(MAX_PROBE_RESULTS_BYTES + 1)
-        .read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > MAX_PROBE_RESULTS_BYTES {
-        return Err(DiscoveryError::LimitExceeded(format!(
-            "probe-results bytes {} exceed limit {MAX_PROBE_RESULTS_BYTES}",
-            bytes.len()
-        )));
-    }
+    let bytes = read_bounded_input(path, MAX_PROBE_RESULTS_BYTES, "probe-results")?;
     let results: Vec<ProbeResult> = serde_json::from_slice(&bytes)?;
     if results.len() > MAX_PROBE_RESULTS {
         return Err(DiscoveryError::LimitExceeded(format!(
@@ -74,7 +47,52 @@ pub fn read_probe_results(path: &Path) -> DiscoveryResult<Vec<ProbeResult>> {
     Ok(results)
 }
 
-/// Runs the deterministic Rust inspect → recall → graph → rank → plan pipeline.
+/// Reads and validates a bounded typed [`GoalSpec`] JSON document.
+///
+/// # Errors
+///
+/// Returns a typed I/O, limit, serialization, or semantic input error. Symlinks
+/// and replacement races are rejected without exposing their targets.
+pub fn read_goal_spec(path: &Path) -> DiscoveryResult<GoalSpec> {
+    let bytes = read_bounded_input(path, MAX_GOAL_BYTES, "goal")?;
+    let goal: GoalSpec = serde_json::from_slice(&bytes)?;
+    goal.validate()?;
+    Ok(goal)
+}
+
+fn read_bounded_input(path: &Path, max_bytes: u64, kind: &str) -> DiscoveryResult<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "{kind} input must be a regular file"
+        )));
+    }
+    if metadata.len() > max_bytes {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "{kind} bytes {} exceed limit {max_bytes}",
+            metadata.len()
+        )));
+    }
+    let mut file = match nofollow_open_readonly(path)? {
+        NofollowResult::Opened(file) => file,
+        NofollowResult::SymlinkOrRace => {
+            return Err(DiscoveryError::InvalidInput(format!(
+                "{kind} input must not be a symlink or replaced file"
+            )));
+        }
+    };
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref().take(max_bytes + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "{kind} bytes {} exceed limit {max_bytes}",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
+}
+
+/// Runs the deterministic project inspect → recall → graph → rank → plan pipeline.
 ///
 /// The operation is read-only and offline. It does not invoke Cargo, rustc,
 /// build scripts, project code, a shell, providers, probes, or the network.
@@ -82,28 +100,21 @@ pub fn read_probe_results(path: &Path) -> DiscoveryResult<Vec<ProbeResult>> {
 ///
 /// # Errors
 ///
-/// Returns a typed inspection, planner, catalog, or normalization error. npm-only
-/// and unknown project roots are rejected until their dedicated vertical slice.
-pub fn recommend_rust_envelope(
+/// Returns a typed inspection, planner, catalog, or normalization error.
+/// Unknown project roots are rejected without attempting project execution.
+pub fn recommend_project_envelope(
     catalog: &Catalog,
     project_root: &Path,
     goal: GoalSpec,
     probe_results: Vec<ProbeResult>,
     limits: &InspectionLimits,
 ) -> DiscoveryResult<Envelope<DiscoveryOutcome<Recommendation>>> {
-    if goal.statement.trim().is_empty() {
-        return Err(DiscoveryError::InvalidInput(
-            "recommendation goal must not be empty".to_owned(),
-        ));
-    }
+    goal.validate()?;
 
-    let snapshot = inspect_rust_project(project_root, limits)?;
-    if !matches!(
-        snapshot.project_kind,
-        ProjectKind::RustCargo | ProjectKind::Mixed
-    ) {
+    let snapshot = inspect_supported_project(project_root, limits)?;
+    if matches!(snapshot.project_kind, ProjectKind::Unknown) {
         return Err(DiscoveryError::InvalidInput(
-            "recommend currently requires a Rust/Cargo project".to_owned(),
+            "recommend requires a Rust/Cargo or npm/TypeScript project".to_owned(),
         ));
     }
     let compatibility = snapshot_compatibility(&snapshot);
@@ -138,17 +149,14 @@ pub fn recommend_rust_envelope(
         .iter()
         .map(|candidate| candidate.capability_id.clone())
         .collect::<Vec<_>>();
-    let graph =
-        CapabilityGraphExpander::default().expand(catalog, &seeds, &GraphConstraints::default())?;
+    let graph_constraints = graph_constraints(catalog, &planning_context);
+    let graph = CapabilityGraphExpander::default().expand(catalog, &seeds, &graph_constraints)?;
     let ranking = CandidateRanker::default().rank(
         catalog,
         &graph,
         &recalled,
         &planning_context.snapshot,
-        &RankingContext {
-            probe_results: planning_context.probe_results.clone(),
-            ..RankingContext::default()
-        },
+        &ranking_context(&planning_context),
     )?;
 
     let Some(preferred_ranked) = ranking.preferred.as_ref() else {
@@ -265,6 +273,97 @@ pub fn recommend_rust_envelope(
         warnings,
         DiscoveryOutcome::Recommended(recommendation),
     ))
+}
+
+/// Backward-compatible Task 14A entry point for recommendation.
+///
+/// The pipeline now also supports npm/TypeScript projects; new callers should
+/// prefer [`recommend_project_envelope`].
+///
+/// # Errors
+///
+/// Returns the same typed errors as [`recommend_project_envelope`].
+pub fn recommend_rust_envelope(
+    catalog: &Catalog,
+    project_root: &Path,
+    goal: GoalSpec,
+    probe_results: Vec<ProbeResult>,
+    limits: &InspectionLimits,
+) -> DiscoveryResult<Envelope<DiscoveryOutcome<Recommendation>>> {
+    recommend_project_envelope(catalog, project_root, goal, probe_results, limits)
+}
+
+fn mapped_typescript_capabilities(context: &PlanningContext) -> BTreeSet<crate::CapabilityId> {
+    context
+        .snapshot
+        .typescript
+        .as_ref()
+        .into_iter()
+        .flat_map(|typescript| &typescript.capabilities)
+        .map(|evidence| evidence.capability_id.clone())
+        .collect()
+}
+
+fn graph_constraints(catalog: &Catalog, context: &PlanningContext) -> GraphConstraints {
+    let mapped = mapped_typescript_capabilities(context);
+    let blocked_capabilities = match context.snapshot.project_kind {
+        ProjectKind::NpmTypeScript => catalog
+            .capabilities()
+            .iter()
+            .filter(|capability| !mapped.contains(&capability.id))
+            .map(|capability| capability.id.clone())
+            .collect(),
+        ProjectKind::Mixed => catalog
+            .capabilities()
+            .iter()
+            .filter(|capability| {
+                capability.crate_refs.is_empty() && !mapped.contains(&capability.id)
+            })
+            .map(|capability| capability.id.clone())
+            .collect(),
+        ProjectKind::RustCargo | ProjectKind::Unknown => BTreeSet::new(),
+    };
+    GraphConstraints {
+        blocked_capabilities,
+    }
+}
+
+fn ranking_context(context: &PlanningContext) -> RankingContext {
+    let mut ranking = RankingContext {
+        probe_results: context.probe_results.clone(),
+        ..RankingContext::default()
+    };
+    let npm_current = context.snapshot.npm.as_ref().is_some_and(|npm| {
+        npm.package.dependencies.iter().any(|dependency| {
+            dependency.package_name == "@justinelliottcobb/amari-wasm"
+                && dependency.compatibility.status == "applicable"
+        })
+    });
+    for capability_id in mapped_typescript_capabilities(context) {
+        ranking.signals.push(RankingSignal {
+            capability_id: capability_id.clone(),
+            kind: RankingSignalKind::Evidence,
+            strength: 0.9,
+            summary: "installed generated WASM declarations map this capability".to_owned(),
+        });
+        ranking.signals.push(RankingSignal {
+            capability_id: capability_id.clone(),
+            kind: RankingSignalKind::Platform,
+            strength: if npm_current { 0.95 } else { 0.6 },
+            summary: "generated WASM API is available to the TypeScript project".to_owned(),
+        });
+        if npm_current {
+            ranking.prerequisites_satisfied.insert(capability_id);
+        } else {
+            ranking.signals.push(RankingSignal {
+                capability_id,
+                kind: RankingSignalKind::Risk,
+                strength: 0.2,
+                summary: "installed Amari WASM version does not match the catalog".to_owned(),
+            });
+        }
+    }
+    ranking
 }
 
 fn recommendation_score(candidate: &RankedCandidate) -> RecommendationScore {

--- a/amari-discovery/src/inspect/mod.rs
+++ b/amari-discovery/src/inspect/mod.rs
@@ -943,7 +943,7 @@ pub fn inspect_npm_typescript_project(
     Ok(snapshot)
 }
 
-fn inspect_supported_project(
+pub(crate) fn inspect_supported_project(
     root: &Path,
     limits: &InspectionLimits,
 ) -> DiscoveryResult<ProjectSnapshot> {

--- a/amari-discovery/src/planner/normalize.rs
+++ b/amari-discovery/src/planner/normalize.rs
@@ -326,15 +326,21 @@ fn encode_step(step: &PlanStep) -> Term {
         PlanStep::Test {
             capability_id,
             package,
-            target: PlanTestTarget::AllTargets,
-        } => Term::sym(
-            "test",
-            [
-                constant(capability_id.to_string()),
-                constant(package),
-                constant("all_targets"),
-            ],
-        ),
+            target,
+        } => {
+            let target = match target {
+                PlanTestTarget::AllTargets => "all_targets",
+                PlanTestTarget::NpmPackage => "npm_package",
+            };
+            Term::sym(
+                "test",
+                [
+                    constant(capability_id.to_string()),
+                    constant(package),
+                    constant(target),
+                ],
+            )
+        }
     }
 }
 
@@ -409,11 +415,18 @@ fn decode_step(term: &Term) -> DiscoveryResult<PlanStep> {
                 DiscoveryError::Internal(format!("cannot decode normalized probe ID: {error}"))
             })?,
         }),
-        ("test", [id, package, "all_targets"]) => Ok(PlanStep::Test {
-            capability_id: capability(id)?,
-            package: (*package).to_owned(),
-            target: PlanTestTarget::AllTargets,
-        }),
+        ("test", [id, package, target @ ("all_targets" | "npm_package")]) => {
+            let target = if *target == "all_targets" {
+                PlanTestTarget::AllTargets
+            } else {
+                PlanTestTarget::NpmPackage
+            };
+            Ok(PlanStep::Test {
+                capability_id: capability(id)?,
+                package: (*package).to_owned(),
+                target,
+            })
+        }
         _ => invalid_encoded_plan(),
     }
 }

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -10,9 +10,11 @@ use sha2::{Digest, Sha256};
 use super::normalize::{NormalizationLimits, PlanNormalizer};
 use crate::{
     CandidatePlan, CapabilityId, Catalog, CatalogIdentity, DiscoveryError, DiscoveryResult,
-    GoalSpec, PlanCompatibility, PlanNormalization, PlanStep, PlanTestTarget, PlanningContext,
-    ProbeReplayHash, RankedCandidate,
+    PlanCompatibility, PlanNormalization, PlanStep, PlanTestTarget, PlanningContext,
+    ProbeReplayHash, ProjectKind, RankedCandidate,
 };
+
+const AMARI_WASM_PACKAGE: &str = "@justinelliottcobb/amari-wasm";
 
 /// Deterministic catalog-backed candidate-plan generator.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -50,7 +52,7 @@ impl PlanGenerator {
         context: &PlanningContext,
         candidate: &RankedCandidate,
     ) -> DiscoveryResult<CandidatePlan> {
-        validate_goal(&context.goal)?;
+        context.goal.validate()?;
         let prerequisite_order = prerequisite_order(candidate)?;
         let capabilities: BTreeMap<_, _> = catalog
             .capabilities()
@@ -63,6 +65,20 @@ impl PlanGenerator {
             .map(|record| (record.name.as_str(), record))
             .collect();
 
+        let rust_project = matches!(
+            context.snapshot.project_kind,
+            ProjectKind::RustCargo | ProjectKind::Mixed
+        );
+        let npm_project = matches!(
+            context.snapshot.project_kind,
+            ProjectKind::NpmTypeScript | ProjectKind::Mixed
+        );
+        if !rust_project && !npm_project {
+            return Err(DiscoveryError::InvalidInput(
+                "candidate plan requires Rust/Cargo or npm project evidence".to_owned(),
+            ));
+        }
+
         let mut steps = Vec::new();
         for capability_id in &prerequisite_order {
             let capability = capabilities.get(capability_id).ok_or_else(|| {
@@ -70,52 +86,34 @@ impl PlanGenerator {
                     "candidate path references unknown capability `{capability_id}`"
                 ))
             })?;
-            for package in &capability.crate_refs {
-                let record = crates.get(package.as_str()).ok_or_else(|| {
-                    DiscoveryError::CatalogCorruption(format!(
-                        "capability `{capability_id}` references unknown crate `{package}`"
-                    ))
-                })?;
-                steps.push(PlanStep::Dependency {
-                    capability_id: capability_id.clone(),
-                    package: package.clone(),
-                    version: record.version.clone(),
-                });
+            let mut actionable = false;
+            if rust_project {
+                let previous_len = steps.len();
+                append_rust_steps(&mut steps, capability_id, capability, &crates)?;
+                actionable |= steps.len() > previous_len;
             }
-            for reference in &capability.feature_refs {
-                let (package, feature) = split_catalog_reference(reference, "feature")?;
-                steps.push(PlanStep::Feature {
-                    capability_id: capability_id.clone(),
-                    package: package.to_owned(),
-                    feature: feature.to_owned(),
-                });
+            if npm_project {
+                let wasm_paths = context
+                    .snapshot
+                    .typescript
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|typescript| &typescript.capabilities)
+                    .filter(|evidence| evidence.capability_id == *capability_id)
+                    .map(|evidence| evidence.wasm_path.clone())
+                    .collect::<BTreeSet<_>>();
+                if !wasm_paths.is_empty() {
+                    append_npm_steps(&mut steps, capability_id, catalog.version(), wasm_paths);
+                    actionable = true;
+                }
             }
-            for path in &capability.symbol_refs {
-                steps.push(PlanStep::Symbol {
-                    capability_id: capability_id.clone(),
-                    path: path.clone(),
-                });
-            }
-            for reference in &capability.example_refs {
-                let (package, example) = split_catalog_reference(reference, "example")?;
-                steps.push(PlanStep::Example {
-                    capability_id: capability_id.clone(),
-                    package: package.to_owned(),
-                    example: example.to_owned(),
-                });
-            }
-            for probe_id in &capability.probe_refs {
-                steps.push(PlanStep::Probe {
-                    capability_id: capability_id.clone(),
-                    probe_id: probe_id.clone(),
-                });
-            }
-            for package in &capability.crate_refs {
-                steps.push(PlanStep::Test {
-                    capability_id: capability_id.clone(),
-                    package: package.clone(),
-                    target: PlanTestTarget::AllTargets,
-                });
+            if actionable {
+                for probe_id in &capability.probe_refs {
+                    steps.push(PlanStep::Probe {
+                        capability_id: capability_id.clone(),
+                        probe_id: probe_id.clone(),
+                    });
+                }
             }
         }
 
@@ -205,22 +203,76 @@ fn prerequisite_order(candidate: &RankedCandidate) -> DiscoveryResult<Vec<Capabi
         .collect())
 }
 
-fn validate_goal(goal: &GoalSpec) -> DiscoveryResult<()> {
-    if goal.statement.trim().is_empty() {
-        return Err(DiscoveryError::InvalidInput(
-            "planning goal statement must not be empty".to_owned(),
-        ));
+fn append_rust_steps(
+    steps: &mut Vec<PlanStep>,
+    capability_id: &CapabilityId,
+    capability: &crate::CapabilityRecord,
+    crates: &BTreeMap<&str, &crate::CrateRecord>,
+) -> DiscoveryResult<()> {
+    for package in &capability.crate_refs {
+        let record = crates.get(package.as_str()).ok_or_else(|| {
+            DiscoveryError::CatalogCorruption(format!(
+                "capability `{capability_id}` references unknown crate `{package}`"
+            ))
+        })?;
+        steps.push(PlanStep::Dependency {
+            capability_id: capability_id.clone(),
+            package: package.clone(),
+            version: record.version.clone(),
+        });
     }
-    if goal
-        .constraints
-        .iter()
-        .any(|constraint| constraint.trim().is_empty())
-    {
-        return Err(DiscoveryError::InvalidInput(
-            "planning goal constraints must not be empty".to_owned(),
-        ));
+    for reference in &capability.feature_refs {
+        let (package, feature) = split_catalog_reference(reference, "feature")?;
+        steps.push(PlanStep::Feature {
+            capability_id: capability_id.clone(),
+            package: package.to_owned(),
+            feature: feature.to_owned(),
+        });
+    }
+    for path in &capability.symbol_refs {
+        steps.push(PlanStep::Symbol {
+            capability_id: capability_id.clone(),
+            path: path.clone(),
+        });
+    }
+    for reference in &capability.example_refs {
+        let (package, example) = split_catalog_reference(reference, "example")?;
+        steps.push(PlanStep::Example {
+            capability_id: capability_id.clone(),
+            package: package.to_owned(),
+            example: example.to_owned(),
+        });
+    }
+    for package in &capability.crate_refs {
+        steps.push(PlanStep::Test {
+            capability_id: capability_id.clone(),
+            package: package.clone(),
+            target: PlanTestTarget::AllTargets,
+        });
     }
     Ok(())
+}
+
+fn append_npm_steps(
+    steps: &mut Vec<PlanStep>,
+    capability_id: &CapabilityId,
+    version: &str,
+    wasm_paths: BTreeSet<String>,
+) {
+    steps.push(PlanStep::Dependency {
+        capability_id: capability_id.clone(),
+        package: AMARI_WASM_PACKAGE.to_owned(),
+        version: version.to_owned(),
+    });
+    steps.extend(wasm_paths.into_iter().map(|path| PlanStep::Symbol {
+        capability_id: capability_id.clone(),
+        path,
+    }));
+    steps.push(PlanStep::Test {
+        capability_id: capability_id.clone(),
+        package: AMARI_WASM_PACKAGE.to_owned(),
+        target: PlanTestTarget::NpmPackage,
+    });
 }
 
 fn split_catalog_reference<'a>(

--- a/amari-discovery/src/protocol.rs
+++ b/amari-discovery/src/protocol.rs
@@ -294,12 +294,49 @@ pub struct Evidence {
 
 /// A normalized user goal supplied to the discovery planner.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GoalSpec {
     /// Concise statement of the mathematical or integration goal.
     pub statement: String,
     /// Explicit deterministic constraints applied to the goal.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub constraints: Vec<String>,
+}
+
+impl GoalSpec {
+    /// Maximum explicit constraints accepted by the v1 planner protocol.
+    pub const MAX_CONSTRAINTS: usize = 64;
+
+    /// Validates semantic goal invariants shared by CLI and library planning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] for an empty statement or
+    /// constraint, and [`DiscoveryError::LimitExceeded`] above 64 constraints.
+    pub fn validate(&self) -> Result<(), DiscoveryError> {
+        if self.statement.trim().is_empty() {
+            return Err(DiscoveryError::InvalidInput(
+                "planning goal statement must not be empty".to_owned(),
+            ));
+        }
+        if self.constraints.len() > Self::MAX_CONSTRAINTS {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "goal constraints {} exceed limit {}",
+                self.constraints.len(),
+                Self::MAX_CONSTRAINTS
+            )));
+        }
+        if self
+            .constraints
+            .iter()
+            .any(|constraint| constraint.trim().is_empty())
+        {
+            return Err(DiscoveryError::InvalidInput(
+                "planning goal constraints must not be empty".to_owned(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Typed project, goal, and saved-probe inputs used to construct plans.
@@ -343,19 +380,21 @@ pub struct PlanCompatibility {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanTestTarget {
-    /// Run every target belonging to the selected package.
+    /// Run every Cargo target belonging to the selected package.
     AllTargets,
+    /// Run the npm package's declared project test suite.
+    NpmPackage,
 }
 
 /// One read-only integration instruction in a candidate plan.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PlanStep {
-    /// Add an exact Amari package dependency.
+    /// Add an exact Amari Cargo or npm package dependency.
     Dependency {
         /// Capability requiring this step.
         capability_id: CapabilityId,
-        /// Cargo package name.
+        /// Cargo or npm package name.
         package: String,
         /// Exact catalog package version.
         version: String,
@@ -396,7 +435,7 @@ pub enum PlanStep {
     Test {
         /// Capability requiring this step.
         capability_id: CapabilityId,
-        /// Cargo package name.
+        /// Cargo or npm package name.
         package: String,
         /// Static package test scope.
         target: PlanTestTarget,

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -237,6 +237,7 @@ pub(crate) fn write_recommendation_human(
                 {
                     let target = match target {
                         crate::PlanTestTarget::AllTargets => "all targets",
+                        crate::PlanTestTarget::NpmPackage => "npm package tests",
                     };
                     writeln!(writer, "  {package}: {target}")?;
                 }

--- a/amari-discovery/tests/cli_recommend_ts.rs
+++ b/amari-discovery/tests/cli_recommend_ts.rs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end npm/TypeScript recommendation through the installed `amari` binary.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use amari_discovery::{
+    inspect_npm_typescript_project, Catalog, InspectionLimits, ProbeBackend, ProbeResult,
+    ResourceObservations,
+};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::{NamedTempFile, TempDir};
+use walkdir::WalkDir;
+
+const DECLARATION_PATH: &str = "node_modules/@justinelliottcobb/amari-wasm/amari_wasm.d.ts";
+const GOAL: &str = "compute the geometric product of multivectors in browser WebAssembly";
+const CORE_CAPABILITY: &str = "amari:amari-core:product:geometric-product";
+const CORE_PROBE: &str = "amari-probe:core:geometric-product:v1";
+const WASM_PACKAGE: &str = "@justinelliottcobb/amari-wasm";
+
+fn fixture_source() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/ts-project"
+    ))
+}
+
+fn goal_fixture() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/goals/geometric-product.json"
+    ))
+}
+
+fn materialize_fixture(version: &str) -> TempDir {
+    let temp = TempDir::new().unwrap();
+    copy_and_transform(fixture_source(), temp.path(), version);
+    temp
+}
+
+fn copy_and_transform(src: &Path, dst: &Path, version: &str) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let text = name.to_string_lossy();
+        let source = entry.path();
+        if source.is_dir() {
+            copy_and_transform(&source, &dst.join(name), version);
+        } else if text == "amari_wasm.d.ts.fixture" {
+            let declaration = dst.join(DECLARATION_PATH);
+            fs::create_dir_all(declaration.parent().unwrap()).unwrap();
+            fs::copy(source, declaration).unwrap();
+        } else if let Some(base) = text.strip_suffix(".in") {
+            let contents = fs::read_to_string(source).unwrap();
+            fs::write(
+                dst.join(base),
+                contents.replace("__AMARI_VERSION__", version),
+            )
+            .unwrap();
+        } else {
+            fs::copy(source, dst.join(name)).unwrap();
+        }
+    }
+}
+
+fn tree_contents(root: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+    let mut entries = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .map(Result::unwrap)
+        .map(|entry| {
+            let relative = entry.path().strip_prefix(root).unwrap().to_owned();
+            let contents = entry
+                .file_type()
+                .is_file()
+                .then(|| fs::read(entry.path()).unwrap());
+            (relative, contents)
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    entries
+}
+
+fn recommend_json(
+    root: &Path,
+    inline_goal: Option<&str>,
+    goal_file: Option<&Path>,
+    probe_results: Option<&Path>,
+) -> Value {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command.arg("recommend").arg(root);
+    if let Some(goal) = inline_goal {
+        command.args(["--goal", goal]);
+    }
+    if let Some(path) = goal_file {
+        command.arg("--goal-file").arg(path);
+    }
+    if let Some(path) = probe_results {
+        command.arg("--probe-results").arg(path);
+    }
+    let output = command
+        .arg("--json")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn recommendation(value: &Value) -> &Value {
+    assert_eq!(value["data"]["status"], "recommended");
+    &value["data"]["data"]
+}
+
+fn score<'a>(recommendation: &'a Value, capability: &str) -> &'a Value {
+    recommendation["scores"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|score| score["capability_id"] == capability)
+        .unwrap()
+}
+
+#[test]
+fn goal_file_recommends_exact_wasm_package_symbols_probes_and_tests() {
+    let catalog = Catalog::embedded().unwrap();
+    let fixture = materialize_fixture(catalog.version());
+    let value = recommend_json(fixture.path(), None, Some(goal_fixture()), None);
+    let recommendation = recommendation(&value);
+    let preferred = &recommendation["preferred"];
+
+    assert_eq!(preferred["capability_id"], CORE_CAPABILITY);
+    assert_eq!(recommendation["goal"]["statement"], GOAL);
+    assert_eq!(
+        recommendation["goal"]["constraints"],
+        json!(["browser", "wasm"])
+    );
+    assert_eq!(value["provenance"]["compatibility"]["status"], "applicable");
+    assert!(preferred["steps"].as_array().unwrap().iter().any(|step| {
+        step["kind"] == "dependency"
+            && step["package"] == WASM_PACKAGE
+            && step["version"] == catalog.version()
+    }));
+    assert!(preferred["steps"].as_array().unwrap().iter().any(|step| {
+        step["kind"] == "symbol" && step["path"] == "WasmMultivector300.geometricProduct"
+    }));
+    assert!(recommendation["suggested_probes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|probe| probe == CORE_PROBE));
+    assert!(recommendation["suggested_tests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|step| {
+            step["kind"] == "test"
+                && step["package"] == WASM_PACKAGE
+                && step["target"] == "npm_package"
+        }));
+    assert!(score(recommendation, CORE_CAPABILITY)["evidence"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|evidence| evidence["kind"] == "ranking_signal:evidence"));
+    let serialized = serde_json::to_string(&value).unwrap();
+    assert!(!serialized.contains(fixture.path().to_str().unwrap()));
+    assert!(!serialized.contains("Browser-side Amari WASM integration"));
+}
+
+#[test]
+fn inline_and_goal_file_paths_use_the_same_typed_pipeline() {
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    let fixture = materialize_fixture(&version);
+    let inline = recommend_json(fixture.path(), Some(GOAL), None, None);
+    let from_file = recommend_json(fixture.path(), None, Some(goal_fixture()), None);
+
+    assert_eq!(
+        recommendation(&inline)["preferred"]["capability_id"],
+        recommendation(&from_file)["preferred"]["capability_id"]
+    );
+    assert_eq!(
+        recommendation(&inline)["scores"],
+        recommendation(&from_file)["scores"]
+    );
+    assert_ne!(
+        inline["provenance"]["input_hash"], from_file["provenance"]["input_hash"],
+        "goal-file constraints must participate in replay identity"
+    );
+}
+
+#[test]
+fn matching_saved_probe_improves_typescript_candidate_verification() {
+    let catalog = Catalog::embedded().unwrap();
+    let fixture = materialize_fixture(catalog.version());
+    let baseline = recommend_json(fixture.path(), None, Some(goal_fixture()), None);
+    let baseline_verification = score(recommendation(&baseline), CORE_CAPABILITY)["components"]
+        ["verification"]
+        .as_f64()
+        .unwrap();
+    let snapshot =
+        inspect_npm_typescript_project(fixture.path(), &InspectionLimits::default()).unwrap();
+    let probe = ProbeResult {
+        probe_id: CORE_PROBE.parse().unwrap(),
+        backend: ProbeBackend::Cpu,
+        duration_micros: 12,
+        resources: ResourceObservations {
+            operations: 2,
+            nodes: 2,
+            iterations: 1,
+            bytes: 96,
+        },
+        seed: Some(11),
+        project_hash: Some(snapshot.project_hash),
+        catalog_hash: catalog.content_hash().to_owned(),
+        input_hash: "saved-geometric-product-input".to_owned(),
+        validated_assumptions: vec!["product_matches".to_owned()],
+        refuted_assumptions: Vec::new(),
+        warnings: Vec::new(),
+        output: json!({"matches": true}),
+    };
+    let probe_file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(probe_file.as_file(), &vec![probe]).unwrap();
+
+    let with_probe = recommend_json(
+        fixture.path(),
+        None,
+        Some(goal_fixture()),
+        Some(probe_file.path()),
+    );
+    let probe_score = score(recommendation(&with_probe), CORE_CAPABILITY);
+    assert!(probe_score["components"]["verification"].as_f64().unwrap() > baseline_verification);
+    assert!(probe_score["validated_assumptions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|assumption| assumption == "product_matches"));
+}
+
+#[test]
+fn current_and_stale_wasm_versions_are_typed_and_still_deterministic() {
+    let catalog = Catalog::embedded().unwrap();
+    let current_fixture = materialize_fixture(catalog.version());
+    let stale_fixture = materialize_fixture("0.19.0");
+
+    let current = recommend_json(current_fixture.path(), None, Some(goal_fixture()), None);
+    let stale_first = recommend_json(stale_fixture.path(), None, Some(goal_fixture()), None);
+    let stale_second = recommend_json(stale_fixture.path(), None, Some(goal_fixture()), None);
+
+    assert_eq!(
+        current["provenance"]["compatibility"]["status"],
+        "applicable"
+    );
+    assert_eq!(
+        stale_first["provenance"]["compatibility"]["status"],
+        "unknown_version"
+    );
+    assert_eq!(
+        recommendation(&current)["preferred"]["capability_id"],
+        CORE_CAPABILITY
+    );
+    assert_eq!(
+        recommendation(&stale_first)["preferred"]["capability_id"],
+        CORE_CAPABILITY
+    );
+    assert!(recommendation(&stale_first)["preferred"]["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|step| {
+            step["kind"] == "dependency"
+                && step["package"] == WASM_PACKAGE
+                && step["version"] == catalog.version()
+        }));
+    assert_eq!(stale_first, stale_second);
+}
+
+#[test]
+fn typescript_human_output_projects_wasm_plan_actions() {
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    let fixture = materialize_fixture(&version);
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .arg("--goal-file")
+        .arg(goal_fixture())
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    let human = String::from_utf8(output).unwrap();
+
+    assert!(human.contains(CORE_CAPABILITY));
+    assert!(human.contains(CORE_PROBE));
+    assert!(human.contains("@justinelliottcobb/amari-wasm: npm package tests"));
+}
+
+#[test]
+fn recommendation_is_read_only_for_typescript_projects() {
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    let fixture = materialize_fixture(&version);
+    let before = tree_contents(fixture.path());
+
+    let _ = recommend_json(fixture.path(), None, Some(goal_fixture()), None);
+
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn clap_rejects_goal_and_goal_file_together() {
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    let fixture = materialize_fixture(&version);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .args(["--goal", GOAL, "--goal-file"])
+        .arg(goal_fixture())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn malformed_and_semantically_empty_goal_files_are_typed_errors() {
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    let fixture = materialize_fixture(&version);
+    let malformed = NamedTempFile::new().unwrap();
+    fs::write(malformed.path(), b"not-json").unwrap();
+    let empty = NamedTempFile::new().unwrap();
+    fs::write(empty.path(), br#"{"statement":"  ","constraints":[]}"#).unwrap();
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .arg("--goal-file")
+        .arg(malformed.path())
+        .arg("--json")
+        .assert()
+        .code(9)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::starts_with("serialization:"));
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(fixture.path())
+        .arg("--goal-file")
+        .arg(empty.path())
+        .arg("--json")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::starts_with("invalid_input:"));
+}

--- a/amari-discovery/tests/fixtures/goals/geometric-product.json
+++ b/amari-discovery/tests/fixtures/goals/geometric-product.json
@@ -1,0 +1,4 @@
+{
+  "statement": "compute the geometric product of multivectors in browser WebAssembly",
+  "constraints": ["browser", "wasm"]
+}

--- a/amari-discovery/tests/plan_normalization.rs
+++ b/amari-discovery/tests/plan_normalization.rs
@@ -296,6 +296,42 @@ fn generator_threads_explicit_normalization_limits() {
 }
 
 #[test]
+fn mixed_project_keeps_rust_actions_when_wasm_mapping_is_absent() {
+    let catalog = Catalog::embedded().unwrap();
+    let target = id("amari:amari-dual:autodiff:forward-derivative");
+    let mut mixed = context("project-mixed-rust-action");
+    mixed.snapshot.project_kind = ProjectKind::Mixed;
+
+    let plan = PlanGenerator::default()
+        .generate(&catalog, &mixed, &ranked(std::slice::from_ref(&target)))
+        .unwrap();
+
+    assert!(plan.steps.iter().any(|step| {
+        matches!(
+            step,
+            PlanStep::Dependency {
+                capability_id,
+                package,
+                ..
+            } if capability_id == &target && package == "amari-dual"
+        )
+    }));
+}
+
+#[test]
+fn direct_plan_generation_enforces_shared_goal_limits() {
+    let catalog = Catalog::embedded().unwrap();
+    let target = id("amari:amari-dual:autodiff:forward-derivative");
+    let mut oversized = context("project-goal-limit");
+    oversized.goal.constraints = vec!["constraint".to_owned(); GoalSpec::MAX_CONSTRAINTS + 1];
+
+    assert!(matches!(
+        PlanGenerator::default().generate(&catalog, &oversized, &ranked(&[target])),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("goal constraints")
+    ));
+}
+
+#[test]
 fn generation_and_normalization_are_byte_deterministic() {
     let first = generated_dual_plan();
     let second = generated_dual_plan();


### PR DESCRIPTION
## Summary

- extend `amari recommend` to npm/TypeScript and mixed projects using the same inspect → recall → graph → rank → normalized-plan pipeline
- add bounded typed `--goal-file <FILE>` input while retaining mutually exclusive inline `--goal`
- use installed generated `.d.ts` mappings as the sole authority for npm-only capability availability
- emit exact `@justinelliottcobb/amari-wasm` dependency, generated WASM symbol, registered probe, and npm package-test plan steps
- distinguish current and stale WASM versions through compatibility, applicability, platform, and risk evidence
- retain optional provenance-checked saved probe-result input for TypeScript recommendations

## Protocol and safety

- add `PlanTestTarget::NpmPackage` with deterministic rewrite encoding/decoding
- centralize CLI and library goal validation in `GoalSpec::validate`
- reject unknown goal fields, empty goals/constraints, more than 64 constraints, oversized files, symlinks, and replacement races
- cap goal files at 64 KiB using actual bounded reads
- block capabilities absent from installed `.d.ts` mappings for npm-only projects
- preserve Rust-backed capabilities in mixed projects and prevent probe-only plans without integration actions
- preserve read-only/offline authority: no npm, Node, Cargo, project code, probes, shells, providers, or network execution

## Test plan

- [x] typed goal-file recommendation for a materialized TypeScript project
- [x] exact WASM package version, generated symbol, probe, and npm test steps
- [x] inline-goal and goal-file pipeline parity with constraint-sensitive replay hashes
- [x] matching saved probe improves the same TypeScript capability verification
- [x] current WASM version reports applicable
- [x] stale WASM version reports unknown-version and recommends the catalog version deterministically
- [x] TypeScript human/JSON projection parity
- [x] complete project-tree no-mutation check
- [x] Clap rejects `--goal` plus `--goal-file`
- [x] malformed and semantically empty goals return typed errors
- [x] mixed project retains valid Rust integration actions
- [x] direct library planning enforces shared goal limits
- [x] existing Rust recommendation and plan-normalization regressions
- [x] full all-feature and no-default-feature discovery matrices
- [x] Clippy and rustdoc for both feature configurations with warnings denied
- [x] formatting and diff checks
- [x] independent DeepSeek production-readiness review, with all Important findings resolved

Implements Task 14B from `docs/plans/2026-07-09-amari-discovery-implementation-plan.md`.

Saved recommendation-to-plan replay remains Task 14C.
