### PR TITLE
feat: replay discovery recommendations as plans

### DIFF
--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -255,6 +255,11 @@ pub fn run() -> DiscoveryResult<()> {
             goal_file,
             probe_results,
         } => run_recommend(path, goal, goal_file, probe_results, cli.json),
+        Command::Plan {
+            candidate_id,
+            recommendation,
+            project,
+        } => run_plan(candidate_id, recommendation, project, cli.json),
         command => Err(DiscoveryError::NotImplemented(format!(
             "{} is not implemented in this build",
             command.unavailable_name()
@@ -318,6 +323,30 @@ fn run_recommend(
         render::write_json(&mut stdout, &envelope)
     } else {
         render::write_recommendation_human(&mut stdout, &envelope)
+    }
+}
+
+/// Replays one candidate from a saved recommendation artifact.
+fn run_plan(
+    candidate_id: String,
+    recommendation: PathBuf,
+    project: PathBuf,
+    json: bool,
+) -> DiscoveryResult<()> {
+    let artifact = commands::plan::read_recommendation(&recommendation)?;
+    let catalog = Catalog::embedded()?;
+    let envelope = commands::plan::replay_plan_envelope(
+        &catalog,
+        &project,
+        &candidate_id,
+        artifact,
+        &InspectionLimits::default(),
+    )?;
+    let mut stdout = io::stdout().lock();
+    if json {
+        render::write_json(&mut stdout, &envelope)
+    } else {
+        render::write_plan_human(&mut stdout, &envelope)
     }
 }
 

--- a/amari-discovery/src/commands/mod.rs
+++ b/amari-discovery/src/commands/mod.rs
@@ -7,4 +7,5 @@
 //! in the render module.
 
 pub mod discover;
+pub mod plan;
 pub mod recommend;

--- a/amari-discovery/src/commands/plan.rs
+++ b/amari-discovery/src/commands/plan.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Validation and normalization of saved recommendation candidates.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::recommend::read_bounded_input;
+use crate::inspect::{inspect_supported_project, InspectionLimits};
+use crate::planner::catalog_plan_steps;
+use crate::{
+    CandidatePlan, CapabilityId, Catalog, DiscoveryError, DiscoveryOutcome, DiscoveryResult,
+    Envelope, PlanCompatibility, PlanNormalization, PlanNormalizer, ProjectKind, Recommendation,
+    SCHEMA_V1,
+};
+
+const MAX_RECOMMENDATION_BYTES: u64 = 8 * 1_048_576;
+const REQUIRED_REPLAY_HASHES: [&str; 4] = [
+    "catalog_hash",
+    "project_hash",
+    "input_hash",
+    "probe_results",
+];
+
+/// Reads a bounded saved recommendation artifact without following symlinks.
+///
+/// # Errors
+///
+/// Returns a typed I/O, limit, input, identifier, or serialization error for
+/// an unreadable artifact, a non-regular path, or malformed protocol JSON.
+pub fn read_recommendation(
+    path: &Path,
+) -> DiscoveryResult<Envelope<DiscoveryOutcome<Recommendation>>> {
+    let bytes = read_bounded_input(path, MAX_RECOMMENDATION_BYTES, "recommendation")?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Validates and replays one candidate from a saved recommendation artifact.
+///
+/// Replay is read-only and offline. The current project is inspected again,
+/// all catalog/project/input/probe hashes are validated, and the selected plan
+/// is re-derived from the matched catalog and current snapshot before bounded
+/// canonical normalization. No project command, probe, provider, shell, or
+/// network operation is executed.
+///
+/// # Errors
+///
+/// Returns [`DiscoveryError::ReplayDrift`] for stale or internally inconsistent
+/// provenance, [`DiscoveryError::InvalidInput`] for a non-replayable artifact
+/// or unknown candidate, and typed inspection/normalization errors otherwise.
+pub fn replay_plan_envelope(
+    catalog: &Catalog,
+    project_root: &Path,
+    candidate_id: &str,
+    artifact: Envelope<DiscoveryOutcome<Recommendation>>,
+    limits: &InspectionLimits,
+) -> DiscoveryResult<Envelope<CandidatePlan>> {
+    let Envelope {
+        schema_version,
+        provenance,
+        warnings,
+        data,
+    } = artifact;
+    if schema_version != SCHEMA_V1 {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "unsupported recommendation schema `{schema_version}`"
+        )));
+    }
+    if !provenance.replay.replayable {
+        return Err(DiscoveryError::InvalidInput(
+            "recommendation artifact is not replayable".to_owned(),
+        ));
+    }
+    let declared_hashes = provenance
+        .replay
+        .required_hashes
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let required_hashes = REQUIRED_REPLAY_HASHES.into_iter().collect::<BTreeSet<_>>();
+    if declared_hashes != required_hashes
+        || provenance.replay.required_hashes.len() != REQUIRED_REPLAY_HASHES.len()
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "recommendation replay metadata must declare exactly catalog_hash, project_hash, input_hash, and probe_results"
+                .to_owned(),
+        ));
+    }
+
+    let recommendation = match data {
+        DiscoveryOutcome::Recommended(recommendation) => recommendation,
+        DiscoveryOutcome::NoApplicableCapability { .. }
+        | DiscoveryOutcome::InsufficientEvidence { .. }
+        | DiscoveryOutcome::Blocked { .. } => {
+            return Err(DiscoveryError::InvalidInput(
+                "recommendation artifact does not contain candidate plans".to_owned(),
+            ));
+        }
+    };
+    recommendation.goal.validate()?;
+    let candidate_id: CapabilityId = candidate_id.parse()?;
+    let selected = select_candidate(&recommendation, &candidate_id)?;
+
+    compare_replay(
+        "catalog_version",
+        catalog.version(),
+        &provenance.catalog.version,
+    )?;
+    compare_replay(
+        "catalog_hash",
+        catalog.content_hash(),
+        &provenance.catalog.hash,
+    )?;
+    compare_replay(
+        "catalog_version",
+        &provenance.catalog.version,
+        &selected.compatibility.catalog.version,
+    )?;
+    compare_replay(
+        "catalog_hash",
+        &provenance.catalog.hash,
+        &selected.compatibility.catalog.hash,
+    )?;
+    compare_optional_replay(
+        "project_hash",
+        provenance.project_hash.as_deref(),
+        &selected.compatibility.project_hash,
+    )?;
+    compare_optional_replay(
+        "input_hash",
+        provenance.input_hash.as_deref(),
+        &selected.compatibility.input_hash,
+    )?;
+    validate_sha256("plan_hash", &selected.plan_hash)?;
+    for replay_hash in &selected.compatibility.probe_results {
+        validate_sha256("probe_results", &replay_hash.result_hash)?;
+    }
+
+    let snapshot = inspect_supported_project(project_root, limits)?;
+    if matches!(snapshot.project_kind, ProjectKind::Unknown) {
+        return Err(DiscoveryError::InvalidInput(
+            "plan replay requires a Rust/Cargo or npm/TypeScript project".to_owned(),
+        ));
+    }
+    let actual = PlanCompatibility::from_replay_hashes(
+        catalog,
+        snapshot.project_hash.clone(),
+        &recommendation.goal,
+        selected.compatibility.probe_results.clone(),
+    )?;
+    selected.verify_replay(&actual)?;
+
+    let expected_draft = CandidatePlan {
+        capability_id: selected.capability_id.clone(),
+        prerequisite_order: selected.prerequisite_order.clone(),
+        steps: catalog_plan_steps(catalog, &snapshot, &selected.prerequisite_order)?,
+        compatibility: selected.compatibility.clone(),
+        normalization: PlanNormalization::default(),
+        plan_hash: String::new(),
+    };
+    let expected = PlanNormalizer::default().normalize(&expected_draft)?;
+    if expected.steps != selected.steps {
+        return Err(DiscoveryError::ReplayDrift {
+            field: "plan_steps".to_owned(),
+            expected: expected.plan_hash,
+            actual: selected.plan_hash,
+        });
+    }
+    if expected.normalization != selected.normalization {
+        return Err(DiscoveryError::ReplayDrift {
+            field: "normalization".to_owned(),
+            expected: "catalog-derived normalization trace".to_owned(),
+            actual: "saved normalization trace differs".to_owned(),
+        });
+    }
+    if expected.plan_hash != selected.plan_hash {
+        return Err(DiscoveryError::ReplayDrift {
+            field: "plan_hash".to_owned(),
+            expected: expected.plan_hash,
+            actual: selected.plan_hash,
+        });
+    }
+
+    Ok(Envelope {
+        schema_version,
+        provenance,
+        warnings,
+        data: expected,
+    })
+}
+
+fn select_candidate(
+    recommendation: &Recommendation,
+    candidate_id: &CapabilityId,
+) -> DiscoveryResult<CandidatePlan> {
+    std::iter::once(&recommendation.preferred)
+        .chain(&recommendation.alternatives)
+        .find(|plan| plan.capability_id == *candidate_id)
+        .cloned()
+        .ok_or_else(|| {
+            DiscoveryError::InvalidInput(format!(
+                "unknown candidate `{candidate_id}` in recommendation artifact"
+            ))
+        })
+}
+
+fn compare_optional_replay(
+    field: &str,
+    artifact: Option<&str>,
+    selected: &str,
+) -> DiscoveryResult<()> {
+    let artifact = artifact.ok_or_else(|| {
+        DiscoveryError::InvalidInput(format!("recommendation provenance is missing `{field}`"))
+    })?;
+    compare_replay(field, artifact, selected)
+}
+
+fn compare_replay(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(DiscoveryError::ReplayDrift {
+            field: field.to_owned(),
+            expected: expected.to_owned(),
+            actual: actual.to_owned(),
+        })
+    }
+}
+
+fn validate_sha256(field: &str, value: &str) -> DiscoveryResult<()> {
+    if value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(DiscoveryError::ReplayDrift {
+            field: field.to_owned(),
+            expected: "64 lowercase hexadecimal SHA-256 characters".to_owned(),
+            actual: value.to_owned(),
+        })
+    }
+}

--- a/amari-discovery/src/commands/recommend.rs
+++ b/amari-discovery/src/commands/recommend.rs
@@ -60,7 +60,11 @@ pub fn read_goal_spec(path: &Path) -> DiscoveryResult<GoalSpec> {
     Ok(goal)
 }
 
-fn read_bounded_input(path: &Path, max_bytes: u64, kind: &str) -> DiscoveryResult<Vec<u8>> {
+pub(super) fn read_bounded_input(
+    path: &Path,
+    max_bytes: u64,
+    kind: &str,
+) -> DiscoveryResult<Vec<u8>> {
     let metadata = fs::symlink_metadata(path)?;
     if !metadata.file_type().is_file() {
         return Err(DiscoveryError::InvalidInput(format!(

--- a/amari-discovery/src/planner/mod.rs
+++ b/amari-discovery/src/planner/mod.rs
@@ -17,6 +17,7 @@ pub use graph::{
     GraphLimits, GraphPath, GraphStep, RelationCostPolicy,
 };
 pub use normalize::{NormalizationLimits, PlanNormalizer};
+pub(crate) use plan::catalog_plan_steps;
 pub use plan::PlanGenerator;
 pub use rank::{
     BlockedCandidate, CandidateRanker, RankedCandidate, RankingComponents, RankingContext,

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -54,69 +54,7 @@ impl PlanGenerator {
     ) -> DiscoveryResult<CandidatePlan> {
         context.goal.validate()?;
         let prerequisite_order = prerequisite_order(candidate)?;
-        let capabilities: BTreeMap<_, _> = catalog
-            .capabilities()
-            .iter()
-            .map(|record| (record.id.clone(), record))
-            .collect();
-        let crates: BTreeMap<_, _> = catalog
-            .crates()
-            .iter()
-            .map(|record| (record.name.as_str(), record))
-            .collect();
-
-        let rust_project = matches!(
-            context.snapshot.project_kind,
-            ProjectKind::RustCargo | ProjectKind::Mixed
-        );
-        let npm_project = matches!(
-            context.snapshot.project_kind,
-            ProjectKind::NpmTypeScript | ProjectKind::Mixed
-        );
-        if !rust_project && !npm_project {
-            return Err(DiscoveryError::InvalidInput(
-                "candidate plan requires Rust/Cargo or npm project evidence".to_owned(),
-            ));
-        }
-
-        let mut steps = Vec::new();
-        for capability_id in &prerequisite_order {
-            let capability = capabilities.get(capability_id).ok_or_else(|| {
-                DiscoveryError::InvalidInput(format!(
-                    "candidate path references unknown capability `{capability_id}`"
-                ))
-            })?;
-            let mut actionable = false;
-            if rust_project {
-                let previous_len = steps.len();
-                append_rust_steps(&mut steps, capability_id, capability, &crates)?;
-                actionable |= steps.len() > previous_len;
-            }
-            if npm_project {
-                let wasm_paths = context
-                    .snapshot
-                    .typescript
-                    .as_ref()
-                    .into_iter()
-                    .flat_map(|typescript| &typescript.capabilities)
-                    .filter(|evidence| evidence.capability_id == *capability_id)
-                    .map(|evidence| evidence.wasm_path.clone())
-                    .collect::<BTreeSet<_>>();
-                if !wasm_paths.is_empty() {
-                    append_npm_steps(&mut steps, capability_id, catalog.version(), wasm_paths);
-                    actionable = true;
-                }
-            }
-            if actionable {
-                for probe_id in &capability.probe_refs {
-                    steps.push(PlanStep::Probe {
-                        capability_id: capability_id.clone(),
-                        probe_id: probe_id.clone(),
-                    });
-                }
-            }
-        }
-
+        let steps = catalog_plan_steps(catalog, &context.snapshot, &prerequisite_order)?;
         let compatibility = PlanCompatibility::from_context(catalog, context)?;
         let draft = CandidatePlan {
             capability_id: candidate.capability_id.clone(),
@@ -142,6 +80,25 @@ impl PlanCompatibility {
     /// encoded for deterministic hashing.
     pub fn from_context(catalog: &Catalog, context: &PlanningContext) -> DiscoveryResult<Self> {
         compatibility(catalog, context)
+    }
+
+    /// Reconstructs canonical replay compatibility from saved probe hashes.
+    ///
+    /// This constructor lets a fresh process validate a saved recommendation
+    /// without embedding or re-reading the original probe outputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns a semantic goal error or a serialization error while hashing
+    /// canonical replay inputs.
+    pub fn from_replay_hashes(
+        catalog: &Catalog,
+        project_hash: impl Into<String>,
+        goal: &crate::GoalSpec,
+        probe_results: Vec<ProbeReplayHash>,
+    ) -> DiscoveryResult<Self> {
+        goal.validate()?;
+        compatibility_from_hashes(catalog, project_hash.into(), goal, probe_results)
     }
 }
 
@@ -182,6 +139,74 @@ impl CandidatePlan {
         }
         Ok(())
     }
+}
+
+pub(crate) fn catalog_plan_steps(
+    catalog: &Catalog,
+    snapshot: &crate::ProjectSnapshot,
+    prerequisite_order: &[CapabilityId],
+) -> DiscoveryResult<Vec<PlanStep>> {
+    let capabilities: BTreeMap<_, _> = catalog
+        .capabilities()
+        .iter()
+        .map(|record| (record.id.clone(), record))
+        .collect();
+    let crates: BTreeMap<_, _> = catalog
+        .crates()
+        .iter()
+        .map(|record| (record.name.as_str(), record))
+        .collect();
+    let rust_project = matches!(
+        snapshot.project_kind,
+        ProjectKind::RustCargo | ProjectKind::Mixed
+    );
+    let npm_project = matches!(
+        snapshot.project_kind,
+        ProjectKind::NpmTypeScript | ProjectKind::Mixed
+    );
+    if !rust_project && !npm_project {
+        return Err(DiscoveryError::InvalidInput(
+            "candidate plan requires Rust/Cargo or npm project evidence".to_owned(),
+        ));
+    }
+
+    let mut steps = Vec::new();
+    for capability_id in prerequisite_order {
+        let capability = capabilities.get(capability_id).ok_or_else(|| {
+            DiscoveryError::InvalidInput(format!(
+                "candidate path references unknown capability `{capability_id}`"
+            ))
+        })?;
+        let mut actionable = false;
+        if rust_project {
+            let previous_len = steps.len();
+            append_rust_steps(&mut steps, capability_id, capability, &crates)?;
+            actionable |= steps.len() > previous_len;
+        }
+        if npm_project {
+            let wasm_paths = snapshot
+                .typescript
+                .as_ref()
+                .into_iter()
+                .flat_map(|typescript| &typescript.capabilities)
+                .filter(|evidence| evidence.capability_id == *capability_id)
+                .map(|evidence| evidence.wasm_path.clone())
+                .collect::<BTreeSet<_>>();
+            if !wasm_paths.is_empty() {
+                append_npm_steps(&mut steps, capability_id, catalog.version(), wasm_paths);
+                actionable = true;
+            }
+        }
+        if actionable {
+            for probe_id in &capability.probe_refs {
+                steps.push(PlanStep::Probe {
+                    capability_id: capability_id.clone(),
+                    probe_id: probe_id.clone(),
+                });
+            }
+        }
+    }
+    Ok(steps)
 }
 
 fn prerequisite_order(candidate: &RankedCandidate) -> DiscoveryResult<Vec<CapabilityId>> {
@@ -291,7 +316,7 @@ fn compatibility(
     catalog: &Catalog,
     context: &PlanningContext,
 ) -> DiscoveryResult<PlanCompatibility> {
-    let mut probe_results = context
+    let probe_results = context
         .probe_results
         .iter()
         .map(|result| {
@@ -302,14 +327,28 @@ fn compatibility(
             })
         })
         .collect::<DiscoveryResult<Vec<_>>>()?;
+    compatibility_from_hashes(
+        catalog,
+        context.snapshot.project_hash.clone(),
+        &context.goal,
+        probe_results,
+    )
+}
+
+fn compatibility_from_hashes(
+    catalog: &Catalog,
+    project_hash: String,
+    goal: &crate::GoalSpec,
+    mut probe_results: Vec<ProbeReplayHash>,
+) -> DiscoveryResult<PlanCompatibility> {
     probe_results.sort();
     probe_results.dedup();
 
-    let mut constraints = context.goal.constraints.clone();
+    let mut constraints = goal.constraints.clone();
     constraints.sort();
     constraints.dedup();
     let canonical_goal = CanonicalGoal {
-        statement: context.goal.statement.trim(),
+        statement: goal.statement.trim(),
         constraints: &constraints,
         probe_results: &probe_results,
     };
@@ -319,7 +358,7 @@ fn compatibility(
             version: catalog.version().to_owned(),
             hash: catalog.content_hash().to_owned(),
         },
-        project_hash: context.snapshot.project_hash.clone(),
+        project_hash,
         input_hash: hash_serializable(&canonical_goal)?,
         probe_results,
     })

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 
 use crate::{
     commands::discover::{ExampleResult, GraphResult, SearchResults},
-    Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope, PlanStep,
-    ProjectKind, ProjectSnapshot, Recommendation,
+    CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
+    PlanStep, ProjectKind, ProjectSnapshot, Recommendation,
 };
 
 pub(crate) fn write_json<T: Serialize>(
@@ -265,6 +265,45 @@ pub(crate) fn write_recommendation_human(
             writeln!(writer, "Recommendation blocked.")?;
             for reason in reasons {
                 writeln!(writer, "  {reason}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Plan replay
+// ---------------------------------------------------------------------------
+
+pub(crate) fn write_plan_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<CandidatePlan>,
+) -> DiscoveryResult<()> {
+    let plan = &envelope.data;
+    writeln!(writer, "Plan for: {}", plan.capability_id)?;
+    writeln!(writer, "Plan hash: {}", plan.plan_hash)?;
+    writeln!(writer, "Steps:")?;
+    for step in &plan.steps {
+        match step {
+            PlanStep::Dependency {
+                package, version, ..
+            } => writeln!(writer, "  dependency: {package} = {version}")?,
+            PlanStep::Feature {
+                package, feature, ..
+            } => writeln!(writer, "  feature: {package}/{feature}")?,
+            PlanStep::Symbol { path, .. } => writeln!(writer, "  symbol: {path}")?,
+            PlanStep::Example {
+                package, example, ..
+            } => writeln!(writer, "  example: {package}/{example}")?,
+            PlanStep::Probe { probe_id, .. } => writeln!(writer, "  probe: {probe_id}")?,
+            PlanStep::Test {
+                package, target, ..
+            } => {
+                let target = match target {
+                    crate::PlanTestTarget::AllTargets => "all targets",
+                    crate::PlanTestTarget::NpmPackage => "npm package tests",
+                };
+                writeln!(writer, "  test: {package} ({target})")?;
             }
         }
     }

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -201,15 +201,7 @@ fn help_exposes_the_approved_command_families() {
 fn unavailable_commands_use_a_typed_non_internal_failure() {
     Command::cargo_bin("amari")
         .unwrap()
-        .args([
-            "plan",
-            "amari:amari-dual:autodiff:forward-derivative",
-            "--recommendation",
-            "missing.json",
-            "--project",
-            ".",
-            "--json",
-        ])
+        .args(["shell", "--json"])
         .assert()
         .code(69)
         .stdout(predicate::str::is_empty())

--- a/amari-discovery/tests/cli_plan_replay.rs
+++ b/amari-discovery/tests/cli_plan_replay.rs
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Cross-process replay of saved recommendation candidates.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use amari_discovery::{
+    inspect_rust_project, CandidatePlan, CapabilityId, Catalog, InspectionLimits,
+    PlanCompatibility, PlanStep, ProbeBackend, ProbeResult, ResourceObservations,
+};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tempfile::{NamedTempFile, TempDir};
+use walkdir::WalkDir;
+
+const GOAL: &str = "differentiate a scalar polynomial with forward dual numbers";
+const DUAL_CAPABILITY: &str = "amari:amari-dual:autodiff:forward-derivative";
+const DUAL_PROBE: &str = "amari-probe:dual:polynomial-derivative:v1";
+
+fn fixture_source() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/rust-project"
+    ))
+}
+
+fn materialize_fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    copy_and_transform(fixture_source(), temp.path(), &version);
+    temp
+}
+
+fn copy_and_transform(src: &Path, dst: &Path, version: &str) {
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let text = name.to_string_lossy();
+        let source = entry.path();
+        if source.is_dir() {
+            let target = dst.join(&name);
+            fs::create_dir_all(&target).unwrap();
+            copy_and_transform(&source, &target, version);
+        } else if text.ends_with(".in") {
+            let target = dst.join(text.trim_end_matches(".in"));
+            let contents = fs::read_to_string(source).unwrap();
+            fs::write(target, contents.replace("__AMARI_VERSION__", version)).unwrap();
+        } else if (text == "Cargo.toml" || text == "Cargo.lock")
+            && src.join(format!("{text}.in")).exists()
+        {
+            continue;
+        } else {
+            fs::copy(source, dst.join(name)).unwrap();
+        }
+    }
+}
+
+fn tree_contents(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut entries = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| {
+            (
+                entry.path().strip_prefix(root).unwrap().to_owned(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    entries
+}
+
+fn recommendation_json(root: &Path, probe_results: Option<&Path>) -> Value {
+    recommendation_json_for_goal(root, GOAL, probe_results)
+}
+
+fn recommendation_json_for_goal(root: &Path, goal: &str, probe_results: Option<&Path>) -> Value {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command.arg("recommend").arg(root).args(["--goal", goal]);
+    if let Some(path) = probe_results {
+        command.arg("--probe-results").arg(path);
+    }
+    let output = command
+        .arg("--json")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn recompute_plan_hash(plan: &mut Value) {
+    #[derive(Serialize)]
+    struct PlanHashView<'a> {
+        capability_id: &'a CapabilityId,
+        prerequisite_order: &'a [CapabilityId],
+        steps: &'a [PlanStep],
+        compatibility: &'a PlanCompatibility,
+    }
+
+    let typed: CandidatePlan = serde_json::from_value(plan.clone()).unwrap();
+    let bytes = serde_json::to_vec(&PlanHashView {
+        capability_id: &typed.capability_id,
+        prerequisite_order: &typed.prerequisite_order,
+        steps: &typed.steps,
+        compatibility: &typed.compatibility,
+    })
+    .unwrap();
+    plan["plan_hash"] = json!(hex::encode(Sha256::digest(bytes)));
+}
+
+fn save_json(value: &Value) -> NamedTempFile {
+    let file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(file.as_file(), value).unwrap();
+    file
+}
+
+fn plan_output(
+    root: &Path,
+    recommendation: &Path,
+    candidate_id: &str,
+    json_output: bool,
+) -> Vec<u8> {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command
+        .arg("plan")
+        .arg(candidate_id)
+        .arg("--recommendation")
+        .arg(recommendation)
+        .arg("--project")
+        .arg(root);
+    if json_output {
+        command.arg("--json");
+    }
+    command
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone()
+}
+
+fn write_probe_results(root: &Path) -> NamedTempFile {
+    let catalog = Catalog::embedded().unwrap();
+    let snapshot = inspect_rust_project(root, &InspectionLimits::default()).unwrap();
+    let probe = ProbeResult {
+        probe_id: DUAL_PROBE.parse().unwrap(),
+        backend: ProbeBackend::Cpu,
+        duration_micros: 10,
+        resources: ResourceObservations {
+            operations: 3,
+            nodes: 0,
+            iterations: 1,
+            bytes: 64,
+        },
+        seed: Some(7),
+        project_hash: Some(snapshot.project_hash),
+        catalog_hash: catalog.content_hash().to_owned(),
+        input_hash: "saved-dual-input".to_owned(),
+        validated_assumptions: vec!["derivative_matches".to_owned()],
+        refuted_assumptions: Vec::new(),
+        warnings: Vec::new(),
+        output: json!({"matches": true}),
+    };
+    let file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(file.as_file(), &vec![probe]).unwrap();
+    file
+}
+
+#[test]
+fn saved_preferred_candidate_replays_with_plan_and_provenance_parity() {
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+    let recommendation = recommendation_json(fixture.path(), None);
+    let artifact = save_json(&recommendation);
+
+    let first_bytes = plan_output(fixture.path(), artifact.path(), DUAL_CAPABILITY, true);
+    let first: Value = serde_json::from_slice(&first_bytes).unwrap();
+    let second = plan_output(fixture.path(), artifact.path(), DUAL_CAPABILITY, true);
+
+    assert_eq!(first["schema_version"], recommendation["schema_version"]);
+    assert_eq!(first["provenance"], recommendation["provenance"]);
+    assert_eq!(first["data"], recommendation["data"]["data"]["preferred"]);
+    assert_eq!(first["data"]["normalization"]["normalized"], true);
+    assert_eq!(first_bytes, second);
+    assert_eq!(tree_contents(fixture.path()), before);
+    assert!(!serde_json::to_string(&first)
+        .unwrap()
+        .contains(fixture.path().to_str().unwrap()));
+}
+
+#[test]
+fn saved_alternative_candidate_replays_with_exact_plan_parity() {
+    let fixture = materialize_fixture();
+    let recommendation =
+        recommendation_json_for_goal(fixture.path(), "compute geometric algebra products", None);
+    let alternative = recommendation["data"]["data"]["alternatives"]
+        .as_array()
+        .and_then(|alternatives| alternatives.first())
+        .expect("fixture goal must retain a Pareto alternative");
+    let candidate_id = alternative["capability_id"].as_str().unwrap();
+    let artifact = save_json(&recommendation);
+
+    let replay: Value = serde_json::from_slice(&plan_output(
+        fixture.path(),
+        artifact.path(),
+        candidate_id,
+        true,
+    ))
+    .unwrap();
+
+    assert_eq!(&replay["data"], alternative);
+    assert_eq!(replay["provenance"], recommendation["provenance"]);
+}
+
+#[test]
+fn self_rehashed_non_catalog_plan_steps_are_rejected() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommendation_json(fixture.path(), None);
+    let selected = &mut recommendation["data"]["data"]["preferred"];
+    let dependency = selected["steps"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|step| step["kind"] == "dependency")
+        .unwrap();
+    dependency["package"] = json!("amari-evil");
+    dependency["version"] = json!("99.0.0");
+    recompute_plan_hash(selected);
+    let artifact = save_json(&recommendation);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("plan_steps"));
+}
+
+#[test]
+fn human_plan_output_projects_the_selected_normalized_plan() {
+    let fixture = materialize_fixture();
+    let recommendation = recommendation_json(fixture.path(), None);
+    let artifact = save_json(&recommendation);
+    let selected = &recommendation["data"]["data"]["preferred"];
+
+    let human = String::from_utf8(plan_output(
+        fixture.path(),
+        artifact.path(),
+        DUAL_CAPABILITY,
+        false,
+    ))
+    .unwrap();
+
+    assert!(human.contains(DUAL_CAPABILITY));
+    assert!(human.contains(selected["plan_hash"].as_str().unwrap()));
+    assert!(human.contains("amari-dual"));
+    assert!(human.contains(DUAL_PROBE));
+}
+
+#[test]
+fn unknown_candidate_is_rejected_without_project_mutation() {
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+    let artifact = save_json(&recommendation_json(fixture.path(), None));
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg("amari:unknown:module:symbol")
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .arg("--json")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("unknown candidate"));
+
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn changed_project_is_rejected_as_project_hash_drift() {
+    let fixture = materialize_fixture();
+    let artifact = save_json(&recommendation_json(fixture.path(), None));
+    fs::write(
+        fixture.path().join("src/replay-drift.rs"),
+        "pub fn changed_after_recommendation() {}\n",
+    )
+    .unwrap();
+    let before_replay = tree_contents(fixture.path());
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .arg("--json")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("project_hash"));
+
+    assert_eq!(tree_contents(fixture.path()), before_replay);
+}
+
+#[test]
+fn catalog_and_input_hash_drift_are_rejected() {
+    let fixture = materialize_fixture();
+    let recommendation = recommendation_json(fixture.path(), None);
+
+    let mut catalog_drift = recommendation.clone();
+    catalog_drift["provenance"]["catalog"]["hash"] = json!("0".repeat(64));
+    let catalog_artifact = save_json(&catalog_drift);
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(catalog_artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("catalog_hash"));
+
+    let mut input_drift = recommendation;
+    input_drift["data"]["data"]["goal"]["statement"] = json!("a different goal");
+    let input_artifact = save_json(&input_drift);
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(input_artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("input_hash"));
+}
+
+#[test]
+fn saved_probe_hashes_replay_without_reembedding_probe_outputs() {
+    let fixture = materialize_fixture();
+    let probes = write_probe_results(fixture.path());
+    let recommendation = recommendation_json(fixture.path(), Some(probes.path()));
+    let artifact = save_json(&recommendation);
+
+    let replay: Value = serde_json::from_slice(&plan_output(
+        fixture.path(),
+        artifact.path(),
+        DUAL_CAPABILITY,
+        true,
+    ))
+    .unwrap();
+
+    assert_eq!(replay["data"], recommendation["data"]["data"]["preferred"]);
+    assert!(replay["data"]["compatibility"]["probe_results"]
+        .as_array()
+        .is_some_and(|hashes| hashes.len() == 1));
+    assert!(!serde_json::to_string(&replay).unwrap().contains("matches"));
+}
+
+#[test]
+fn malformed_or_changed_probe_replay_hash_is_rejected() {
+    let fixture = materialize_fixture();
+    let probes = write_probe_results(fixture.path());
+    let mut recommendation = recommendation_json(fixture.path(), Some(probes.path()));
+    let mut malformed = recommendation.clone();
+    malformed["data"]["data"]["preferred"]["compatibility"]["probe_results"][0]["result_hash"] =
+        json!("not-a-sha256-hash");
+    let artifact = save_json(&malformed);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("probe_results"));
+
+    recommendation["data"]["data"]["preferred"]["compatibility"]["probe_results"][0]
+        ["result_hash"] = json!("0".repeat(64));
+    let artifact = save_json(&recommendation);
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("input_hash"));
+}
+
+#[test]
+fn replay_metadata_rejects_unknown_required_hashes() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommendation_json(fixture.path(), None);
+    recommendation["provenance"]["replay"]["required_hashes"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!("future_unvalidated_hash"));
+    let artifact = save_json(&recommendation);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("must declare exactly"));
+}
+
+#[test]
+fn changed_normalization_metadata_is_rejected() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommendation_json(fixture.path(), None);
+    recommendation["data"]["data"]["preferred"]["normalization"]["max_rewrites"] = json!(1);
+    let artifact = save_json(&recommendation);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("normalization"));
+}
+
+#[test]
+fn changed_plan_hash_is_rejected() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommendation_json(fixture.path(), None);
+    recommendation["data"]["data"]["preferred"]["plan_hash"] = json!("0".repeat(64));
+    let artifact = save_json(&recommendation);
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact.path())
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("plan_hash"));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_recommendation_artifact_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = materialize_fixture();
+    let artifact = save_json(&recommendation_json(fixture.path(), None));
+    let link_dir = TempDir::new().unwrap();
+    let link = link_dir.path().join("recommendation.json");
+    symlink(artifact.path(), &link).unwrap();
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("plan")
+        .arg(DUAL_CAPABILITY)
+        .arg("--recommendation")
+        .arg(link)
+        .arg("--project")
+        .arg(fixture.path())
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::starts_with("invalid_input:"));
+}


### PR DESCRIPTION
## Summary

- implement `amari plan <candidate-id> --recommendation FILE --project PATH` for fresh-process replay of saved recommendation candidates
- validate v1 schema/replay metadata, embedded catalog identity, current project snapshot hash, canonical goal/probe input hash, probe-result hash records, selected plan hash, and normalized fixed-point metadata
- re-derive exact integration steps from the matched catalog and current project snapshot before emitting the selected plan
- preserve exact recommendation-time plan and provenance for authentic preferred and Pareto-alternative candidates

## Replay safety

- bound recommendation artifacts to 8 MiB actual bytes
- require a regular no-follow artifact and reject symlinks/replacement races
- require exactly the four v1 replay hashes; reject missing, duplicate, or unknown declared requirements
- inspect the current Rust/Cargo, npm/TypeScript, or mixed project read-only and reject project drift
- retain only `ProbeReplayHash` records; saved probe outputs are never re-embedded or executed
- share one canonical `PlanCompatibility` hash constructor between in-process generation and fresh-process replay
- share catalog-backed step derivation between `PlanGenerator` and replay
- re-normalize catalog-derived steps from scratch and require exact steps, trace, limits, and plan-hash parity
- execute no Cargo, npm, Node, project code, probes, providers, shells, or network operations

## Adversarial coverage

- saved preferred and real Pareto-alternative candidate replay
- deterministic byte output, human projection, provenance parity, and no project mutation
- saved-probe hash replay without output-payload leakage
- unknown candidate and unsupported project handling
- catalog, project, goal/input, probe-result, plan-hash, and normalization drift
- self-rehashed non-catalog dependency injection (`amari-evil = 99.0.0`) is rejected
- unknown replay hash requirements are rejected
- symlinked recommendation artifacts are rejected

## Verification

- [x] `cargo test -p amari-discovery --all-features --quiet`
- [x] `cargo test -p amari-discovery --no-default-features --quiet`
- [x] `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --no-default-features --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] independent DeepSeek review and re-review; no Critical blockers, all Important findings resolved

Implements Task 14C from `docs/plans/2026-07-09-amari-discovery-implementation-plan.md`.

Full graph-path authentication and broader adversarial replay hardening remain Task 25B.
