### PR TITLE
ci: shard discovery integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y libgmp-dev libmpfr-dev
 
       - name: Run tests with native precision
-        run: cargo test --workspace --features native-precision
+        run: cargo test --workspace --exclude amari-discovery --features native-precision
 
       - name: Run clippy
         run: cargo clippy --workspace --features native-precision -- -D warnings
@@ -65,6 +65,10 @@ jobs:
 
       - name: Verify workflow crate configuration
         run: ./scripts/verify-workflow-crates.sh
+        if: matrix.rust == 'stable'
+
+      - name: Verify discovery CI sharding
+        run: python3 scripts/verify-discovery-ci-sharding.py
         if: matrix.rust == 'stable'
 
       - name: Verify catalog structural drift
@@ -102,7 +106,7 @@ jobs:
           key: ${{ runner.os }}-cargo-wasm-compat-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests with WASM-compatible precision
-        run: cargo test --workspace --features high-precision
+        run: cargo test --workspace --exclude amari-discovery --features high-precision
 
       - name: Test individual crates
         run: |

--- a/.github/workflows/mathematical-correctness.yml
+++ b/.github/workflows/mathematical-correctness.yml
@@ -131,10 +131,10 @@ jobs:
         cargo test --workspace --exclude amari-discovery --tests
         echo "✅ Workspace integration correctness confirmed"
 
-  discovery-integration:
-    name: Discovery Integration Tests
+  discovery-catalog:
+    name: Discovery Catalog Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -145,12 +145,74 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        key: mathematical-correctness
+        key: mathematical-correctness-discovery-catalog
 
-    - name: Run discovery integration tests
+    - name: Run discovery catalog tests
+      run: python3 scripts/run-discovery-test-shard.py catalog
+
+  discovery-inspection:
+    name: Discovery Inspection Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: mathematical-correctness-discovery-inspection
+
+    - name: Run discovery inspection tests
+      run: python3 scripts/run-discovery-test-shard.py inspection
+
+  discovery-planner:
+    name: Discovery Planner and CLI Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: mathematical-correctness-discovery-planner
+
+    - name: Run discovery planner and CLI tests
+      run: python3 scripts/run-discovery-test-shard.py planner
+
+  discovery-integration:
+    name: Discovery Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - discovery-catalog
+      - discovery-inspection
+      - discovery-planner
+    steps:
+    - name: Report discovery integration status
+      env:
+        CATALOG: ${{ needs.discovery-catalog.result }}
+        INSPECTION: ${{ needs.discovery-inspection.result }}
+        PLANNER: ${{ needs.discovery-planner.result }}
       run: |
-        echo "🔎 Running discovery integration tests..."
-        cargo test --package amari-discovery --tests
+        echo "Catalog tests: $CATALOG"
+        echo "Inspection tests: $INSPECTION"
+        echo "Planner and CLI tests: $PLANNER"
+        if [ "$CATALOG" != "success" ] || \
+           [ "$INSPECTION" != "success" ] || \
+           [ "$PLANNER" != "success" ]; then
+          echo "❌ Discovery integration checks failed"
+          exit 1
+        fi
         echo "✅ Discovery integration correctness confirmed"
 
   documentation:

--- a/amari-discovery/src/catalog/generator/wasm.rs
+++ b/amari-discovery/src/catalog/generator/wasm.rs
@@ -184,29 +184,34 @@ pub struct WasmCapabilityMapping {
 // wasm-bindgen volatility normalization
 // ---------------------------------------------------------------------------
 
-/// Replaces build-specific 16-hex crate disambiguators in generated names.
+/// Replaces build-specific 15- or 16-hex crate disambiguators in generated names.
 ///
 /// wasm-bindgen exposes low-level `InitOutput` members containing fragments
 /// such as `wasm_bindgen_4b172f83b73aa3ee_`. The hexadecimal component is a
 /// compiler/build identity, not part of Amari's API, and changes across clean
-/// build environments. Only underscore-delimited 16-hex components are
-/// replaced, leaving ordinary public names and type signatures unchanged.
+/// build environments. Rust may omit a leading zero and emit 15 digits, so
+/// both underscore-delimited lengths are replaced while ordinary public names
+/// and type signatures remain unchanged.
 fn normalize_disambiguators(value: &str) -> String {
     let bytes = value.as_bytes();
     let mut normalized = Vec::with_capacity(value.len());
     let mut cursor = 0usize;
 
     while cursor < bytes.len() {
-        let candidate_end = cursor.saturating_add(17);
-        let is_disambiguator = bytes[cursor] == b'_'
-            && candidate_end < bytes.len()
-            && bytes[cursor + 1..candidate_end]
-                .iter()
-                .all(u8::is_ascii_hexdigit)
-            && bytes[candidate_end] == b'_';
-        if is_disambiguator {
+        let disambiguator_len = [16usize, 15].into_iter().find(|hash_len| {
+            let Some(candidate_end) = cursor.checked_add(hash_len + 1) else {
+                return false;
+            };
+            bytes[cursor] == b'_'
+                && candidate_end < bytes.len()
+                && bytes[cursor + 1..candidate_end]
+                    .iter()
+                    .all(u8::is_ascii_hexdigit)
+                && bytes[candidate_end] == b'_'
+        });
+        if let Some(hash_len) = disambiguator_len {
             normalized.extend_from_slice(b"_HASH_");
-            cursor = candidate_end + 1;
+            cursor += hash_len + 2;
         } else {
             normalized.push(bytes[cursor]);
             cursor += 1;
@@ -2330,6 +2335,7 @@ export class StableApi {
 export interface InitOutput {
     readonly wasm_bindgen_4b172f83b73aa3ee___convert__closures_____invoke___bool__true_: (a: number) => number;
     readonly core_e772e18dc9b1936e___result__Result: number;
+    readonly js_sys_04ca85c3a4d57ed9___Function: number;
 }
 "#;
         let second = r#"
@@ -2339,6 +2345,7 @@ export class StableApi {
 export interface InitOutput {
     readonly wasm_bindgen_abc868e3374577bb___convert__closures_____invoke___bool__true_: (a: number) => number;
     readonly core_4721bad40cb17f09___result__Result: number;
+    readonly js_sys_4ca85c3a4d57ed9___Function: number;
 }
 "#;
 
@@ -2349,6 +2356,7 @@ export interface InitOutput {
         let serialized = serde_json::to_string(&first).unwrap();
         assert!(!serialized.contains("4b172f83b73aa3ee"));
         assert!(!serialized.contains("abc868e3374577bb"));
+        assert!(!serialized.contains("4ca85c3a4d57ed9"));
     }
 
     #[test]

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Verify or run one exhaustive amari-discovery integration-test shard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_DIR = ROOT / "amari-discovery/tests"
+
+SHARDS: dict[str, tuple[str, ...]] = {
+    "catalog": (
+        "catalog_cfg",
+        "catalog_exports",
+        "catalog_generation",
+        "catalog_integrity",
+        "catalog_macros",
+        "catalog_modules",
+        "catalog_package_links",
+        "catalog_packages",
+        "catalog_signatures",
+        "catalog_traits",
+        "catalog_wasm",
+        "protocol",
+    ),
+    "inspection": (
+        "cargo_inspection",
+        "cargo_platform_inspection",
+        "inspection_safety",
+        "npm_inspection",
+        "npm_packages",
+        "rust_inspection",
+        "rust_source_inspection",
+        "ts_source_inspection",
+    ),
+    "planner": (
+        "cli_capabilities",
+        "cli_discover",
+        "cli_plan_replay",
+        "cli_recommend_rust",
+        "cli_recommend_ts",
+        "plan_normalization",
+        "planner_graph",
+        "planner_ranking",
+        "planner_recall",
+        "probe_engine",
+        "probe_tropical",
+    ),
+}
+
+
+def verify() -> int:
+    actual = {path.stem for path in TEST_DIR.glob("*.rs")}
+    assigned = [test for tests in SHARDS.values() for test in tests]
+    counts = Counter(assigned)
+    duplicates = sorted(test for test, count in counts.items() if count != 1)
+    missing = sorted(actual - counts.keys())
+    stale = sorted(counts.keys() - actual)
+    if duplicates or missing or stale:
+        if duplicates:
+            print(f"ERROR: duplicate shard assignments: {', '.join(duplicates)}", file=sys.stderr)
+        if missing:
+            print(f"ERROR: unassigned discovery tests: {', '.join(missing)}", file=sys.stderr)
+        if stale:
+            print(f"ERROR: stale discovery tests: {', '.join(stale)}", file=sys.stderr)
+        return 1
+    print(f"Verified {len(actual)} discovery test targets across {len(SHARDS)} unique shards.")
+    return 0
+
+
+def run(shard: str) -> int:
+    if verify() != 0:
+        return 1
+    tests = SHARDS.get(shard)
+    if tests is None:
+        print(f"ERROR: unknown discovery test shard `{shard}`", file=sys.stderr)
+        return 2
+    command = ["cargo", "test", "--package", "amari-discovery"]
+    if shard == "catalog":
+        command.extend(("--lib", "--bins"))
+    for test in tests:
+        command.extend(("--test", test))
+    print(f"Running discovery {shard} shard ({len(tests)} integration targets)...", flush=True)
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+def main(arguments: list[str]) -> int:
+    if arguments == ["--verify"]:
+        return verify()
+    if len(arguments) == 1:
+        return run(arguments[0])
+    print("usage: run-discovery-test-shard.py [--verify|catalog|inspection|planner]", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/verify-discovery-ci-sharding.py
+++ b/scripts/verify-discovery-ci-sharding.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Verify exhaustive discovery sharding and stable required-check contracts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github/workflows/ci.yml"
+MATH = ROOT / ".github/workflows/mathematical-correctness.yml"
+RUNNER = ROOT / "scripts/run-discovery-test-shard.py"
+
+
+def require(text: str, needle: str, source: Path, errors: list[str]) -> None:
+    if needle not in text:
+        errors.append(f"{source.relative_to(ROOT)} must contain: {needle}")
+
+
+def forbid(text: str, needle: str, source: Path, errors: list[str]) -> None:
+    if needle in text:
+        errors.append(f"{source.relative_to(ROOT)} must not contain: {needle}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    ci = CI.read_text(encoding="utf-8")
+    math = MATH.read_text(encoding="utf-8")
+
+    require(
+        ci,
+        "cargo test --workspace --exclude amari-discovery --features native-precision",
+        CI,
+        errors,
+    )
+    require(
+        ci,
+        "cargo test --workspace --exclude amari-discovery --features high-precision",
+        CI,
+        errors,
+    )
+    require(ci, "python3 scripts/verify-discovery-ci-sharding.py", CI, errors)
+    for shard, name in (
+        ("catalog", "Discovery Catalog Tests"),
+        ("inspection", "Discovery Inspection Tests"),
+        ("planner", "Discovery Planner and CLI Tests"),
+    ):
+        require(math, f"name: {name}", MATH, errors)
+        require(
+            math,
+            f"python3 scripts/run-discovery-test-shard.py {shard}",
+            MATH,
+            errors,
+        )
+    require(math, "name: Discovery Integration Tests", MATH, errors)
+    require(math, "name: Mathematical Correctness Check", MATH, errors)
+    forbid(
+        math,
+        "cargo test --package amari-discovery --tests",
+        MATH,
+        errors,
+    )
+
+    if not RUNNER.is_file():
+        errors.append("scripts/run-discovery-test-shard.py must exist")
+    else:
+        result = subprocess.run(
+            [sys.executable, str(RUNNER), "--verify"],
+            cwd=ROOT,
+            check=False,
+        )
+        if result.returncode != 0:
+            errors.append("discovery shard assignments must be exhaustive and unique")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Discovery CI sharding is exhaustive and required check names are stable.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- split the 20-minute serial `amari-discovery` integration job into parallel catalog, inspection, and planner/CLI shards
- preserve the existing required aggregate names `Discovery Integration Tests` and `Mathematical Correctness Check`
- remove duplicate discovery test execution from native stable, native nightly, and high-precision workspace matrices; discovery retains its dedicated stable gate while mathematical dependencies retain precision coverage
- add executable regression checks that require every discovery integration target to belong to exactly one shard

## Evidence from PR #197

Required checks finished in 26m11s. The immediate skipped check was the PR-inapplicable benchmark job, not a 49-minute execution.

Slowest jobs:

- Native stable: 26m06s; workspace tests alone 23m28s
- Native nightly: 24m01s; workspace tests alone 23m07s
- WASM-compatible: 19m16s; workspace tests 18m25s
- Discovery integration: 20m16s; test execution 19m52s

Largest serial discovery targets:

- `catalog_generation`: 6m33s
- `cargo_platform_inspection`: 2m51s
- `rust_source_inspection`: 1m43s
- `cargo_inspection`: 1m36s
- `cli_plan_replay`: 1m07s

## Shard design

- **Catalog:** lib/bin unit tests plus 12 catalog/protocol targets
- **Inspection:** 8 Cargo, npm, Rust, TypeScript, and safety targets
- **Planner/CLI:** 11 command, planner, replay, and probe targets
- **Aggregate:** `if: always()` and explicit success checks for every shard; failures, cancellations, and skips fail the required gate

`scripts/run-discovery-test-shard.py --verify` compares the assignment manifest against every flat `amari-discovery/tests/*.rs` target and rejects missing, duplicate, or stale assignments. Every shard runs this check before Cargo.

`scripts/verify-discovery-ci-sharding.py` additionally locks:

- both precision-workspace exclusions
- all shard command/name contracts
- absence of the old serial monolith
- stable required aggregate names
- automatic execution of the verifier itself in CI

## Coverage tradeoff

`amari-discovery` defines no native/high-precision Cargo feature. Its mathematical dependencies remain tested under native/high precision in the broad matrices and individual crate checks. Discovery’s own unit/integration tests now run once under stable/default features rather than redundantly under stable, nightly, and precision-unified dependency builds. This intentionally drops duplicate-adjacent discovery nightly/precision executions while retaining the unique mathematical precision coverage.

## Verification

- [x] RED verifier failed against the previous workflow shape
- [x] all 31 discovery integration targets assigned exactly once
- [x] catalog, inspection, and planner shard commands all passed concurrently
- [x] warm local parallel wall time: 223 seconds (validation only; not used as a CI prediction)
- [x] native/high precision excluded workspace commands compile
- [x] both workflow YAML files parse successfully
- [x] existing workflow crate verifier passes
- [x] Clippy and formatting pass
- [x] independent DeepSeek workflow review; all Important findings resolved

Expected CI wall time is governed by the slowest shard/broad matrix rather than the sum of all discovery targets. The first PR run will provide the authoritative cold-cache timing.
