### PR TITLE
feat: add typed probe registry

### DIFF
--- a/amari-discovery/src/capabilities.rs
+++ b/amari-discovery/src/capabilities.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Catalog, CatalogIdentity, Compatibility, DiscoveryError, DiscoveryResult, Envelope,
-    ReplayMetadata, SCHEMA_V1,
+    ProbeEngine, ReplayMetadata, SCHEMA_V1,
 };
 
 /// Embedded catalog availability reported by the running binary.
@@ -194,10 +194,12 @@ impl Capabilities {
     ///
     /// # Errors
     ///
-    /// Returns a catalog-corruption error when the embedded structural,
-    /// semantic, or probe documents fail validation.
+    /// Returns a catalog-corruption error when embedded documents fail
+    /// validation or a compiled adapter diverges from its probe descriptor.
     pub fn current() -> DiscoveryResult<Self> {
         let catalog = Catalog::embedded()?;
+        let probe_engine =
+            ProbeEngine::with_catalog(&catalog, crate::ProbeEngineLimits::default())?;
         let known_probes = catalog
             .probes()
             .iter()
@@ -209,18 +211,24 @@ impl Capabilities {
                     .cloned()
                     .collect();
                 let available = missing_features.is_empty();
+                let executable = available && probe_engine.is_executable(&probe.id);
                 RuntimeCapabilityState {
                     id: probe.id.to_string(),
                     known: true,
                     available,
-                    executable: false,
-                    reason: Some(if available {
-                        "required features are compiled; probe adapter is not registered yet".into()
-                    } else {
+                    executable,
+                    reason: Some(if !available {
                         format!(
                             "required features are not compiled: {}",
                             missing_features.join(", ")
                         )
+                    } else if executable && probe.deterministic {
+                        "registered deterministic adapter is available with cooperative isolation"
+                            .into()
+                    } else if executable {
+                        "registered adapter is available with cooperative isolation".into()
+                    } else {
+                        "required features are compiled; probe adapter is not registered yet".into()
                     }),
                 }
             })

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -8,9 +8,8 @@
 //!
 //! ## Features
 //!
-//! - `standard-probes` (default): compiles the standard dual-number, game,
-//!   surreal, and surcomplex probe dependencies. Probe execution is added in
-//!   later discovery runtime phases.
+//! - `standard-probes` (default): compiles registered deterministic probe
+//!   adapters, beginning with bounded tropical Viterbi decoding.
 //! - `ai`: reserves the provider-neutral AI adapter contract. It does not
 //!   enable network access or an external provider transport.
 
@@ -23,6 +22,7 @@ pub mod commands;
 pub mod error;
 pub mod inspect;
 pub mod planner;
+mod probes;
 pub mod protocol;
 mod render;
 
@@ -79,6 +79,10 @@ pub use planner::{
     RankingComponents, RankingContext, RankingProvenance, RankingResult, RankingSignal,
     RankingSignalKind, RecallConfig, RelationCostPolicy, RetrievalSource, RetrievedCandidate,
     RANKING_OBJECTIVE_ORDER,
+};
+pub use probes::{
+    ProbeEngine, ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,
+    TropicalViterbiRequest,
 };
 pub use protocol::{
     CandidatePlan, CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Registered bounded in-process capability probes.
+//!
+//! The public engine executes only fixed adapters validated against the
+//! embedded catalog. Limits are cooperative: adapters report and enforce
+//! deterministic operation, node, iteration, and byte ceilings, but this
+//! in-process API does not provide crash or wall-clock isolation.
+
+mod registry;
+mod tropical;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
+pub use tropical::{TropicalViterbiOutput, TropicalViterbiRequest};
+
+use crate::{
+    Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ResourceObservations,
+};
+
+/// Caller-selected ceilings for cooperative in-process probe execution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProbeEngineLimits {
+    /// Maximum canonical request JSON bytes.
+    pub max_input_bytes: u64,
+    /// Maximum canonical result JSON bytes.
+    pub max_output_bytes: u64,
+    /// Maximum reported domain operations.
+    pub max_operations: u64,
+    /// Maximum reported domain nodes.
+    pub max_nodes: u64,
+    /// Maximum reported domain iterations.
+    pub max_iterations: u64,
+}
+
+impl Default for ProbeEngineLimits {
+    fn default() -> Self {
+        Self {
+            max_input_bytes: 1_048_576,
+            max_output_bytes: 1_048_576,
+            max_operations: 1_000_000,
+            max_nodes: 1_000_000,
+            max_iterations: 1_000_000,
+        }
+    }
+}
+
+/// Isolation guarantee attached to a probe execution result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeIsolation {
+    /// In-process execution with cooperative limits and no crash/timeout boundary.
+    Cooperative,
+    /// Out-of-process execution with supervisor-enforced isolation.
+    Process,
+}
+
+/// Deterministic mathematical output and resource accounting from one probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeExecution {
+    /// Stable executed probe ID.
+    pub probe_id: ProbeId,
+    /// Versioned request schema validated by the adapter.
+    pub input_schema: String,
+    /// Versioned response schema emitted by the adapter.
+    pub output_schema: String,
+    /// Execution backend.
+    pub backend: ProbeBackend,
+    /// Available isolation boundary.
+    pub isolation: ProbeIsolation,
+    /// Whether identical validated inputs produce identical mathematical output.
+    pub deterministic: bool,
+    /// Cooperative resource observations.
+    pub resources: ResourceObservations,
+    /// Typed probe-specific result encoded as JSON.
+    pub output: Value,
+}
+
+/// Public cooperative executor over the fixed private probe registry.
+pub struct ProbeEngine {
+    registry: ProbeRegistry,
+    limits: ProbeEngineLimits,
+}
+
+impl ProbeEngine {
+    /// Builds an engine with default cooperative ceilings.
+    ///
+    /// # Errors
+    ///
+    /// Returns a catalog-corruption error when a compiled adapter does not
+    /// match its embedded declarative descriptor.
+    pub fn new() -> DiscoveryResult<Self> {
+        Self::with_limits(ProbeEngineLimits::default())
+    }
+
+    /// Builds an engine with caller-tightened cooperative ceilings.
+    ///
+    /// Descriptor limits always remain authoritative; caller limits can only
+    /// reduce the effective ceiling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] when any limit is zero or a
+    /// catalog-corruption error for an invalid compiled adapter registry.
+    pub fn with_limits(limits: ProbeEngineLimits) -> DiscoveryResult<Self> {
+        if limits.max_input_bytes == 0
+            || limits.max_output_bytes == 0
+            || limits.max_operations == 0
+            || limits.max_nodes == 0
+            || limits.max_iterations == 0
+        {
+            return Err(DiscoveryError::InvalidInput(
+                "cooperative probe limits must be greater than zero".to_owned(),
+            ));
+        }
+        let catalog = Catalog::embedded()?;
+        Self::with_catalog(&catalog, limits)
+    }
+
+    pub(crate) fn with_catalog(
+        catalog: &Catalog,
+        limits: ProbeEngineLimits,
+    ) -> DiscoveryResult<Self> {
+        if limits.max_input_bytes == 0
+            || limits.max_output_bytes == 0
+            || limits.max_operations == 0
+            || limits.max_nodes == 0
+            || limits.max_iterations == 0
+        {
+            return Err(DiscoveryError::InvalidInput(
+                "cooperative probe limits must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(Self {
+            registry: ProbeRegistry::build(catalog, compiled_registrations()?)?,
+            limits,
+        })
+    }
+
+    /// Returns whether a known descriptor has executable code in this build.
+    pub fn is_executable(&self, id: &ProbeId) -> bool {
+        self.registry.is_executable(id)
+    }
+
+    /// Returns every executable probe ID in deterministic order.
+    pub fn executable_probe_ids(&self) -> Vec<ProbeId> {
+        self.registry.executable_ids()
+    }
+
+    /// Validates and executes one registered probe in-process.
+    ///
+    /// This method never invokes project code, a shell, an external executable,
+    /// a provider, or the network. Isolation is explicitly cooperative.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error for an unknown descriptor, a
+    /// probe-unavailable error when the adapter is not compiled, a limit error
+    /// for request/result/resource ceilings, or a typed adapter failure.
+    pub fn execute(&self, id: &ProbeId, input: &Value) -> DiscoveryResult<ProbeExecution> {
+        if !self.registry.is_known(id) {
+            return Err(DiscoveryError::InvalidInput(format!(
+                "unknown probe `{id}`"
+            )));
+        }
+        let registered = self.registry.descriptor(id).ok_or_else(|| {
+            DiscoveryError::ProbeUnavailable(format!(
+                "probe `{id}` has no executable adapter in this build"
+            ))
+        })?;
+        // ProbeDescriptor v1 exposes one domain-work ceiling. Apply that
+        // conservative ceiling independently to operations, nodes, and
+        // iterations until the catalog protocol grows dedicated fields.
+        let descriptor_work_limit = registered.limits.max_operations;
+        let effective = EffectiveProbeLimits {
+            max_input_bytes: registered
+                .limits
+                .max_input_bytes
+                .min(self.limits.max_input_bytes),
+            max_output_bytes: registered
+                .limits
+                .max_output_bytes
+                .min(self.limits.max_output_bytes),
+            max_operations: descriptor_work_limit.min(self.limits.max_operations),
+            max_nodes: descriptor_work_limit.min(self.limits.max_nodes),
+            max_iterations: descriptor_work_limit.min(self.limits.max_iterations),
+        };
+        let input_bytes = u64::try_from(serde_json::to_vec(input)?.len()).map_err(|_| {
+            DiscoveryError::LimitExceeded("probe input byte count overflow".to_owned())
+        })?;
+        enforce_limit("input bytes", input_bytes, effective.max_input_bytes)?;
+
+        let mut result = self.registry.execute(id, input, &effective)?;
+        enforce_limit(
+            "operations",
+            result.resources.operations,
+            effective.max_operations,
+        )?;
+        enforce_limit("nodes", result.resources.nodes, effective.max_nodes)?;
+        enforce_limit(
+            "iterations",
+            result.resources.iterations,
+            effective.max_iterations,
+        )?;
+        let output_bytes =
+            u64::try_from(serde_json::to_vec(&result.output)?.len()).map_err(|_| {
+                DiscoveryError::LimitExceeded("probe output byte count overflow".to_owned())
+            })?;
+        enforce_limit("output bytes", output_bytes, effective.max_output_bytes)?;
+        result.resources.bytes = input_bytes.checked_add(output_bytes).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("probe total byte count overflow".to_owned())
+        })?;
+
+        Ok(ProbeExecution {
+            probe_id: id.clone(),
+            input_schema: registered.input_schema.clone(),
+            output_schema: registered.output_schema.clone(),
+            backend: ProbeBackend::Cpu,
+            isolation: ProbeIsolation::Cooperative,
+            deterministic: registered.deterministic,
+            resources: result.resources,
+            output: result.output,
+        })
+    }
+}
+
+fn enforce_limit(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
+    if observed <= maximum {
+        Ok(())
+    } else {
+        Err(DiscoveryError::LimitExceeded(format!(
+            "probe {kind} {observed} exceeds limit {maximum}"
+        )))
+    }
+}
+
+#[cfg(feature = "standard-probes")]
+fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
+    Ok(vec![tropical::registration()?])
+}
+
+#[cfg(not(feature = "standard-probes"))]
+fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
+    Ok(Vec::new())
+}

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Private descriptor-to-adapter registry validation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use crate::{
+    CapabilityId, Catalog, DiscoveryError, DiscoveryResult, ProbeDescriptor, ProbeId, ProbeLimits,
+    ResourceObservations, SideEffectPolicy,
+};
+
+pub(crate) type AdapterFn = fn(&Value, &EffectiveProbeLimits) -> DiscoveryResult<AdapterOutput>;
+
+#[derive(Clone)]
+pub(crate) struct AdapterRegistration {
+    pub(crate) id: ProbeId,
+    pub(crate) capability_id: CapabilityId,
+    pub(crate) input_schema: String,
+    pub(crate) output_schema: String,
+    pub(crate) required_features: Vec<String>,
+    pub(crate) limits: ProbeLimits,
+    pub(crate) deterministic: bool,
+    pub(crate) side_effects: SideEffectPolicy,
+    pub(crate) network: bool,
+    pub(crate) execute: AdapterFn,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct EffectiveProbeLimits {
+    pub(crate) max_input_bytes: u64,
+    pub(crate) max_output_bytes: u64,
+    pub(crate) max_operations: u64,
+    pub(crate) max_nodes: u64,
+    pub(crate) max_iterations: u64,
+}
+
+pub(crate) struct AdapterOutput {
+    pub(crate) resources: ResourceObservations,
+    pub(crate) output: Value,
+}
+
+pub(crate) struct ProbeRegistry {
+    known_ids: BTreeSet<ProbeId>,
+    adapters: BTreeMap<ProbeId, RegisteredAdapter>,
+}
+
+struct RegisteredAdapter {
+    descriptor: ProbeDescriptor,
+    execute: AdapterFn,
+}
+
+impl ProbeRegistry {
+    pub(crate) fn build(
+        catalog: &Catalog,
+        registrations: Vec<AdapterRegistration>,
+    ) -> DiscoveryResult<Self> {
+        let descriptors = catalog
+            .probes()
+            .iter()
+            .map(|descriptor| (descriptor.id.clone(), descriptor))
+            .collect::<BTreeMap<_, _>>();
+        let known_ids = descriptors.keys().cloned().collect();
+        let mut adapters = BTreeMap::new();
+        for registration in registrations {
+            if adapters.contains_key(&registration.id) {
+                return Err(DiscoveryError::CatalogCorruption(format!(
+                    "duplicate probe adapter `{}`",
+                    registration.id
+                )));
+            }
+            let descriptor = descriptors.get(&registration.id).ok_or_else(|| {
+                DiscoveryError::CatalogCorruption(format!(
+                    "probe adapter `{}` references an unknown descriptor",
+                    registration.id
+                ))
+            })?;
+            validate_registration(descriptor, &registration)?;
+            adapters.insert(
+                registration.id.clone(),
+                RegisteredAdapter {
+                    descriptor: (*descriptor).clone(),
+                    execute: registration.execute,
+                },
+            );
+        }
+        Ok(Self {
+            known_ids,
+            adapters,
+        })
+    }
+
+    pub(crate) fn is_known(&self, id: &ProbeId) -> bool {
+        self.known_ids.contains(id)
+    }
+
+    pub(crate) fn is_executable(&self, id: &ProbeId) -> bool {
+        self.adapters.contains_key(id)
+    }
+
+    pub(crate) fn executable_ids(&self) -> Vec<ProbeId> {
+        self.adapters.keys().cloned().collect()
+    }
+
+    pub(crate) fn execute(
+        &self,
+        id: &ProbeId,
+        input: &Value,
+        limits: &EffectiveProbeLimits,
+    ) -> DiscoveryResult<AdapterOutput> {
+        let adapter = self.adapters.get(id).ok_or_else(|| {
+            DiscoveryError::ProbeUnavailable(format!(
+                "probe `{id}` has no executable adapter in this build"
+            ))
+        })?;
+        (adapter.execute)(input, limits)
+    }
+
+    pub(crate) fn descriptor(&self, id: &ProbeId) -> Option<&ProbeDescriptor> {
+        self.adapters.get(id).map(|adapter| &adapter.descriptor)
+    }
+}
+
+fn validate_registration(
+    descriptor: &ProbeDescriptor,
+    registration: &AdapterRegistration,
+) -> DiscoveryResult<()> {
+    if descriptor.capability_id != registration.capability_id {
+        return mismatch(&registration.id, "capability");
+    }
+    if descriptor.input_schema != registration.input_schema {
+        return mismatch(&registration.id, "input schema");
+    }
+    if descriptor.output_schema != registration.output_schema {
+        return mismatch(&registration.id, "output schema");
+    }
+    if descriptor.required_features != registration.required_features {
+        return mismatch(&registration.id, "required features");
+    }
+    if descriptor.limits != registration.limits {
+        return mismatch(&registration.id, "limits");
+    }
+    if descriptor.deterministic != registration.deterministic {
+        return mismatch(&registration.id, "determinism");
+    }
+    if descriptor.side_effects != SideEffectPolicy::None
+        || registration.side_effects != SideEffectPolicy::None
+    {
+        return mismatch(&registration.id, "side effects");
+    }
+    if registration.network {
+        return mismatch(&registration.id, "network authority");
+    }
+    Ok(())
+}
+
+fn mismatch<T>(id: &ProbeId, field: &str) -> DiscoveryResult<T> {
+    Err(DiscoveryError::CatalogCorruption(format!(
+        "probe adapter `{id}` does not match descriptor {field}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{Catalog, DiscoveryError};
+
+    fn dummy_execute(
+        _input: &serde_json::Value,
+        _limits: &EffectiveProbeLimits,
+    ) -> crate::DiscoveryResult<AdapterOutput> {
+        Ok(AdapterOutput {
+            resources: ResourceObservations::default(),
+            output: json!({"ok": true}),
+        })
+    }
+
+    fn registration() -> AdapterRegistration {
+        let catalog = Catalog::embedded().unwrap();
+        let descriptor = catalog
+            .probes()
+            .iter()
+            .find(|probe| probe.id.to_string() == "amari-probe:tropical:viterbi:v1")
+            .unwrap();
+        AdapterRegistration {
+            id: descriptor.id.clone(),
+            capability_id: descriptor.capability_id.clone(),
+            input_schema: descriptor.input_schema.clone(),
+            output_schema: descriptor.output_schema.clone(),
+            required_features: descriptor.required_features.clone(),
+            limits: descriptor.limits.clone(),
+            deterministic: descriptor.deterministic,
+            side_effects: descriptor.side_effects,
+            network: false,
+            execute: dummy_execute,
+        }
+    }
+
+    fn rejects(registration: AdapterRegistration, expected: &str) {
+        let catalog = Catalog::embedded().unwrap();
+        assert!(matches!(
+            ProbeRegistry::build(&catalog, vec![registration]),
+            Err(DiscoveryError::CatalogCorruption(message)) if message.contains(expected)
+        ));
+    }
+
+    #[test]
+    fn executable_adapter_maps_one_to_one_to_known_descriptor() {
+        let catalog = Catalog::embedded().unwrap();
+        let registry = ProbeRegistry::build(&catalog, vec![registration()]).unwrap();
+        let id = "amari-probe:tropical:viterbi:v1".parse().unwrap();
+
+        assert!(registry.is_executable(&id));
+        assert_eq!(registry.executable_ids(), vec![id]);
+    }
+
+    #[test]
+    fn duplicate_and_unknown_adapters_are_rejected() {
+        let duplicate = registration();
+        let catalog = Catalog::embedded().unwrap();
+        assert!(matches!(
+            ProbeRegistry::build(&catalog, vec![duplicate.clone(), duplicate]),
+            Err(DiscoveryError::CatalogCorruption(message)) if message.contains("duplicate")
+        ));
+
+        let mut unknown = registration();
+        unknown.id = "amari-probe:tropical:unknown:v1".parse().unwrap();
+        rejects(unknown, "unknown descriptor");
+    }
+
+    #[test]
+    fn capability_and_schema_mismatches_are_rejected() {
+        let mut capability = registration();
+        capability.capability_id = "amari:amari-core:product:geometric-product"
+            .parse()
+            .unwrap();
+        rejects(capability, "capability");
+
+        let mut input = registration();
+        input.input_schema = "amari.discovery/probe/wrong/input/v1".to_owned();
+        rejects(input, "input schema");
+
+        let mut output = registration();
+        output.output_schema = "amari.discovery/probe/wrong/output/v1".to_owned();
+        rejects(output, "output schema");
+    }
+
+    #[test]
+    fn side_effect_and_network_authority_are_rejected() {
+        let mut side_effects = registration();
+        side_effects.side_effects = SideEffectPolicy::ReadOnly;
+        rejects(side_effects, "side effects");
+
+        let mut network = registration();
+        network.network = true;
+        rejects(network, "network");
+    }
+
+    #[test]
+    fn limit_determinism_and_feature_mismatches_are_rejected() {
+        let mut limits = registration();
+        limits.limits.max_operations -= 1;
+        rejects(limits, "limits");
+
+        let mut determinism = registration();
+        determinism.deterministic = false;
+        rejects(determinism, "determinism");
+
+        let mut features = registration();
+        features.required_features = vec!["ai".to_owned()];
+        rejects(features, "features");
+    }
+}

--- a/amari-discovery/src/probes/tropical.rs
+++ b/amari-discovery/src/probes/tropical.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded tropical Viterbi probe adapter.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "standard-probes")]
+use amari_tropical::viterbi::TropicalViterbi;
+#[cfg(feature = "standard-probes")]
+use serde_json::Value;
+
+#[cfg(feature = "standard-probes")]
+use super::registry::{AdapterOutput, AdapterRegistration, EffectiveProbeLimits};
+#[cfg(feature = "standard-probes")]
+use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, SideEffectPolicy};
+
+#[cfg(feature = "standard-probes")]
+const MAX_STATES: usize = 64;
+#[cfg(feature = "standard-probes")]
+const MAX_EMISSION_SYMBOLS: usize = 4_096;
+#[cfg(feature = "standard-probes")]
+const MAX_OBSERVATIONS: usize = 4_096;
+
+/// Typed input for the tropical Viterbi proof-slice probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TropicalViterbiRequest {
+    /// Square state-transition matrix of tropical log weights.
+    pub transitions: Vec<Vec<f64>>,
+    /// State-by-symbol emission matrix of tropical log weights.
+    pub emissions: Vec<Vec<f64>>,
+    /// Emission symbol indices to decode.
+    pub observations: Vec<usize>,
+}
+
+/// Typed output from tropical Viterbi decoding.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TropicalViterbiOutput {
+    /// Most likely state index at each observation.
+    pub path: Vec<usize>,
+    /// Tropical score returned by `TropicalViterbi::decode`.
+    pub score: f64,
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:tropical:viterbi:v1".parse()?,
+        capability_id: "amari:amari-tropical:sequence:viterbi".parse()?,
+        input_schema: "amari.discovery/probe/tropical-viterbi/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/tropical-viterbi/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute(input: &Value, limits: &EffectiveProbeLimits) -> DiscoveryResult<AdapterOutput> {
+    let request: TropicalViterbiRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "tropical Viterbi request does not match the versioned request schema: {error}"
+            ))
+        })?;
+    let shape = validate_request(&request, limits)?;
+    let decoder = TropicalViterbi::new(request.transitions, request.emissions);
+    let (path, score) = decoder.decode(&request.observations);
+    let score = score.value();
+    if !score.is_finite() {
+        return Err(DiscoveryError::ProbeFailed(
+            "tropical Viterbi produced a non-finite score".to_owned(),
+        ));
+    }
+    Ok(AdapterOutput {
+        resources: ResourceObservations {
+            operations: shape.operations,
+            nodes: shape.nodes,
+            iterations: shape.iterations,
+            bytes: 0,
+        },
+        output: serde_json::to_value(TropicalViterbiOutput { path, score })?,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+struct RequestShape {
+    operations: u64,
+    nodes: u64,
+    iterations: u64,
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_request(
+    request: &TropicalViterbiRequest,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<RequestShape> {
+    let states = request.transitions.len();
+    if states == 0 {
+        return invalid("tropical Viterbi requires at least one state");
+    }
+    if states > MAX_STATES {
+        return invalid(format!(
+            "tropical Viterbi state count {states} exceeds limit {MAX_STATES}"
+        ));
+    }
+    if request.transitions.iter().any(|row| row.len() != states) {
+        return invalid("tropical Viterbi requires a square transition matrix");
+    }
+    if request.emissions.len() != states {
+        return invalid("tropical Viterbi requires one emission row per state");
+    }
+    let symbols = request.emissions.first().map_or(0, Vec::len);
+    if symbols == 0
+        || symbols > MAX_EMISSION_SYMBOLS
+        || request.emissions.iter().any(|row| row.len() != symbols)
+    {
+        return invalid(format!(
+            "tropical Viterbi emission rows require equal nonzero width at most {MAX_EMISSION_SYMBOLS}"
+        ));
+    }
+    if request.observations.is_empty() {
+        return invalid("tropical Viterbi requires at least one observation");
+    }
+    if request.observations.len() > MAX_OBSERVATIONS {
+        return invalid(format!(
+            "tropical Viterbi observation count {} exceeds limit {MAX_OBSERVATIONS}",
+            request.observations.len()
+        ));
+    }
+    if request
+        .observations
+        .iter()
+        .any(|observation| *observation >= symbols)
+    {
+        return invalid(format!(
+            "tropical Viterbi observation index must be below emission width {symbols}"
+        ));
+    }
+    if request
+        .transitions
+        .iter()
+        .chain(&request.emissions)
+        .flatten()
+        .any(|weight| !weight.is_finite())
+    {
+        return invalid("tropical Viterbi matrix weights must be finite");
+    }
+
+    let states = u64::try_from(states).map_err(|_| limit("state count overflow"))?;
+    let symbols = u64::try_from(symbols).map_err(|_| limit("symbol count overflow"))?;
+    let observations = u64::try_from(request.observations.len())
+        .map_err(|_| limit("observation count overflow"))?;
+    let transition_operations = observations
+        .saturating_sub(1)
+        .checked_mul(states)
+        .and_then(|value| value.checked_mul(states))
+        .ok_or_else(|| limit("tropical Viterbi operations overflow"))?;
+    let operations = states
+        .checked_add(transition_operations)
+        .and_then(|value| value.checked_add(states))
+        .and_then(|value| value.checked_add(observations.saturating_sub(1)))
+        .ok_or_else(|| limit("tropical Viterbi operations overflow"))?;
+    let nodes = states
+        .checked_mul(states)
+        .and_then(|value| value.checked_add(states.checked_mul(symbols)?))
+        .and_then(|value| value.checked_add(states.checked_mul(observations)?))
+        .ok_or_else(|| limit("tropical Viterbi nodes overflow"))?;
+
+    enforce("operations", operations, limits.max_operations)?;
+    enforce("nodes", nodes, limits.max_nodes)?;
+    enforce("iterations", observations, limits.max_iterations)?;
+    Ok(RequestShape {
+        operations,
+        nodes,
+        iterations: observations,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn enforce(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
+    if observed <= maximum {
+        Ok(())
+    } else {
+        Err(limit(format!(
+            "tropical Viterbi {kind} {observed} exceeds limit {maximum}"
+        )))
+    }
+}
+
+#[cfg(feature = "standard-probes")]
+fn invalid<T>(message: impl Into<String>) -> DiscoveryResult<T> {
+    Err(DiscoveryError::InvalidInput(message.into()))
+}
+
+#[cfg(feature = "standard-probes")]
+fn limit(message: impl Into<String>) -> DiscoveryError {
+    DiscoveryError::LimitExceeded(message.into())
+}

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -56,7 +56,7 @@ fn capabilities_json_self_describes_schema_and_exit_codes() {
 }
 
 #[test]
-fn embedded_catalog_capabilities_do_not_forecast_probe_execution() {
+fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
     let value = capabilities_json();
 
     assert_eq!(value["data"]["catalog"]["version"], "0.23.0");
@@ -70,7 +70,9 @@ fn embedded_catalog_capabilities_do_not_forecast_probe_execution() {
     for probe in probes {
         assert_eq!(probe["known"], true);
         assert_eq!(probe["available"], cfg!(feature = "standard-probes"));
-        assert_eq!(probe["executable"], false);
+        let expected_executable =
+            cfg!(feature = "standard-probes") && probe["id"] == "amari-probe:tropical:viterbi:v1";
+        assert_eq!(probe["executable"], expected_executable);
     }
 
     for inspector in value["data"]["project_inspectors"].as_array().unwrap() {

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Public cooperative probe-engine contracts.
+
+#[cfg(feature = "standard-probes")]
+use amari_discovery::ProbeIsolation;
+use amari_discovery::{DiscoveryError, ProbeEngine, TropicalViterbiRequest};
+use serde_json::json;
+
+const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:core:geometric-product:v1";
+
+fn request() -> TropicalViterbiRequest {
+    TropicalViterbiRequest {
+        transitions: vec![vec![-1.0, -2.0], vec![-2.0, -1.0]],
+        emissions: vec![vec![-1.0, -3.0], vec![-3.0, -1.0]],
+        observations: vec![0, 1, 0],
+    }
+}
+
+#[test]
+fn engine_derives_executable_state_from_the_private_registry() {
+    let engine = ProbeEngine::new().unwrap();
+    let viterbi = VITERBI.parse().unwrap();
+    let unregistered = KNOWN_UNREGISTERED.parse().unwrap();
+
+    assert_eq!(
+        engine.is_executable(&viterbi),
+        cfg!(feature = "standard-probes")
+    );
+    assert!(!engine.is_executable(&unregistered));
+    assert_eq!(
+        engine.executable_probe_ids(),
+        if cfg!(feature = "standard-probes") {
+            vec![viterbi]
+        } else {
+            Vec::new()
+        }
+    );
+}
+
+#[test]
+fn unknown_and_known_unregistered_probes_are_typed_errors() {
+    let engine = ProbeEngine::new().unwrap();
+    let unknown = "amari-probe:unknown:operation:v1".parse().unwrap();
+    let known = KNOWN_UNREGISTERED.parse().unwrap();
+
+    assert!(matches!(
+        engine.execute(&unknown, &json!({})),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("unknown probe")
+    ));
+    assert!(matches!(
+        engine.execute(&known, &json!({})),
+        Err(DiscoveryError::ProbeUnavailable(message)) if message.contains(KNOWN_UNREGISTERED)
+    ));
+}
+
+#[cfg(feature = "standard-probes")]
+#[test]
+fn execution_reports_cooperative_isolation_and_is_byte_deterministic() {
+    let engine = ProbeEngine::new().unwrap();
+    let id = VITERBI.parse().unwrap();
+    let input = serde_json::to_value(request()).unwrap();
+
+    let first = engine.execute(&id, &input).unwrap();
+    let second = engine.execute(&id, &input).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first.probe_id, id);
+    assert_eq!(first.isolation, ProbeIsolation::Cooperative);
+    assert_eq!(first.backend, amari_discovery::ProbeBackend::Cpu);
+    assert!(first.deterministic);
+    assert_eq!(
+        first.input_schema,
+        "amari.discovery/probe/tropical-viterbi/input/v1"
+    );
+    assert_eq!(
+        first.output_schema,
+        "amari.discovery/probe/tropical-viterbi/output/v1"
+    );
+    assert!(first.resources.operations > 0);
+    assert!(first.resources.nodes > 0);
+    assert!(first.resources.iterations > 0);
+    assert!(first.resources.bytes > 0);
+}
+
+#[cfg(not(feature = "standard-probes"))]
+#[test]
+fn no_default_features_keeps_descriptor_known_but_not_executable() {
+    let engine = ProbeEngine::new().unwrap();
+    let id = VITERBI.parse().unwrap();
+
+    assert!(!engine.is_executable(&id));
+    assert!(matches!(
+        engine.execute(&id, &serde_json::to_value(request()).unwrap()),
+        Err(DiscoveryError::ProbeUnavailable(_))
+    ));
+}

--- a/amari-discovery/tests/probe_tropical.rs
+++ b/amari-discovery/tests/probe_tropical.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tropical Viterbi proof-slice parity and cooperative limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, ProbeEngine, ProbeEngineLimits, TropicalViterbiOutput, TropicalViterbiRequest,
+};
+use amari_tropical::viterbi::TropicalViterbi;
+use serde_json::{json, Value};
+
+const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
+
+fn request() -> TropicalViterbiRequest {
+    TropicalViterbiRequest {
+        transitions: vec![vec![-1.0, -2.0], vec![-2.0, -1.0]],
+        emissions: vec![vec![-1.0, -3.0], vec![-3.0, -1.0]],
+        observations: vec![0, 1, 0],
+    }
+}
+
+fn execute(engine: &ProbeEngine, request: &TropicalViterbiRequest) -> TropicalViterbiOutput {
+    let execution = engine
+        .execute(
+            &VITERBI.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap();
+    serde_json::from_value(execution.output).unwrap()
+}
+
+fn invalid(engine: &ProbeEngine, input: Value, expected: &str) {
+    let error = engine
+        .execute(&VITERBI.parse().unwrap(), &input)
+        .unwrap_err();
+    assert!(
+        matches!(error, DiscoveryError::InvalidInput(ref message) if message.contains(expected)),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn viterbi_output_matches_direct_amari_tropical_decode() {
+    let request = request();
+    let direct = TropicalViterbi::new(request.transitions.clone(), request.emissions.clone())
+        .decode(&request.observations);
+    let output = execute(&ProbeEngine::new().unwrap(), &request);
+
+    assert_eq!(output.path, direct.0);
+    assert_eq!(output.score, direct.1.value());
+}
+
+#[test]
+fn matrix_shape_state_and_observation_validation_precedes_execution() {
+    let engine = ProbeEngine::new().unwrap();
+    let mut empty_states = request();
+    empty_states.transitions.clear();
+    invalid(
+        &engine,
+        serde_json::to_value(empty_states).unwrap(),
+        "at least one state",
+    );
+
+    let mut non_square = request();
+    non_square.transitions[0].pop();
+    invalid(
+        &engine,
+        serde_json::to_value(non_square).unwrap(),
+        "square transition",
+    );
+
+    let mut emission_rows = request();
+    emission_rows.emissions.pop();
+    invalid(
+        &engine,
+        serde_json::to_value(emission_rows).unwrap(),
+        "emission row per state",
+    );
+
+    let mut ragged_emissions = request();
+    ragged_emissions.emissions[0].pop();
+    invalid(
+        &engine,
+        serde_json::to_value(ragged_emissions).unwrap(),
+        "equal nonzero width",
+    );
+
+    let mut no_observations = request();
+    no_observations.observations.clear();
+    invalid(
+        &engine,
+        serde_json::to_value(no_observations).unwrap(),
+        "at least one observation",
+    );
+
+    let mut bad_observation = request();
+    bad_observation.observations[1] = 2;
+    invalid(
+        &engine,
+        serde_json::to_value(bad_observation).unwrap(),
+        "observation index",
+    );
+
+    let mut non_finite = serde_json::to_value(request()).unwrap();
+    non_finite["transitions"][0][0] = Value::Null;
+    invalid(&engine, non_finite, "request schema");
+}
+
+#[test]
+fn state_and_observation_count_ceilings_are_enforced() {
+    let engine = ProbeEngine::new().unwrap();
+    let states = 65;
+    let too_many_states = TropicalViterbiRequest {
+        transitions: vec![vec![0.0; states]; states],
+        emissions: vec![vec![0.0]; states],
+        observations: vec![0],
+    };
+    invalid(
+        &engine,
+        serde_json::to_value(too_many_states).unwrap(),
+        "state count",
+    );
+
+    let mut too_many_observations = request();
+    too_many_observations.observations = vec![0; 4097];
+    invalid(
+        &engine,
+        serde_json::to_value(too_many_observations).unwrap(),
+        "observation count",
+    );
+}
+
+#[test]
+fn request_operation_node_iteration_and_output_byte_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_nodes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "nodes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let engine = ProbeEngine::with_limits(limits).unwrap();
+        let error = engine
+            .execute(&VITERBI.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
+    }
+}
+
+#[test]
+fn caller_limits_cannot_loosen_descriptor_work_ceiling() {
+    let states = 64;
+    let request = TropicalViterbiRequest {
+        transitions: vec![vec![0.0; states]; states],
+        emissions: vec![vec![0.0]; states],
+        observations: vec![0; 30],
+    };
+    let engine = ProbeEngine::with_limits(ProbeEngineLimits {
+        max_input_bytes: u64::MAX,
+        max_output_bytes: u64::MAX,
+        max_operations: u64::MAX,
+        max_nodes: u64::MAX,
+        max_iterations: u64::MAX,
+    })
+    .unwrap();
+
+    assert!(matches!(
+        engine.execute(
+            &VITERBI.parse().unwrap(),
+            &serde_json::to_value(request).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("operations") && message.contains("100000")
+    ));
+}
+
+#[test]
+fn non_finite_algorithm_result_is_a_typed_probe_failure() {
+    let request = TropicalViterbiRequest {
+        transitions: vec![vec![1.7e308]],
+        emissions: vec![vec![1.7e308]],
+        observations: vec![0, 0],
+    };
+
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &VITERBI.parse().unwrap(),
+            &serde_json::to_value(request).unwrap()
+        ),
+        Err(DiscoveryError::ProbeFailed(message)) if message.contains("non-finite score")
+    ));
+}
+
+#[test]
+fn zero_cooperative_limits_are_rejected() {
+    assert!(matches!(
+        ProbeEngine::with_limits(ProbeEngineLimits {
+            max_iterations: 0,
+            ..ProbeEngineLimits::default()
+        }),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("greater than zero")
+    ));
+}
+
+#[test]
+fn malformed_json_shape_is_a_typed_input_error() {
+    invalid(
+        &ProbeEngine::new().unwrap(),
+        json!({"transitions": [], "unexpected": true}),
+        "request schema",
+    );
+}


### PR DESCRIPTION
## Summary

- add a private fixed probe registry that validates each compiled adapter one-to-one against its embedded declarative `ProbeDescriptor`
- expose a public cooperative `ProbeEngine` with explicit request/output/operation/node/iteration ceilings and `isolation = cooperative`
- implement the first `standard-probes` adapter: bounded tropical Viterbi decoding with direct `amari_tropical::viterbi::TropicalViterbi::decode` parity
- derive `amari capabilities` probe executability from the validated registry rather than hardcoded names

## Registry trust boundary

- reject duplicate adapters and unknown descriptor IDs
- reject capability, input/output schema, required-feature, limit, and determinism mismatches
- reject any adapter or descriptor side-effect authority beyond `none`
- reject adapter network authority
- keep registry, registrations, and function pointers crate-private
- expose no dynamic registration, executable path, shell, provider, project-code, or network surface

## Cooperative engine

- intersects caller limits with authoritative descriptor ceilings; callers can tighten but never loosen
- validates canonical JSON input bytes before adapter execution
- enforces domain shape and work limits before direct mathematical API calls
- defensively rechecks reported operations, nodes, and iterations after execution
- bounds serialized output and checked aggregate byte accounting
- reports deterministic CPU execution and explicit cooperative isolation
- makes no crash or wall-clock isolation claim; process isolation remains Tasks 21A–21C

## Tropical Viterbi proof slice

- typed `TropicalViterbiRequest { transitions, emissions, observations }`
- typed `TropicalViterbiOutput { path, score }`
- square transitions, matching/ragged emission validation, finite weights, symbol indices, nonempty inputs
- 64-state and 4,096-observation/symbol ceilings
- checked exact algorithm operation accounting and bounded matrix/trellis node accounting
- typed handling of non-finite algorithm output
- request/output byte ceilings and caller-tightened operation/node/iteration limits

## Feature behavior

- `standard-probes`: Viterbi descriptor is known, available, and executable
- `--no-default-features`: all catalog probe descriptors remain known but no adapters are executable
- capabilities reuse one validated catalog parse and derive executable IDs from the private registry

## Verification

- [x] strict RED → GREEN for registry rejection and public probe behavior
- [x] `cargo test -p amari-discovery --all-features --quiet`
- [x] `cargo test -p amari-discovery --no-default-features --quiet`
- [x] `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --no-default-features --no-deps`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] independent DeepSeek review and re-review; no Critical or Important blockers

Implements Task 15 from `docs/plans/2026-07-09-amari-discovery-implementation-plan.md`.

Next planned slices add core and dual adapters through this same registry/engine boundary.
