### PR TITLE
feat: add optimization and holographic discovery probes

### DIFF
--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -81,7 +81,8 @@ pub use planner::{
     RANKING_OBJECTIVE_ORDER,
 };
 pub use probes::{
-    Cl3ProductOutput, Cl3ProductRequest, NetworkPath, NetworkShortestPathOutput,
+    Cl3ProductOutput, Cl3ProductRequest, HolographicSuperpositionOutput,
+    HolographicSuperpositionRequest, NetworkPath, NetworkShortestPathOutput,
     NetworkShortestPathRequest, ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest,
     ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
     ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -81,11 +81,12 @@ pub use planner::{
     RANKING_OBJECTIVE_ORDER,
 };
 pub use probes::{
-    Cl3ProductOutput, Cl3ProductRequest, HolographicSuperpositionOutput,
-    HolographicSuperpositionRequest, NetworkPath, NetworkShortestPathOutput,
-    NetworkShortestPathRequest, ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest,
-    ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
-    ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,
+    Cl3ProductOutput, Cl3ProductRequest, HolographicAttribution, HolographicCapacity,
+    HolographicEntry, HolographicRecallOutput, HolographicRecallRequest,
+    HolographicSuperpositionOutput, HolographicSuperpositionRequest, NetworkPath,
+    NetworkShortestPathOutput, NetworkShortestPathRequest, ObjectiveDirection, ParetoFrontOutput,
+    ParetoFrontRequest, ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest,
+    ProbeEngine, ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,
     TropicalViterbiRequest,
 };
 pub use protocol::{

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -82,8 +82,9 @@ pub use planner::{
 };
 pub use probes::{
     Cl3ProductOutput, Cl3ProductRequest, NetworkPath, NetworkShortestPathOutput,
-    NetworkShortestPathRequest, PolynomialDerivativeOutput, PolynomialDerivativeRequest,
-    ProbeEngine, ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,
+    NetworkShortestPathRequest, ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest,
+    ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
+    ProbeEngineLimits, ProbeExecution, ProbeIsolation, TropicalViterbiOutput,
     TropicalViterbiRequest,
 };
 pub use protocol::{

--- a/amari-discovery/src/probes/holographic.rs
+++ b/amari-discovery/src/probes/holographic.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "standard-probes")]
-use amari_holographic::{algebra::map::MAP256, BindingAlgebra};
+use amari_holographic::{algebra::map::MAP256, AlgebraConfig, BindingAlgebra, HolographicMemory};
 #[cfg(feature = "standard-probes")]
 use serde_json::Value;
 
@@ -18,6 +18,12 @@ use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, 
 const MAP_DIMENSION: u64 = 256;
 #[cfg(feature = "standard-probes")]
 const MAX_SUPERPOSITION_SEEDS: u64 = 256;
+#[cfg(feature = "standard-probes")]
+const MAX_RECALL_ENTRIES: u64 = 32;
+#[cfg(feature = "standard-probes")]
+const RECALL_PASSES_PER_ENTRY: u64 = 11;
+#[cfg(feature = "standard-probes")]
+const RECALL_FIXED_PASSES: u64 = 6;
 
 /// Typed request for deterministic additive MAP256 superposition.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -32,6 +38,90 @@ pub struct HolographicSuperpositionRequest {
 pub struct HolographicSuperpositionOutput {
     /// Additive trace coefficients in MAP component order.
     pub coefficients: Vec<f64>,
+}
+
+/// One deterministic key-value entry for holographic memory.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HolographicEntry {
+    /// Seed for the MAP256 key.
+    pub key_seed: u64,
+    /// Seed for the MAP256 value.
+    pub value_seed: u64,
+}
+
+/// Typed request for MAP256 associative-memory retrieval.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HolographicRecallRequest {
+    /// Ordered key-value entries stored with existing memory semantics.
+    pub entries: Vec<HolographicEntry>,
+    /// Seed for the query key.
+    pub query_seed: u64,
+}
+
+/// One normalized key-attribution weight.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HolographicAttribution {
+    /// Entry index in storage order.
+    pub index: usize,
+    /// Nonnegative normalized attribution weight.
+    pub weight: f64,
+}
+
+/// Capacity metrics reported by `HolographicMemory<MAP256>`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HolographicCapacity {
+    /// Number of stored entries.
+    pub item_count: usize,
+    /// Theoretical MAP256 capacity estimate.
+    pub theoretical_capacity: usize,
+    /// Current estimated signal-to-noise ratio.
+    pub estimated_snr: f64,
+    /// Recommended minimum signal-to-noise ratio.
+    pub snr_threshold: f64,
+    /// Whether storage exceeds half the theoretical capacity.
+    pub near_capacity: bool,
+}
+
+/// Typed output from MAP256 associative-memory retrieval.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HolographicRecallOutput {
+    /// Retrieved value after configured cleanup.
+    pub value_coefficients: Vec<f64>,
+    /// Raw value before configured cleanup.
+    pub raw_coefficients: Vec<f64>,
+    /// Deterministic confidence derived from entry count and dimension.
+    pub confidence: f64,
+    /// Similarity between the retrieved value and query key.
+    pub query_similarity: f64,
+    /// Significant tracked-key attributions in memory order semantics.
+    pub attribution: Vec<HolographicAttribution>,
+    /// Capacity metrics from the underlying memory.
+    pub capacity: HolographicCapacity,
+    /// Deterministic bounded warnings.
+    pub warnings: Vec<String>,
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn recall_registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:holographic:recall:v1".parse()?,
+        capability_id: "amari:amari-holographic:memory:retrieval".parse()?,
+        input_schema: "amari.discovery/probe/holographic-recall/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/holographic-recall/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute: execute_recall,
+    })
 }
 
 #[cfg(feature = "standard-probes")]
@@ -52,6 +142,75 @@ pub(super) fn superposition_registration() -> DiscoveryResult<AdapterRegistratio
         side_effects: SideEffectPolicy::None,
         network: false,
         execute: execute_superposition,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute_recall(input: &Value, limits: &EffectiveProbeLimits) -> DiscoveryResult<AdapterOutput> {
+    let request: HolographicRecallRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "holographic recall request requires bounded entries with integer seeds: {error}"
+            ))
+        })?;
+    let resources = validate_recall(&request, limits)?;
+
+    let mut memory = HolographicMemory::<MAP256>::with_key_tracking(AlgebraConfig::default());
+    for entry in request.entries {
+        memory.store(
+            &MAP256::from_seed(entry.key_seed),
+            &MAP256::from_seed(entry.value_seed),
+        );
+    }
+    let retrieval = memory.retrieve(&MAP256::from_seed(request.query_seed));
+    let capacity = memory.capacity_info();
+    let value_coefficients = retrieval.value.components().to_vec();
+    let raw_coefficients = retrieval.raw_value.components().to_vec();
+    if value_coefficients
+        .iter()
+        .chain(&raw_coefficients)
+        .any(|coefficient| !coefficient.is_finite())
+        || !retrieval.confidence.is_finite()
+        || !retrieval.query_similarity.is_finite()
+        || retrieval
+            .attribution
+            .iter()
+            .any(|(_, weight)| !weight.is_finite())
+        || !capacity.estimated_snr.is_finite()
+        || !capacity.snr_threshold.is_finite()
+    {
+        return Err(DiscoveryError::ProbeFailed(
+            "MAP256 recall produced a non-finite result".to_owned(),
+        ));
+    }
+    let attribution = retrieval
+        .attribution
+        .into_iter()
+        .map(|(index, weight)| HolographicAttribution { index, weight })
+        .collect();
+    let warnings = if capacity.near_capacity {
+        vec!["MAP256 memory is near or above recommended capacity".to_owned()]
+    } else {
+        Vec::new()
+    };
+
+    Ok(AdapterOutput {
+        resources,
+        output: serde_json::to_value(HolographicRecallOutput {
+            value_coefficients,
+            raw_coefficients,
+            confidence: retrieval.confidence,
+            query_similarity: retrieval.query_similarity,
+            attribution,
+            capacity: HolographicCapacity {
+                item_count: capacity.item_count,
+                theoretical_capacity: capacity.theoretical_capacity,
+                estimated_snr: capacity.estimated_snr,
+                snr_threshold: capacity.snr_threshold,
+                near_capacity: capacity.near_capacity,
+            },
+            warnings,
+        })?,
     })
 }
 
@@ -87,6 +246,57 @@ fn execute_superposition(
     Ok(AdapterOutput {
         resources,
         output: serde_json::to_value(HolographicSuperpositionOutput { coefficients })?,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_recall(
+    request: &HolographicRecallRequest,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<ResourceObservations> {
+    if request.entries.is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "holographic recall requires at least one entry".to_owned(),
+        ));
+    }
+    let entry_count = u64::try_from(request.entries.len()).map_err(|_| {
+        DiscoveryError::LimitExceeded("holographic entry count overflow".to_owned())
+    })?;
+    if entry_count > MAX_RECALL_ENTRIES {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "holographic entry count {entry_count} exceeds limit {MAX_RECALL_ENTRIES}"
+        )));
+    }
+    let operations = entry_count
+        .checked_mul(RECALL_PASSES_PER_ENTRY)
+        .and_then(|passes| passes.checked_add(RECALL_FIXED_PASSES))
+        .and_then(|passes| passes.checked_mul(MAP_DIMENSION))
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("holographic recall operation count overflow".to_owned())
+        })?;
+    let nodes = entry_count
+        .checked_mul(2)
+        .and_then(|count| count.checked_add(3))
+        .and_then(|count| count.checked_mul(MAP_DIMENSION))
+        .and_then(|count| count.checked_add(entry_count))
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("holographic recall node count overflow".to_owned())
+        })?;
+    let iterations = entry_count
+        .checked_mul(2)
+        .and_then(|count| count.checked_add(1))
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("holographic recall iteration count overflow".to_owned())
+        })?;
+    enforce("operations", operations, limits.max_operations)?;
+    enforce("nodes", nodes, limits.max_nodes)?;
+    enforce("iterations", iterations, limits.max_iterations)?;
+
+    Ok(ResourceObservations {
+        operations,
+        nodes,
+        iterations,
+        bytes: 0,
     })
 }
 

--- a/amari-discovery/src/probes/holographic.rs
+++ b/amari-discovery/src/probes/holographic.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded holographic MAP256 probe adapters.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "standard-probes")]
+use amari_holographic::{algebra::map::MAP256, BindingAlgebra};
+#[cfg(feature = "standard-probes")]
+use serde_json::Value;
+
+#[cfg(feature = "standard-probes")]
+use super::registry::{AdapterOutput, AdapterRegistration, EffectiveProbeLimits};
+#[cfg(feature = "standard-probes")]
+use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, SideEffectPolicy};
+
+#[cfg(feature = "standard-probes")]
+const MAP_DIMENSION: u64 = 256;
+#[cfg(feature = "standard-probes")]
+const MAX_SUPERPOSITION_SEEDS: u64 = 256;
+
+/// Typed request for deterministic additive MAP256 superposition.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HolographicSuperpositionRequest {
+    /// Seeds converted deterministically with `MAP256::from_seed`.
+    pub seeds: Vec<u64>,
+}
+
+/// Typed output from additive MAP256 superposition.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HolographicSuperpositionOutput {
+    /// Additive trace coefficients in MAP component order.
+    pub coefficients: Vec<f64>,
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn superposition_registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:holographic:superposition:v1".parse()?,
+        capability_id: "amari:amari-holographic:algebra:superposition".parse()?,
+        input_schema: "amari.discovery/probe/holographic-superposition/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/holographic-superposition/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute: execute_superposition,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute_superposition(
+    input: &Value,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<AdapterOutput> {
+    let request: HolographicSuperpositionRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "holographic superposition request requires an array of integer seeds: {error}"
+            ))
+        })?;
+    let resources = validate_superposition(&request, limits)?;
+
+    let mut trace = MAP256::zero();
+    for seed in request.seeds {
+        trace = trace.superpose(&MAP256::from_seed(seed)).map_err(|error| {
+            DiscoveryError::ProbeFailed(format!("MAP256 additive superposition failed: {error}"))
+        })?;
+    }
+    let coefficients = trace.components().to_vec();
+    if coefficients
+        .iter()
+        .any(|coefficient| !coefficient.is_finite())
+    {
+        return Err(DiscoveryError::ProbeFailed(
+            "MAP256 additive superposition produced a non-finite coefficient".to_owned(),
+        ));
+    }
+
+    Ok(AdapterOutput {
+        resources,
+        output: serde_json::to_value(HolographicSuperpositionOutput { coefficients })?,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_superposition(
+    request: &HolographicSuperpositionRequest,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<ResourceObservations> {
+    if request.seeds.is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "holographic superposition requires at least one seed".to_owned(),
+        ));
+    }
+    let seed_count = u64::try_from(request.seeds.len())
+        .map_err(|_| DiscoveryError::LimitExceeded("holographic seed count overflow".to_owned()))?;
+    if seed_count > MAX_SUPERPOSITION_SEEDS {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "holographic seed count {seed_count} exceeds limit {MAX_SUPERPOSITION_SEEDS}"
+        )));
+    }
+    let operations = seed_count.checked_mul(MAP_DIMENSION).ok_or_else(|| {
+        DiscoveryError::LimitExceeded("holographic operation count overflow".to_owned())
+    })?;
+    let nodes = seed_count
+        .checked_add(1)
+        .and_then(|count| count.checked_mul(MAP_DIMENSION))
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("holographic node count overflow".to_owned())
+        })?;
+    enforce("operations", operations, limits.max_operations)?;
+    enforce("nodes", nodes, limits.max_nodes)?;
+    enforce("iterations", seed_count, limits.max_iterations)?;
+
+    Ok(ResourceObservations {
+        operations,
+        nodes,
+        iterations: seed_count,
+        bytes: 0,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn enforce(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
+    if observed <= maximum {
+        Ok(())
+    } else {
+        Err(DiscoveryError::LimitExceeded(format!(
+            "holographic {kind} {observed} exceeds limit {maximum}"
+        )))
+    }
+}

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -20,7 +20,10 @@ use serde_json::Value;
 
 pub use core::{Cl3ProductOutput, Cl3ProductRequest};
 pub use dual::{PolynomialDerivativeOutput, PolynomialDerivativeRequest};
-pub use holographic::{HolographicSuperpositionOutput, HolographicSuperpositionRequest};
+pub use holographic::{
+    HolographicAttribution, HolographicCapacity, HolographicEntry, HolographicRecallOutput,
+    HolographicRecallRequest, HolographicSuperpositionOutput, HolographicSuperpositionRequest,
+};
 pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathRequest};
 pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
@@ -251,6 +254,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
     Ok(vec![
         core::registration()?,
         dual::registration()?,
+        holographic::recall_registration()?,
         holographic::superposition_registration()?,
         network::registration()?,
         optimization::registration()?,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -10,6 +10,7 @@
 mod core;
 mod dual;
 mod network;
+mod optimization;
 mod registry;
 mod tropical;
 
@@ -19,6 +20,7 @@ use serde_json::Value;
 pub use core::{Cl3ProductOutput, Cl3ProductRequest};
 pub use dual::{PolynomialDerivativeOutput, PolynomialDerivativeRequest};
 pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathRequest};
+pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
 pub use tropical::{TropicalViterbiOutput, TropicalViterbiRequest};
 
@@ -248,6 +250,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
         core::registration()?,
         dual::registration()?,
         network::registration()?,
+        optimization::registration()?,
         tropical::registration()?,
     ])
 }

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -9,6 +9,7 @@
 
 mod core;
 mod dual;
+mod holographic;
 mod network;
 mod optimization;
 mod registry;
@@ -19,6 +20,7 @@ use serde_json::Value;
 
 pub use core::{Cl3ProductOutput, Cl3ProductRequest};
 pub use dual::{PolynomialDerivativeOutput, PolynomialDerivativeRequest};
+pub use holographic::{HolographicSuperpositionOutput, HolographicSuperpositionRequest};
 pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathRequest};
 pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
@@ -249,6 +251,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
     Ok(vec![
         core::registration()?,
         dual::registration()?,
+        holographic::superposition_registration()?,
         network::registration()?,
         optimization::registration()?,
         tropical::registration()?,

--- a/amari-discovery/src/probes/optimization.rs
+++ b/amari-discovery/src/probes/optimization.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded multi-objective Pareto-front probe adapter.
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "standard-probes")]
+use amari_optimization::multiobjective::{Individual, ParetoFront};
+#[cfg(feature = "standard-probes")]
+use serde_json::Value;
+
+#[cfg(feature = "standard-probes")]
+use super::registry::{AdapterOutput, AdapterRegistration, EffectiveProbeLimits};
+#[cfg(feature = "standard-probes")]
+use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, SideEffectPolicy};
+
+#[cfg(feature = "standard-probes")]
+const MAX_POPULATION: u64 = 256;
+#[cfg(feature = "standard-probes")]
+const MAX_DIMENSIONS: u64 = 32;
+
+/// Optimization direction for one objective dimension.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectiveDirection {
+    /// Prefer lower objective values.
+    Minimize,
+    /// Prefer higher objective values.
+    Maximize,
+}
+
+/// Typed request for extracting a Pareto front from objective vectors.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParetoFrontRequest {
+    /// Objective vector for each candidate.
+    pub objectives: Vec<Vec<f64>>,
+    /// Direction for each objective dimension.
+    pub directions: Vec<ObjectiveDirection>,
+}
+
+/// One non-dominated point in the original objective convention.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ParetoPoint {
+    /// Zero-based candidate index from the request.
+    pub index: usize,
+    /// Original, untransformed objective values.
+    pub objectives: Vec<f64>,
+}
+
+/// Typed output from Pareto-front extraction.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ParetoFrontOutput {
+    /// Non-dominated points ordered by original candidate index.
+    pub solutions: Vec<ParetoPoint>,
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:optimization:pareto-front:v1".parse()?,
+        capability_id: "amari:amari-optimization:multiobjective:pareto-front".parse()?,
+        input_schema: "amari.discovery/probe/optimization-pareto-front/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/optimization-pareto-front/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute(input: &Value, limits: &EffectiveProbeLimits) -> DiscoveryResult<AdapterOutput> {
+    let request: ParetoFrontRequest = serde_json::from_value(input.clone()).map_err(|error| {
+        DiscoveryError::InvalidInput(format!(
+            "Pareto request requires a finite rectangular population and objective directions: {error}"
+        ))
+    })?;
+    let resources = validate_request(&request, limits)?;
+
+    let mut front = ParetoFront::new();
+    for (index, objectives) in request.objectives.iter().enumerate() {
+        let mut individual = Individual::new(vec![index as f64]);
+        individual.objectives = objectives
+            .iter()
+            .zip(&request.directions)
+            .map(|(objective, direction)| match direction {
+                ObjectiveDirection::Minimize => *objective,
+                ObjectiveDirection::Maximize => -*objective,
+            })
+            .collect();
+        front.add_if_non_dominated(individual);
+    }
+
+    let mut indices = front
+        .solutions
+        .iter()
+        .map(|individual| {
+            let marker = individual.variables.first().copied().ok_or_else(|| {
+                DiscoveryError::Internal("Pareto result lost its candidate marker".to_owned())
+            })?;
+            let index = marker as usize;
+            if index >= request.objectives.len() || index as f64 != marker {
+                return Err(DiscoveryError::Internal(
+                    "Pareto result contains an invalid candidate marker".to_owned(),
+                ));
+            }
+            Ok(index)
+        })
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    indices.sort_unstable();
+    let solutions = indices
+        .into_iter()
+        .map(|index| ParetoPoint {
+            index,
+            objectives: request.objectives[index].clone(),
+        })
+        .collect();
+
+    Ok(AdapterOutput {
+        resources,
+        output: serde_json::to_value(ParetoFrontOutput { solutions })?,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_request(
+    request: &ParetoFrontRequest,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<ResourceObservations> {
+    if request.objectives.is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "Pareto population must be non-empty".to_owned(),
+        ));
+    }
+    let population = u64::try_from(request.objectives.len()).map_err(|_| {
+        DiscoveryError::LimitExceeded("Pareto population count overflow".to_owned())
+    })?;
+    if population > MAX_POPULATION {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "Pareto population {population} exceeds limit {MAX_POPULATION}"
+        )));
+    }
+    if request.directions.is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "Pareto objective dimension must be non-zero".to_owned(),
+        ));
+    }
+    let dimensions = u64::try_from(request.directions.len())
+        .map_err(|_| DiscoveryError::LimitExceeded("Pareto dimension count overflow".to_owned()))?;
+    if dimensions > MAX_DIMENSIONS {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "Pareto dimensions {dimensions} exceeds limit {MAX_DIMENSIONS}"
+        )));
+    }
+    if request
+        .objectives
+        .iter()
+        .any(|objectives| objectives.len() != request.directions.len())
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "every Pareto candidate must match the objective dimension".to_owned(),
+        ));
+    }
+    if request
+        .objectives
+        .iter()
+        .flatten()
+        .any(|objective| !objective.is_finite())
+    {
+        return Err(DiscoveryError::InvalidInput(
+            "Pareto objectives must be finite".to_owned(),
+        ));
+    }
+
+    let nodes = population.checked_mul(dimensions).ok_or_else(|| {
+        DiscoveryError::LimitExceeded("Pareto objective cell count overflow".to_owned())
+    })?;
+    let operations = population.checked_mul(nodes).ok_or_else(|| {
+        DiscoveryError::LimitExceeded("Pareto operation count overflow".to_owned())
+    })?;
+    enforce("operations", operations, limits.max_operations)?;
+    enforce("nodes", nodes, limits.max_nodes)?;
+    enforce("iterations", population, limits.max_iterations)?;
+
+    Ok(ResourceObservations {
+        operations,
+        nodes,
+        iterations: population,
+        bytes: 0,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn enforce(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
+    if observed <= maximum {
+        Ok(())
+    } else {
+        Err(DiscoveryError::LimitExceeded(format!(
+            "Pareto {kind} {observed} exceeds limit {maximum}"
+        )))
+    }
+}

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -230,6 +230,7 @@ mod tests {
             vec![
                 "amari-probe:core:geometric-product:v1".parse().unwrap(),
                 "amari-probe:dual:polynomial-derivative:v1".parse().unwrap(),
+                "amari-probe:holographic:superposition:v1".parse().unwrap(),
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
                 "amari-probe:optimization:pareto-front:v1".parse().unwrap(),
                 "amari-probe:tropical:viterbi:v1".parse().unwrap(),

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -230,6 +230,7 @@ mod tests {
             vec![
                 "amari-probe:core:geometric-product:v1".parse().unwrap(),
                 "amari-probe:dual:polynomial-derivative:v1".parse().unwrap(),
+                "amari-probe:holographic:recall:v1".parse().unwrap(),
                 "amari-probe:holographic:superposition:v1".parse().unwrap(),
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
                 "amari-probe:optimization:pareto-front:v1".parse().unwrap(),

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -231,6 +231,7 @@ mod tests {
                 "amari-probe:core:geometric-product:v1".parse().unwrap(),
                 "amari-probe:dual:polynomial-derivative:v1".parse().unwrap(),
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
+                "amari-probe:optimization:pareto-front:v1".parse().unwrap(),
                 "amari-probe:tropical:viterbi:v1".parse().unwrap(),
             ]
         );

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -77,6 +77,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                     "amari-probe:core:geometric-product:v1"
                         | "amari-probe:dual:polynomial-derivative:v1"
                         | "amari-probe:network:shortest-path:v1"
+                        | "amari-probe:optimization:pareto-front:v1"
                         | "amari-probe:tropical:viterbi:v1"
                 )
             );

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -76,6 +76,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                 Some(
                     "amari-probe:core:geometric-product:v1"
                         | "amari-probe:dual:polynomial-derivative:v1"
+                        | "amari-probe:holographic:recall:v1"
                         | "amari-probe:holographic:superposition:v1"
                         | "amari-probe:network:shortest-path:v1"
                         | "amari-probe:optimization:pareto-front:v1"

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -76,6 +76,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                 Some(
                     "amari-probe:core:geometric-product:v1"
                         | "amari-probe:dual:polynomial-derivative:v1"
+                        | "amari-probe:holographic:superposition:v1"
                         | "amari-probe:network:shortest-path:v1"
                         | "amari-probe:optimization:pareto-front:v1"
                         | "amari-probe:tropical:viterbi:v1"

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -10,8 +10,9 @@ use serde_json::json;
 const CORE_PRODUCT: &str = "amari-probe:core:geometric-product:v1";
 const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
+const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:optimization:pareto-front:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:holographic:superposition:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -27,6 +28,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let core = CORE_PRODUCT.parse().unwrap();
     let dual = POLYNOMIAL_DERIVATIVE.parse().unwrap();
     let network = SHORTEST_PATH.parse().unwrap();
+    let optimization = PARETO_FRONT.parse().unwrap();
     let viterbi = VITERBI.parse().unwrap();
     let unregistered = KNOWN_UNREGISTERED.parse().unwrap();
 
@@ -43,6 +45,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
+        engine.is_executable(&optimization),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
         engine.is_executable(&viterbi),
         cfg!(feature = "standard-probes")
     );
@@ -50,7 +56,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     assert_eq!(
         engine.executable_probe_ids(),
         if cfg!(feature = "standard-probes") {
-            vec![core, dual, network, viterbi]
+            vec![core, dual, network, optimization, viterbi]
         } else {
             Vec::new()
         }

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -11,8 +11,9 @@ const CORE_PRODUCT: &str = "amari-probe:core:geometric-product:v1";
 const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
 const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
+const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:holographic:superposition:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:holographic:recall:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -29,6 +30,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let dual = POLYNOMIAL_DERIVATIVE.parse().unwrap();
     let network = SHORTEST_PATH.parse().unwrap();
     let optimization = PARETO_FRONT.parse().unwrap();
+    let superposition = SUPERPOSITION.parse().unwrap();
     let viterbi = VITERBI.parse().unwrap();
     let unregistered = KNOWN_UNREGISTERED.parse().unwrap();
 
@@ -38,6 +40,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
     );
     assert_eq!(
         engine.is_executable(&dual),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
+        engine.is_executable(&superposition),
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
@@ -56,7 +62,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     assert_eq!(
         engine.executable_probe_ids(),
         if cfg!(feature = "standard-probes") {
-            vec![core, dual, network, optimization, viterbi]
+            vec![core, dual, superposition, network, optimization, viterbi]
         } else {
             Vec::new()
         }

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -11,9 +11,10 @@ const CORE_PRODUCT: &str = "amari-probe:core:geometric-product:v1";
 const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
 const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
+const RECALL: &str = "amari-probe:holographic:recall:v1";
 const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:holographic:recall:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:cgt:nim-sum:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -30,6 +31,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let dual = POLYNOMIAL_DERIVATIVE.parse().unwrap();
     let network = SHORTEST_PATH.parse().unwrap();
     let optimization = PARETO_FRONT.parse().unwrap();
+    let recall = RECALL.parse().unwrap();
     let superposition = SUPERPOSITION.parse().unwrap();
     let viterbi = VITERBI.parse().unwrap();
     let unregistered = KNOWN_UNREGISTERED.parse().unwrap();
@@ -40,6 +42,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
     );
     assert_eq!(
         engine.is_executable(&dual),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
+        engine.is_executable(&recall),
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
@@ -62,7 +68,15 @@ fn engine_derives_executable_state_from_the_private_registry() {
     assert_eq!(
         engine.executable_probe_ids(),
         if cfg!(feature = "standard-probes") {
-            vec![core, dual, superposition, network, optimization, viterbi]
+            vec![
+                core,
+                dual,
+                recall,
+                superposition,
+                network,
+                optimization,
+                viterbi,
+            ]
         } else {
             Vec::new()
         }

--- a/amari-discovery/tests/probe_holographic.rs
+++ b/amari-discovery/tests/probe_holographic.rs
@@ -5,12 +5,14 @@
 #![cfg(feature = "standard-probes")]
 
 use amari_discovery::{
-    DiscoveryError, HolographicSuperpositionOutput, HolographicSuperpositionRequest, ProbeEngine,
-    ProbeEngineLimits, ProbeExecution,
+    DiscoveryError, HolographicAttribution, HolographicCapacity, HolographicEntry,
+    HolographicRecallOutput, HolographicRecallRequest, HolographicSuperpositionOutput,
+    HolographicSuperpositionRequest, ProbeEngine, ProbeEngineLimits, ProbeExecution,
 };
-use amari_holographic::{algebra::map::MAP256, BindingAlgebra};
+use amari_holographic::{algebra::map::MAP256, AlgebraConfig, BindingAlgebra, HolographicMemory};
 use serde_json::json;
 
+const RECALL: &str = "amari-probe:holographic:recall:v1";
 const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 
 fn execute_superposition(
@@ -20,6 +22,15 @@ fn execute_superposition(
     engine
         .execute(
             &SUPERPOSITION.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+fn execute_recall(engine: &ProbeEngine, request: HolographicRecallRequest) -> ProbeExecution {
+    engine
+        .execute(
+            &RECALL.parse().unwrap(),
             &serde_json::to_value(request).unwrap(),
         )
         .unwrap()
@@ -94,6 +105,193 @@ fn empty_and_oversized_seed_sets_are_rejected() {
                 | DiscoveryError::LimitExceeded(ref message)
                 if message.contains(expected)
         ));
+    }
+}
+
+#[test]
+fn recall_matches_direct_holographic_memory_retrieval() {
+    let request = HolographicRecallRequest {
+        entries: vec![
+            HolographicEntry {
+                key_seed: 3,
+                value_seed: 103,
+            },
+            HolographicEntry {
+                key_seed: 5,
+                value_seed: 105,
+            },
+            HolographicEntry {
+                key_seed: 8,
+                value_seed: 108,
+            },
+        ],
+        query_seed: 5,
+    };
+    let mut memory = HolographicMemory::<MAP256>::with_key_tracking(AlgebraConfig::default());
+    for entry in &request.entries {
+        memory.store(
+            &MAP256::from_seed(entry.key_seed),
+            &MAP256::from_seed(entry.value_seed),
+        );
+    }
+    let expected = memory.retrieve(&MAP256::from_seed(request.query_seed));
+    let capacity = memory.capacity_info();
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute_recall(&engine, request.clone());
+    let second = execute_recall(&engine, request);
+    let output: HolographicRecallOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(output.value_coefficients, expected.value.components());
+    assert_eq!(output.raw_coefficients, expected.raw_value.components());
+    assert_eq!(output.confidence, expected.confidence);
+    assert_eq!(output.query_similarity, expected.query_similarity);
+    assert_eq!(
+        output.attribution,
+        expected
+            .attribution
+            .into_iter()
+            .map(|(index, weight)| HolographicAttribution { index, weight })
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        output.capacity,
+        HolographicCapacity {
+            item_count: capacity.item_count,
+            theoretical_capacity: capacity.theoretical_capacity,
+            estimated_snr: capacity.estimated_snr,
+            snr_threshold: capacity.snr_threshold,
+            near_capacity: capacity.near_capacity,
+        }
+    );
+    assert!(output.warnings.is_empty());
+    assert_eq!(first.resources.operations, 9_984);
+    assert_eq!(first.resources.nodes, 2_307);
+    assert_eq!(first.resources.iterations, 7);
+}
+
+#[test]
+fn recall_capacity_warning_is_deterministic() {
+    let entries = (0..24)
+        .map(|seed| HolographicEntry {
+            key_seed: seed,
+            value_seed: seed + 1_000,
+        })
+        .collect();
+    let request = HolographicRecallRequest {
+        entries,
+        query_seed: 0,
+    };
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute_recall(&engine, request.clone());
+    let second = execute_recall(&engine, request);
+    let output: HolographicRecallOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert!(output.capacity.near_capacity);
+    assert_eq!(output.capacity.item_count, 24);
+    assert_eq!(output.capacity.theoretical_capacity, 46);
+    assert_eq!(output.warnings.len(), 1);
+    assert!(output.warnings[0].contains("capacity"));
+}
+
+#[test]
+fn recall_entries_and_shape_are_bounded() {
+    for (input, expected) in [
+        (
+            json!({ "entries": [], "query_seed": 0 }),
+            "at least one entry",
+        ),
+        (
+            json!({
+                "entries": vec![json!({ "key_seed": 0, "value_seed": 1 }); 33],
+                "query_seed": 0,
+            }),
+            "entry count 33 exceeds limit 32",
+        ),
+        (
+            json!({ "entries": [{ "key_seed": "bad", "value_seed": 1 }], "query_seed": 0 }),
+            "integer seeds",
+        ),
+    ] {
+        let error = ProbeEngine::new()
+            .unwrap()
+            .execute(&RECALL.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            DiscoveryError::InvalidInput(ref message)
+                | DiscoveryError::LimitExceeded(ref message)
+                if message.contains(expected)
+        ));
+    }
+}
+
+#[test]
+fn recall_cooperative_limits_are_enforced() {
+    let input = serde_json::to_value(HolographicRecallRequest {
+        entries: vec![
+            HolographicEntry {
+                key_seed: 3,
+                value_seed: 103,
+            },
+            HolographicEntry {
+                key_seed: 5,
+                value_seed: 105,
+            },
+            HolographicEntry {
+                key_seed: 8,
+                value_seed: 108,
+            },
+        ],
+        query_seed: 5,
+    })
+    .unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 9_983,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_nodes: 2_306,
+                ..ProbeEngineLimits::default()
+            },
+            "nodes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 6,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let error = ProbeEngine::with_limits(limits)
+            .unwrap()
+            .execute(&RECALL.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
     }
 }
 

--- a/amari-discovery/tests/probe_holographic.rs
+++ b/amari-discovery/tests/probe_holographic.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Holographic MAP256 probe parity and limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, HolographicSuperpositionOutput, HolographicSuperpositionRequest, ProbeEngine,
+    ProbeEngineLimits, ProbeExecution,
+};
+use amari_holographic::{algebra::map::MAP256, BindingAlgebra};
+use serde_json::json;
+
+const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
+
+fn execute_superposition(
+    engine: &ProbeEngine,
+    request: HolographicSuperpositionRequest,
+) -> ProbeExecution {
+    engine
+        .execute(
+            &SUPERPOSITION.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+fn direct_superposition(seeds: &[u64]) -> MAP256 {
+    seeds.iter().fold(MAP256::zero(), |trace, seed| {
+        trace.superpose(&MAP256::from_seed(*seed)).unwrap()
+    })
+}
+
+#[test]
+fn superposition_matches_repeated_binding_algebra_addition() {
+    let request = HolographicSuperpositionRequest {
+        seeds: vec![7, 11, 29],
+    };
+    let expected = direct_superposition(&request.seeds);
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute_superposition(&engine, request.clone());
+    let second = execute_superposition(&engine, request);
+    let output: HolographicSuperpositionOutput =
+        serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(output.coefficients, expected.components().to_vec());
+    assert_eq!(output.coefficients.len(), 256);
+    assert_eq!(first.resources.operations, 768);
+    assert_eq!(first.resources.nodes, 1_024);
+    assert_eq!(first.resources.iterations, 3);
+}
+
+#[test]
+fn additive_superposition_is_not_attention_style_bundle_cleanup() {
+    let seeds = vec![3, 5, 8];
+    let elements = seeds
+        .iter()
+        .map(|seed| MAP256::from_seed(*seed))
+        .collect::<Vec<_>>();
+    let bundled = <MAP256 as BindingAlgebra>::bundle_all(&elements, 1.0).unwrap();
+    let output: HolographicSuperpositionOutput = serde_json::from_value(
+        execute_superposition(
+            &ProbeEngine::new().unwrap(),
+            HolographicSuperpositionRequest { seeds },
+        )
+        .output,
+    )
+    .unwrap();
+
+    assert_ne!(output.coefficients, bundled.components().to_vec());
+    assert!(output
+        .coefficients
+        .iter()
+        .any(|coefficient| coefficient.abs() > 1.0));
+}
+
+#[test]
+fn empty_and_oversized_seed_sets_are_rejected() {
+    for (input, expected) in [
+        (json!({ "seeds": [] }), "at least one seed"),
+        (
+            json!({ "seeds": vec![0; 257] }),
+            "seed count 257 exceeds limit 256",
+        ),
+    ] {
+        let error = ProbeEngine::new()
+            .unwrap()
+            .execute(&SUPERPOSITION.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            DiscoveryError::InvalidInput(ref message)
+                | DiscoveryError::LimitExceeded(ref message)
+                if message.contains(expected)
+        ));
+    }
+}
+
+#[test]
+fn superposition_cooperative_limits_are_enforced() {
+    let input = serde_json::to_value(HolographicSuperpositionRequest {
+        seeds: vec![7, 11, 29],
+    })
+    .unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 767,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_nodes: 1_023,
+                ..ProbeEngineLimits::default()
+            },
+            "nodes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 2,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let error = ProbeEngine::with_limits(limits)
+            .unwrap()
+            .execute(&SUPERPOSITION.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
+    }
+}

--- a/amari-discovery/tests/probe_optimization.rs
+++ b/amari-discovery/tests/probe_optimization.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Multi-objective Pareto-front probe parity and limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint,
+    ProbeEngine, ProbeEngineLimits, ProbeExecution,
+};
+use amari_optimization::multiobjective::{Individual, ParetoFront};
+use serde_json::json;
+
+const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
+
+fn request() -> ParetoFrontRequest {
+    ParetoFrontRequest {
+        objectives: vec![
+            vec![1.0, 1.0],
+            vec![2.0, 3.0],
+            vec![0.5, 0.5],
+            vec![3.0, 0.0],
+        ],
+        directions: vec![ObjectiveDirection::Minimize, ObjectiveDirection::Maximize],
+    }
+}
+
+fn execute(engine: &ProbeEngine, request: ParetoFrontRequest) -> ProbeExecution {
+    engine
+        .execute(
+            &PARETO_FRONT.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+fn direct_front(request: &ParetoFrontRequest) -> Vec<usize> {
+    let mut front = ParetoFront::new();
+    for (index, objectives) in request.objectives.iter().enumerate() {
+        let mut individual = Individual::new(vec![index as f64]);
+        individual.objectives = objectives
+            .iter()
+            .zip(&request.directions)
+            .map(|(objective, direction)| match direction {
+                ObjectiveDirection::Minimize => *objective,
+                ObjectiveDirection::Maximize => -*objective,
+            })
+            .collect();
+        front.add_if_non_dominated(individual);
+    }
+    let mut indices = front
+        .solutions
+        .iter()
+        .map(|individual| individual.variables[0] as usize)
+        .collect::<Vec<_>>();
+    indices.sort_unstable();
+    indices
+}
+
+#[test]
+fn output_matches_direct_individual_and_pareto_front_parity() {
+    let request = request();
+    let expected = direct_front(&request);
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute(&engine, request.clone());
+    let second = execute(&engine, request.clone());
+    let output: ParetoFrontOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        output
+            .solutions
+            .iter()
+            .map(|point| point.index)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert_eq!(
+        output.solutions,
+        vec![
+            ParetoPoint {
+                index: 0,
+                objectives: vec![1.0, 1.0],
+            },
+            ParetoPoint {
+                index: 1,
+                objectives: vec![2.0, 3.0],
+            },
+            ParetoPoint {
+                index: 2,
+                objectives: vec![0.5, 0.5],
+            },
+        ]
+    );
+    assert_eq!(first.resources.operations, 32);
+    assert_eq!(first.resources.nodes, 8);
+    assert_eq!(first.resources.iterations, 4);
+}
+
+#[test]
+fn maximize_direction_is_transformed_to_minimization() {
+    let output: ParetoFrontOutput = serde_json::from_value(
+        execute(
+            &ProbeEngine::new().unwrap(),
+            ParetoFrontRequest {
+                objectives: vec![vec![1.0], vec![3.0], vec![2.0]],
+                directions: vec![ObjectiveDirection::Maximize],
+            },
+        )
+        .output,
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.solutions,
+        vec![ParetoPoint {
+            index: 1,
+            objectives: vec![3.0],
+        }]
+    );
+}
+
+#[test]
+fn empty_ragged_and_non_finite_objectives_are_rejected() {
+    for (input, expected) in [
+        (
+            json!({ "objectives": [], "directions": ["minimize"] }),
+            "population",
+        ),
+        (
+            json!({ "objectives": [[1.0]], "directions": [] }),
+            "dimension",
+        ),
+        (
+            json!({ "objectives": [[1.0], [2.0, 3.0]], "directions": ["minimize"] }),
+            "dimension",
+        ),
+        (
+            json!({ "objectives": [[null]], "directions": ["minimize"] }),
+            "finite",
+        ),
+    ] {
+        assert!(matches!(
+            ProbeEngine::new()
+                .unwrap()
+                .execute(&PARETO_FRONT.parse().unwrap(), &input),
+            Err(DiscoveryError::InvalidInput(message)) if message.contains(expected)
+        ));
+    }
+}
+
+#[test]
+fn population_dimension_and_combined_work_are_bounded() {
+    let too_many_candidates = json!({
+        "objectives": vec![vec![0]; 257],
+        "directions": ["minimize"],
+    });
+    assert!(matches!(
+        ProbeEngine::new()
+            .unwrap()
+            .execute(&PARETO_FRONT.parse().unwrap(), &too_many_candidates),
+        Err(DiscoveryError::LimitExceeded(message))
+            if message.contains("population 257 exceeds limit 256")
+    ));
+
+    let too_many_dimensions = json!({
+        "objectives": [vec![0; 33]],
+        "directions": vec!["minimize"; 33],
+    });
+    assert!(matches!(
+        ProbeEngine::new()
+            .unwrap()
+            .execute(&PARETO_FRONT.parse().unwrap(), &too_many_dimensions),
+        Err(DiscoveryError::LimitExceeded(message))
+            if message.contains("dimensions 33 exceeds limit 32")
+    ));
+
+    let too_much_work = json!({
+        "objectives": vec![vec![0; 32]; 64],
+        "directions": vec!["minimize"; 32],
+    });
+    assert!(matches!(
+        ProbeEngine::new()
+            .unwrap()
+            .execute(&PARETO_FRONT.parse().unwrap(), &too_much_work),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("operations")
+    ));
+}
+
+#[test]
+fn cooperative_input_work_node_iteration_and_output_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 31,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_nodes: 7,
+                ..ProbeEngineLimits::default()
+            },
+            "nodes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 3,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let error = ProbeEngine::with_limits(limits)
+            .unwrap()
+            .execute(&PARETO_FRONT.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
+    }
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -52,6 +52,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_dual",
         "probe_engine",
         "probe_network",
+        "probe_optimization",
         "probe_tropical",
     ),
 }

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -51,6 +51,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_core",
         "probe_dual",
         "probe_engine",
+        "probe_holographic",
         "probe_network",
         "probe_optimization",
         "probe_tropical",


### PR DESCRIPTION
## Summary

This grouped cohort completes discovery Tasks 17B, 18A, and 18B in three independently verified RED→GREEN commits.

### Task 17B — Pareto optimization (`fc862f3`)
- add typed objective matrix and per-dimension minimize/maximize directions
- transform maximize objectives to canonical minimization before direct `Individual` / `ParetoFront` execution
- return original objective values in deterministic candidate-index order
- bound population (256), dimensions (32), combined `population² × dimensions` work, nodes, iterations, and I/O

### Task 18A — additive holographic superposition (`4877bf6`)
- generate deterministic `MAP256` elements from seeds
- accumulate from algebraic zero through repeated `BindingAlgebra::superpose`
- return exact additive coefficients and explicitly test distinction from attention/cleanup `bundle`
- bound seed count (256), coefficient operations/nodes, iterations, and I/O

### Task 18B — holographic recall (`bebab9b`)
- parity-test existing `HolographicMemory<MAP256>` store/retrieve semantics with key tracking and default configuration
- return cleaned/raw coefficients, deterministic confidence/query similarity, attribution, and capacity metrics
- emit deterministic near-capacity warnings while preserving existing bundle-based memory semantics
- cap entries at 32 and conservatively account for storage, retrieval, attribution, coefficient nodes, iterations, and I/O

### Shared integration
- register all three exact catalog descriptors only under `standard-probes`
- preserve known-but-non-executable no-default behavior
- update exact registry/capability expectations
- assign both new integration targets exactly once in the exhaustive discovery CI shard map

## TDD

Each task began with public `ProbeEngine` tests that failed because its DTO/adapter was absent, then received only the implementation needed to go green. Each task was committed only after focused default/no-default tests, Clippy, registry/capability checks, and shard verification passed.

## Verification

- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --no-default-features --no-deps`
- `cargo fmt --all --check`
- `python3 scripts/verify-discovery-ci-sharding.py`
- `python3 -m py_compile scripts/run-discovery-test-shard.py scripts/verify-discovery-ci-sharding.py`
- `git diff --check origin/develop...HEAD`

Independent cohort review found no Critical or Important issues.

## Hook note

The three focused commits used the established `--no-verify` exception after scoped checks because the whole-workspace hook remains blocked by unrelated existing `amari-core/src/generic.rs` Clippy warnings.
