### PR TITLE
feat: add bounded rewrite discovery probes

### DIFF
--- a/amari-discovery/catalog/probes.toml
+++ b/amari-discovery/catalog/probes.toml
@@ -181,6 +181,21 @@ max_operations = 100000
 timeout_millis = 2000
 
 [[probes]]
+id = "amari-probe:rewrite:predecessors:v1"
+capability_id = "amari:amari-rewrite:inverse:predecessors"
+input_schema = "amari.discovery/probe/rewrite-predecessors/input/v1"
+output_schema = "amari.discovery/probe/rewrite-predecessors/output/v1"
+required_features = ["standard-probes"]
+cost = "moderate"
+deterministic = true
+side_effects = "none"
+[probes.limits]
+max_input_bytes = 65536
+max_output_bytes = 65536
+max_operations = 100000
+timeout_millis = 2000
+
+[[probes]]
 id = "amari-probe:rewrite:infer-rule:v1"
 capability_id = "amari:amari-rewrite:synthesis:infer-rule"
 input_schema = "amari.discovery/probe/rewrite-infer-rule/input/v1"

--- a/amari-discovery/catalog/semantic/core.toml
+++ b/amari-discovery/catalog/semantic/core.toml
@@ -183,6 +183,20 @@ stability = "stable"
 cost = "moderate"
 
 [[capabilities]]
+id = "amari:amari-rewrite:inverse:predecessors"
+name = "Bounded predecessor search"
+description = "Enumerate deterministic inverse-rewrite predecessors under explicit depth, frontier, node, and byte limits."
+aliases = ["inverse rewriting", "backward search"]
+concepts = ["term rewriting system", "predecessor search"]
+crate_refs = ["amari-rewrite"]
+feature_refs = ["amari-rewrite:std"]
+symbol_refs = ["amari_rewrite::inverse::BackwardSearch"]
+example_refs = ["amari-rewrite:inverse_search"]
+probe_refs = ["amari-probe:rewrite:predecessors:v1"]
+stability = "stable"
+cost = "moderate"
+
+[[capabilities]]
 id = "amari:amari-rewrite:synthesis:infer-rule"
 name = "Rule inference from examples"
 description = "Infer a conservative rewrite rule from bounded positive examples."

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -89,7 +89,8 @@ pub use probes::{
     ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
     ProbeEngineLimits, ProbeExecution, ProbeIsolation, RationalSurcomplexDivisionOutput,
     RationalSurcomplexDivisionRequest, RationalSurrealArithmeticOutput,
-    RationalSurrealArithmeticRequest, TropicalViterbiOutput, TropicalViterbiRequest,
+    RationalSurrealArithmeticRequest, RewriteNormalizeOutput, RewriteNormalizeRequest, RewriteRule,
+    RewriteTerm, TropicalViterbiOutput, TropicalViterbiRequest,
 };
 pub use protocol::{
     CandidatePlan, CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope,

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -89,7 +89,8 @@ pub use probes::{
     ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
     ProbeEngineLimits, ProbeExecution, ProbeIsolation, RationalSurcomplexDivisionOutput,
     RationalSurcomplexDivisionRequest, RationalSurrealArithmeticOutput,
-    RationalSurrealArithmeticRequest, RewriteNormalizeOutput, RewriteNormalizeRequest,
+    RationalSurrealArithmeticRequest, RewriteExample, RewriteInferRuleOutput,
+    RewriteInferRuleRequest, RewriteNormalizeOutput, RewriteNormalizeRequest,
     RewritePredecessorsOutput, RewritePredecessorsRequest, RewriteRule, RewriteTerm,
     TropicalViterbiOutput, TropicalViterbiRequest,
 };

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -89,8 +89,9 @@ pub use probes::{
     ParetoPoint, PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine,
     ProbeEngineLimits, ProbeExecution, ProbeIsolation, RationalSurcomplexDivisionOutput,
     RationalSurcomplexDivisionRequest, RationalSurrealArithmeticOutput,
-    RationalSurrealArithmeticRequest, RewriteNormalizeOutput, RewriteNormalizeRequest, RewriteRule,
-    RewriteTerm, TropicalViterbiOutput, TropicalViterbiRequest,
+    RationalSurrealArithmeticRequest, RewriteNormalizeOutput, RewriteNormalizeRequest,
+    RewritePredecessorsOutput, RewritePredecessorsRequest, RewriteRule, RewriteTerm,
+    TropicalViterbiOutput, TropicalViterbiRequest,
 };
 pub use protocol::{
     CandidatePlan, CapabilityId, CatalogIdentity, Compatibility, DiscoveryOutcome, Envelope,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -14,6 +14,7 @@ mod holographic;
 mod network;
 mod optimization;
 mod registry;
+mod rewrite;
 mod surreal;
 mod tropical;
 

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -31,6 +31,7 @@ pub use holographic::{
 pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathRequest};
 pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
+pub use rewrite::{RewriteNormalizeOutput, RewriteNormalizeRequest, RewriteRule, RewriteTerm};
 pub use surreal::{
     DecimalRational, DecimalSurcomplex, RationalSurcomplexDivisionOutput,
     RationalSurcomplexDivisionRequest, RationalSurrealArithmeticOutput,
@@ -268,6 +269,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
         holographic::superposition_registration()?,
         network::registration()?,
         optimization::registration()?,
+        rewrite::normalize_registration()?,
         surreal::surcomplex_division_registration()?,
         surreal::rational_arithmetic_registration()?,
         tropical::registration()?,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -31,7 +31,10 @@ pub use holographic::{
 pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathRequest};
 pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
-pub use rewrite::{RewriteNormalizeOutput, RewriteNormalizeRequest, RewriteRule, RewriteTerm};
+pub use rewrite::{
+    RewriteNormalizeOutput, RewriteNormalizeRequest, RewritePredecessorsOutput,
+    RewritePredecessorsRequest, RewriteRule, RewriteTerm,
+};
 pub use surreal::{
     DecimalRational, DecimalSurcomplex, RationalSurcomplexDivisionOutput,
     RationalSurcomplexDivisionRequest, RationalSurrealArithmeticOutput,
@@ -270,6 +273,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
         network::registration()?,
         optimization::registration()?,
         rewrite::normalize_registration()?,
+        rewrite::predecessors_registration()?,
         surreal::surcomplex_division_registration()?,
         surreal::rational_arithmetic_registration()?,
         tropical::registration()?,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -32,8 +32,9 @@ pub use network::{NetworkPath, NetworkShortestPathOutput, NetworkShortestPathReq
 pub use optimization::{ObjectiveDirection, ParetoFrontOutput, ParetoFrontRequest, ParetoPoint};
 use registry::{AdapterRegistration, EffectiveProbeLimits, ProbeRegistry};
 pub use rewrite::{
-    RewriteNormalizeOutput, RewriteNormalizeRequest, RewritePredecessorsOutput,
-    RewritePredecessorsRequest, RewriteRule, RewriteTerm,
+    RewriteExample, RewriteInferRuleOutput, RewriteInferRuleRequest, RewriteNormalizeOutput,
+    RewriteNormalizeRequest, RewritePredecessorsOutput, RewritePredecessorsRequest, RewriteRule,
+    RewriteTerm,
 };
 pub use surreal::{
     DecimalRational, DecimalSurcomplex, RationalSurcomplexDivisionOutput,
@@ -272,6 +273,7 @@ fn compiled_registrations() -> DiscoveryResult<Vec<AdapterRegistration>> {
         holographic::superposition_registration()?,
         network::registration()?,
         optimization::registration()?,
+        rewrite::infer_rule_registration()?,
         rewrite::normalize_registration()?,
         rewrite::predecessors_registration()?,
         surreal::surcomplex_division_registration()?,

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -235,6 +235,7 @@ mod tests {
                 "amari-probe:holographic:superposition:v1".parse().unwrap(),
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
                 "amari-probe:optimization:pareto-front:v1".parse().unwrap(),
+                "amari-probe:rewrite:infer-rule:v1".parse().unwrap(),
                 "amari-probe:rewrite:normalize:v1".parse().unwrap(),
                 "amari-probe:rewrite:predecessors:v1".parse().unwrap(),
                 "amari-probe:surcomplex:rational-division:v1"

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -236,6 +236,7 @@ mod tests {
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
                 "amari-probe:optimization:pareto-front:v1".parse().unwrap(),
                 "amari-probe:rewrite:normalize:v1".parse().unwrap(),
+                "amari-probe:rewrite:predecessors:v1".parse().unwrap(),
                 "amari-probe:surcomplex:rational-division:v1"
                     .parse()
                     .unwrap(),

--- a/amari-discovery/src/probes/registry.rs
+++ b/amari-discovery/src/probes/registry.rs
@@ -235,6 +235,7 @@ mod tests {
                 "amari-probe:holographic:superposition:v1".parse().unwrap(),
                 "amari-probe:network:shortest-path:v1".parse().unwrap(),
                 "amari-probe:optimization:pareto-front:v1".parse().unwrap(),
+                "amari-probe:rewrite:normalize:v1".parse().unwrap(),
                 "amari-probe:surcomplex:rational-division:v1"
                     .parse()
                     .unwrap(),

--- a/amari-discovery/src/probes/rewrite.rs
+++ b/amari-discovery/src/probes/rewrite.rs
@@ -7,10 +7,10 @@
 #![cfg_attr(any(not(test), not(feature = "standard-probes")), allow(dead_code))]
 
 #[cfg(feature = "standard-probes")]
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 #[cfg(feature = "standard-probes")]
-use amari_rewrite::trs::{Rule, Term, TermSystem};
+use amari_rewrite::trs::{match_pattern, Rule, Term, TermSystem};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "standard-probes")]
 use serde_json::Value;
@@ -30,6 +30,12 @@ const MAX_TERM_NODES: u64 = 4_096;
 const MAX_RULES: u64 = 256;
 #[cfg(feature = "standard-probes")]
 const MAX_NORMALIZATION_STEPS: u64 = 4_096;
+#[cfg(feature = "standard-probes")]
+const MAX_PREDECESSOR_DEPTH: u64 = 16;
+#[cfg(feature = "standard-probes")]
+const MAX_PREDECESSOR_RESULTS: u64 = 1_024;
+#[cfg(feature = "standard-probes")]
+const MAX_PREDECESSOR_FRONTIER: u64 = 1_024;
 
 /// Serializable first-order term accepted by rewrite probes.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -123,6 +129,31 @@ pub struct RewriteNormalizeOutput {
     pub steps: u64,
 }
 
+/// Typed input for bounded inverse-rewrite predecessor search.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RewritePredecessorsRequest {
+    /// Target term whose predecessors are requested.
+    pub target: RewriteTerm,
+    /// Ordered checked forward rules explored in reverse.
+    pub rules: Vec<RewriteRule>,
+    /// Maximum backward-search depth.
+    pub max_depth: u64,
+    /// Maximum returned predecessor terms.
+    pub max_results: u64,
+    /// Maximum queued search terms at one time.
+    pub max_frontier: u64,
+}
+
+/// Deterministic bounded predecessor-search result.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RewritePredecessorsOutput {
+    /// Unique predecessor terms in canonical DTO order.
+    pub predecessors: Vec<RewriteTerm>,
+    /// Whether the requested result cap omitted at least one predecessor.
+    pub truncated: bool,
+}
+
 #[cfg(feature = "standard-probes")]
 pub(super) fn normalize_registration() -> DiscoveryResult<AdapterRegistration> {
     Ok(AdapterRegistration {
@@ -141,6 +172,27 @@ pub(super) fn normalize_registration() -> DiscoveryResult<AdapterRegistration> {
         side_effects: SideEffectPolicy::None,
         network: false,
         execute: execute_normalize,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn predecessors_registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:rewrite:predecessors:v1".parse()?,
+        capability_id: "amari:amari-rewrite:inverse:predecessors".parse()?,
+        input_schema: "amari.discovery/probe/rewrite-predecessors/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/rewrite-predecessors/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute: execute_predecessors,
     })
 }
 
@@ -240,6 +292,174 @@ fn execute_normalize(
         current = next;
         current_dto = RewriteTerm::from_term(&current);
     }
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute_predecessors(
+    input: &Value,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<AdapterOutput> {
+    let request: RewritePredecessorsRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "rewrite predecessor request has an invalid term, rule, or limit shape: {error}"
+            ))
+        })?;
+    if request.max_results == 0 || request.max_frontier == 0 {
+        return Err(DiscoveryError::InvalidInput(
+            "rewrite predecessor results and frontier limits must be greater than zero".to_owned(),
+        ));
+    }
+    enforce(
+        "predecessor depth",
+        request.max_depth,
+        MAX_PREDECESSOR_DEPTH,
+    )?;
+    enforce(
+        "predecessor results",
+        request.max_results,
+        MAX_PREDECESSOR_RESULTS,
+    )?;
+    enforce(
+        "predecessor frontier",
+        request.max_frontier,
+        MAX_PREDECESSOR_FRONTIER,
+    )?;
+
+    let bounds = effective_bounds(limits);
+    let analysis = validate_rewrite_request(&request, [&request.target], &request.rules, bounds)?;
+    if analysis.lhs_duplicates_variable {
+        return Err(DiscoveryError::InvalidInput(
+            "reverse rewrite rejects a rule whose LHS duplicates variable occurrences".to_owned(),
+        ));
+    }
+    let predicted_term_nodes = checked_growth_bound(
+        analysis.input_nodes,
+        request.max_depth,
+        analysis.max_backward_constant,
+    )?;
+    enforce(
+        "predecessor term nodes",
+        predicted_term_nodes,
+        bounds.max_term_nodes,
+    )?;
+
+    let rules = request
+        .rules
+        .iter()
+        .map(RewriteRule::to_rule)
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    let target = request.target.to_term()?;
+    let mut queue = VecDeque::from([(target.clone(), 0_u64)]);
+    let mut visited = BTreeSet::from([target]);
+    let mut predecessors = BTreeSet::new();
+    let mut operations = 0_u64;
+    let mut iterations = 0_u64;
+    let mut cumulative_nodes = analysis.input_nodes;
+    let mut encoded_result_bytes = 0_u64;
+    let mut truncated = false;
+
+    'search: while let Some((term, depth)) = queue.pop_front() {
+        if depth >= request.max_depth {
+            continue;
+        }
+        iterations = iterations.checked_add(1).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite predecessor iteration overflow".to_owned())
+        })?;
+        enforce("iterations", iterations, limits.max_iterations)?;
+
+        for path in term.positions() {
+            let subterm = term.subterm(&path).ok_or_else(|| {
+                DiscoveryError::ProbeFailed(
+                    "bounded predecessor search produced an invalid term path".to_owned(),
+                )
+            })?;
+            for rule in &rules {
+                operations = operations.checked_add(1).ok_or_else(|| {
+                    DiscoveryError::LimitExceeded(
+                        "rewrite predecessor operation count overflow".to_owned(),
+                    )
+                })?;
+                enforce("operations", operations, limits.max_operations)?;
+                let Some(substitution) = match_pattern(rule.rhs(), subterm) else {
+                    continue;
+                };
+                let replacement = substitution.apply(rule.lhs());
+                let candidate = term.replace_at(&path, replacement).map_err(|_| {
+                    DiscoveryError::ProbeFailed("bounded predecessor replacement failed".to_owned())
+                })?;
+                if candidate == term || visited.contains(&candidate) {
+                    continue;
+                }
+                if u64::try_from(predecessors.len()).map_err(|_| {
+                    DiscoveryError::LimitExceeded(
+                        "rewrite predecessor result count overflow".to_owned(),
+                    )
+                })? >= request.max_results
+                {
+                    truncated = true;
+                    break 'search;
+                }
+
+                let candidate_dto = RewriteTerm::from_term(&candidate);
+                let stats =
+                    term_stats(&candidate_dto, bounds.max_term_depth, bounds.max_term_nodes)?;
+                cumulative_nodes = cumulative_nodes.checked_add(stats.nodes).ok_or_else(|| {
+                    DiscoveryError::LimitExceeded(
+                        "rewrite predecessor cumulative node count overflow".to_owned(),
+                    )
+                })?;
+                enforce("predecessor nodes", cumulative_nodes, limits.max_nodes)?;
+                encoded_result_bytes = encoded_result_bytes
+                    .checked_add(encoded_bytes(&candidate_dto, "rewrite predecessor")?)
+                    .ok_or_else(|| {
+                        DiscoveryError::LimitExceeded(
+                            "rewrite predecessor output byte count overflow".to_owned(),
+                        )
+                    })?;
+                enforce(
+                    "predecessor output bytes",
+                    encoded_result_bytes,
+                    bounds.max_output_bytes,
+                )?;
+
+                visited.insert(candidate.clone());
+                predecessors.insert(candidate_dto);
+                let next_depth = depth.checked_add(1).ok_or_else(|| {
+                    DiscoveryError::LimitExceeded("rewrite predecessor depth overflow".to_owned())
+                })?;
+                if next_depth < request.max_depth {
+                    let next_frontier = queue.len().checked_add(1).ok_or_else(|| {
+                        DiscoveryError::LimitExceeded(
+                            "rewrite predecessor frontier overflow".to_owned(),
+                        )
+                    })?;
+                    let next_frontier = u64::try_from(next_frontier).map_err(|_| {
+                        DiscoveryError::LimitExceeded(
+                            "rewrite predecessor frontier overflow".to_owned(),
+                        )
+                    })?;
+                    enforce("predecessor frontier", next_frontier, request.max_frontier)?;
+                    queue.push_back((candidate, next_depth));
+                }
+            }
+        }
+    }
+
+    let output = RewritePredecessorsOutput {
+        predecessors: predecessors.into_iter().collect(),
+        truncated,
+    };
+    validate_encoded_output(&output, bounds)?;
+    Ok(AdapterOutput {
+        resources: ResourceObservations {
+            operations,
+            nodes: cumulative_nodes,
+            iterations,
+            bytes: 0,
+        },
+        output: serde_json::to_value(output)?,
+    })
 }
 
 #[cfg(feature = "standard-probes")]

--- a/amari-discovery/src/probes/rewrite.rs
+++ b/amari-discovery/src/probes/rewrite.rs
@@ -10,14 +10,26 @@
 use std::collections::BTreeMap;
 
 #[cfg(feature = "standard-probes")]
-use amari_rewrite::trs::{Rule, Term};
+use amari_rewrite::trs::{Rule, Term, TermSystem};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "standard-probes")]
+use serde_json::Value;
 
 #[cfg(feature = "standard-probes")]
-use crate::{DiscoveryError, DiscoveryResult};
+use super::registry::{AdapterOutput, AdapterRegistration, EffectiveProbeLimits};
+#[cfg(feature = "standard-probes")]
+use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, SideEffectPolicy};
 
 #[cfg(feature = "standard-probes")]
 const MAX_NAME_BYTES: usize = 256;
+#[cfg(feature = "standard-probes")]
+const MAX_TERM_DEPTH: u64 = 64;
+#[cfg(feature = "standard-probes")]
+const MAX_TERM_NODES: u64 = 4_096;
+#[cfg(feature = "standard-probes")]
+const MAX_RULES: u64 = 256;
+#[cfg(feature = "standard-probes")]
+const MAX_NORMALIZATION_STEPS: u64 = 4_096;
 
 /// Serializable first-order term accepted by rewrite probes.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -55,6 +67,18 @@ impl RewriteTerm {
             }
         }
     }
+
+    fn from_term(term: &Term) -> Self {
+        match term {
+            Term::Var(variable) => Self::Variable {
+                name: variable.as_str().to_owned(),
+            },
+            Term::Sym(symbol, arguments) => Self::Symbol {
+                name: symbol.as_str().to_owned(),
+                arguments: arguments.iter().map(Self::from_term).collect(),
+            },
+        }
+    }
 }
 
 /// Serializable checked first-order rewrite rule.
@@ -75,6 +99,157 @@ impl RewriteRule {
                 "rewrite rule RHS variable does not occur in its LHS".to_owned(),
             )
         })
+    }
+}
+
+/// Typed input for bounded ordered term normalization.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RewriteNormalizeRequest {
+    /// Initial first-order term.
+    pub term: RewriteTerm,
+    /// Ordered checked rewrite rules.
+    pub rules: Vec<RewriteRule>,
+    /// Maximum successful rewrite steps.
+    pub max_steps: u64,
+}
+
+/// Typed fixed-point result from bounded term normalization.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RewriteNormalizeOutput {
+    /// Reached normal form.
+    pub normal_form: RewriteTerm,
+    /// Number of successful rewrite steps.
+    pub steps: u64,
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn normalize_registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:rewrite:normalize:v1".parse()?,
+        capability_id: "amari:amari-rewrite:trs:normalization".parse()?,
+        input_schema: "amari.discovery/probe/rewrite-normalize/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/rewrite-normalize/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute: execute_normalize,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute_normalize(
+    input: &Value,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<AdapterOutput> {
+    let request: RewriteNormalizeRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "rewrite normalization request has an invalid term, rule, or limit shape: {error}"
+            ))
+        })?;
+    if request.max_steps == 0 {
+        return Err(DiscoveryError::InvalidInput(
+            "rewrite normalization max steps must be greater than zero".to_owned(),
+        ));
+    }
+    enforce(
+        "normalization steps",
+        request.max_steps,
+        MAX_NORMALIZATION_STEPS,
+    )?;
+
+    let bounds = effective_bounds(limits);
+    let analysis = validate_rewrite_request(&request, [&request.term], &request.rules, bounds)?;
+    if analysis.max_forward_constant > 0 {
+        return Err(DiscoveryError::InvalidInput(
+            "rewrite normalization rejects expanding rules".to_owned(),
+        ));
+    }
+    let predicted_nodes = checked_growth_bound(
+        analysis.input_nodes,
+        request.max_steps,
+        analysis.max_forward_constant,
+    )?;
+    enforce("term nodes", predicted_nodes, bounds.max_term_nodes)?;
+
+    let rules = request
+        .rules
+        .iter()
+        .map(RewriteRule::to_rule)
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    let system = TermSystem::new(rules);
+    let mut current = request.term.to_term()?;
+    let mut current_dto = request.term;
+    let mut steps = 0_u64;
+    let mut operations = 0_u64;
+    let mut iterations = 0_u64;
+    let mut observed_nodes = analysis.input_nodes;
+    let rule_factor = analysis.rule_count.max(1);
+
+    loop {
+        let stats = term_stats(&current_dto, bounds.max_term_depth, bounds.max_term_nodes)?;
+        observed_nodes = observed_nodes.max(stats.nodes);
+        let attempt_operations = stats.nodes.checked_mul(rule_factor).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite operation count overflow".to_owned())
+        })?;
+        operations = operations.checked_add(attempt_operations).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite operation count overflow".to_owned())
+        })?;
+        iterations = iterations.checked_add(1).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite iteration count overflow".to_owned())
+        })?;
+        enforce("operations", operations, limits.max_operations)?;
+        enforce("iterations", iterations, limits.max_iterations)?;
+
+        let next = system.apply_once(&current).map_err(|_| {
+            DiscoveryError::ProbeFailed("bounded rewrite normalization failed".to_owned())
+        })?;
+        let Some(next) = next else {
+            let output = RewriteNormalizeOutput {
+                normal_form: current_dto,
+                steps,
+            };
+            validate_encoded_output(&output, bounds)?;
+            return Ok(AdapterOutput {
+                resources: ResourceObservations {
+                    operations,
+                    nodes: observed_nodes,
+                    iterations,
+                    bytes: 0,
+                },
+                output: serde_json::to_value(output)?,
+            });
+        };
+        if steps == request.max_steps {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "rewrite normalization step limit {} reached before fixed point",
+                request.max_steps
+            )));
+        }
+        steps = steps.checked_add(1).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite normalization step count overflow".to_owned())
+        })?;
+        current = next;
+        current_dto = RewriteTerm::from_term(&current);
+    }
+}
+
+#[cfg(feature = "standard-probes")]
+fn effective_bounds(limits: &EffectiveProbeLimits) -> RewriteBounds {
+    RewriteBounds {
+        max_request_bytes: limits.max_input_bytes,
+        max_output_bytes: limits.max_output_bytes,
+        max_term_depth: MAX_TERM_DEPTH,
+        max_term_nodes: MAX_TERM_NODES.min(limits.max_nodes),
+        max_rules: MAX_RULES,
     }
 }
 

--- a/amari-discovery/src/probes/rewrite.rs
+++ b/amari-discovery/src/probes/rewrite.rs
@@ -2,15 +2,14 @@
 
 //! Bounded DTO validation shared by registered rewrite probes.
 
-// Task 20A intentionally lands validation primitives before the executable
-// adapters in Tasks 20B-20D; remove this transition allowance once registered.
-#![cfg_attr(any(not(test), not(feature = "standard-probes")), allow(dead_code))]
-
 #[cfg(feature = "standard-probes")]
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 #[cfg(feature = "standard-probes")]
-use amari_rewrite::trs::{match_pattern, Rule, Term, TermSystem};
+use amari_rewrite::{
+    synthesis::infer_rule,
+    trs::{match_pattern, Rule, Term, TermSystem},
+};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "standard-probes")]
 use serde_json::Value;
@@ -36,6 +35,8 @@ const MAX_PREDECESSOR_DEPTH: u64 = 16;
 const MAX_PREDECESSOR_RESULTS: u64 = 1_024;
 #[cfg(feature = "standard-probes")]
 const MAX_PREDECESSOR_FRONTIER: u64 = 1_024;
+#[cfg(feature = "standard-probes")]
+const MAX_INFERENCE_EXAMPLES: u64 = 256;
 
 /// Serializable first-order term accepted by rewrite probes.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -106,6 +107,13 @@ impl RewriteRule {
             )
         })
     }
+
+    fn from_rule(rule: &Rule) -> Self {
+        Self {
+            lhs: RewriteTerm::from_term(rule.lhs()),
+            rhs: RewriteTerm::from_term(rule.rhs()),
+        }
+    }
 }
 
 /// Typed input for bounded ordered term normalization.
@@ -154,6 +162,31 @@ pub struct RewritePredecessorsOutput {
     pub truncated: bool,
 }
 
+/// One positive before/after rewrite example.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RewriteExample {
+    /// Concrete term before rewriting.
+    pub before: RewriteTerm,
+    /// Concrete term after rewriting.
+    pub after: RewriteTerm,
+}
+
+/// Typed input for bounded single-rule inference.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RewriteInferRuleRequest {
+    /// Positive rewrite examples used for anti-unification.
+    pub examples: Vec<RewriteExample>,
+}
+
+/// Exact checked rule inferred from positive examples.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RewriteInferRuleOutput {
+    /// Inferred checked first-order rewrite rule.
+    pub rule: RewriteRule,
+}
+
 #[cfg(feature = "standard-probes")]
 pub(super) fn normalize_registration() -> DiscoveryResult<AdapterRegistration> {
     Ok(AdapterRegistration {
@@ -172,6 +205,27 @@ pub(super) fn normalize_registration() -> DiscoveryResult<AdapterRegistration> {
         side_effects: SideEffectPolicy::None,
         network: false,
         execute: execute_normalize,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+pub(super) fn infer_rule_registration() -> DiscoveryResult<AdapterRegistration> {
+    Ok(AdapterRegistration {
+        id: "amari-probe:rewrite:infer-rule:v1".parse()?,
+        capability_id: "amari:amari-rewrite:synthesis:infer-rule".parse()?,
+        input_schema: "amari.discovery/probe/rewrite-infer-rule/input/v1".to_owned(),
+        output_schema: "amari.discovery/probe/rewrite-infer-rule/output/v1".to_owned(),
+        required_features: vec!["standard-probes".to_owned()],
+        limits: ProbeLimits {
+            max_input_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_operations: 100_000,
+            timeout_millis: 2_000,
+        },
+        deterministic: true,
+        side_effects: SideEffectPolicy::None,
+        network: false,
+        execute: execute_infer_rule,
     })
 }
 
@@ -292,6 +346,98 @@ fn execute_normalize(
         current = next;
         current_dto = RewriteTerm::from_term(&current);
     }
+}
+
+#[cfg(feature = "standard-probes")]
+fn execute_infer_rule(
+    input: &Value,
+    limits: &EffectiveProbeLimits,
+) -> DiscoveryResult<AdapterOutput> {
+    let request: RewriteInferRuleRequest =
+        serde_json::from_value(input.clone()).map_err(|error| {
+            DiscoveryError::InvalidInput(format!(
+                "rewrite inference request has an invalid example shape: {error}"
+            ))
+        })?;
+    if request.examples.is_empty() {
+        return Err(DiscoveryError::InvalidInput(
+            "rewrite inference requires at least one example".to_owned(),
+        ));
+    }
+    let example_count = u64::try_from(request.examples.len()).map_err(|_| {
+        DiscoveryError::LimitExceeded("rewrite inference example count overflow".to_owned())
+    })?;
+    enforce(
+        "inference example count",
+        example_count,
+        MAX_INFERENCE_EXAMPLES,
+    )?;
+
+    let bounds = effective_bounds(limits);
+    let terms = request
+        .examples
+        .iter()
+        .flat_map(|example| [&example.before, &example.after]);
+    let analysis = validate_rewrite_request(&request, terms, &[], bounds)?;
+    enforce(
+        "inference input nodes",
+        analysis.input_nodes,
+        limits.max_nodes,
+    )?;
+    let operations = analysis
+        .input_nodes
+        .checked_mul(example_count)
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite inference operation count overflow".to_owned())
+        })?;
+    enforce("operations", operations, limits.max_operations)?;
+    enforce("iterations", example_count, limits.max_iterations)?;
+
+    let examples = request
+        .examples
+        .iter()
+        .map(|example| Ok((example.before.to_term()?, example.after.to_term()?)))
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    let inferred = infer_rule(&examples).map_err(|_| {
+        DiscoveryError::ProbeFailed("bounded rewrite rule inference failed".to_owned())
+    })?;
+    let inferred = RewriteRule::from_rule(&inferred);
+    let lhs = term_stats(&inferred.lhs, bounds.max_term_depth, bounds.max_term_nodes)?;
+    let rhs = term_stats(&inferred.rhs, bounds.max_term_depth, bounds.max_term_nodes)?;
+    inferred.to_rule()?;
+    let growth = analyze_rule_growth(&inferred)?;
+    if growth.rhs_duplicates_variable {
+        return Err(DiscoveryError::InvalidInput(
+            "inferred rewrite rule RHS duplicates variable occurrences".to_owned(),
+        ));
+    }
+    let generated_nodes = lhs.nodes.checked_add(rhs.nodes).ok_or_else(|| {
+        DiscoveryError::LimitExceeded("generated rewrite rule node count overflow".to_owned())
+    })?;
+    let total_nodes = analysis
+        .input_nodes
+        .checked_add(generated_nodes)
+        .ok_or_else(|| {
+            DiscoveryError::LimitExceeded("generated rewrite rule node count overflow".to_owned())
+        })?;
+    if total_nodes > limits.max_nodes {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "rewrite generated rule nodes raise cumulative nodes {total_nodes} above limit {}",
+            limits.max_nodes
+        )));
+    }
+
+    let output = RewriteInferRuleOutput { rule: inferred };
+    validate_encoded_output(&output, bounds)?;
+    Ok(AdapterOutput {
+        resources: ResourceObservations {
+            operations,
+            nodes: total_nodes,
+            iterations: example_count,
+            bytes: 0,
+        },
+        output: serde_json::to_value(output)?,
+    })
 }
 
 #[cfg(feature = "standard-probes")]

--- a/amari-discovery/src/probes/rewrite.rs
+++ b/amari-discovery/src/probes/rewrite.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded DTO validation shared by registered rewrite probes.
+
+// Task 20A intentionally lands validation primitives before the executable
+// adapters in Tasks 20B-20D; remove this transition allowance once registered.
+#![cfg_attr(any(not(test), not(feature = "standard-probes")), allow(dead_code))]
+
+#[cfg(feature = "standard-probes")]
+use std::collections::BTreeMap;
+
+#[cfg(feature = "standard-probes")]
+use amari_rewrite::trs::{Rule, Term};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "standard-probes")]
+use crate::{DiscoveryError, DiscoveryResult};
+
+#[cfg(feature = "standard-probes")]
+const MAX_NAME_BYTES: usize = 256;
+
+/// Serializable first-order term accepted by rewrite probes.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RewriteTerm {
+    /// Pattern variable.
+    Variable {
+        /// Variable name.
+        name: String,
+    },
+    /// Function symbol or constant when `arguments` is empty.
+    Symbol {
+        /// Function or constant name.
+        name: String,
+        /// Ordered child terms.
+        arguments: Vec<RewriteTerm>,
+    },
+}
+
+#[cfg(feature = "standard-probes")]
+impl RewriteTerm {
+    fn to_term(&self) -> DiscoveryResult<Term> {
+        match self {
+            Self::Variable { name } => {
+                validate_name(name)?;
+                Ok(Term::var(name.clone()))
+            }
+            Self::Symbol { name, arguments } => {
+                validate_name(name)?;
+                let arguments = arguments
+                    .iter()
+                    .map(Self::to_term)
+                    .collect::<DiscoveryResult<Vec<_>>>()?;
+                Ok(Term::sym(name.clone(), arguments))
+            }
+        }
+    }
+}
+
+/// Serializable checked first-order rewrite rule.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RewriteRule {
+    /// Left-hand side pattern.
+    pub lhs: RewriteTerm,
+    /// Right-hand side template.
+    pub rhs: RewriteTerm,
+}
+
+#[cfg(feature = "standard-probes")]
+impl RewriteRule {
+    fn to_rule(&self) -> DiscoveryResult<Rule> {
+        Rule::new(self.lhs.to_term()?, self.rhs.to_term()?).map_err(|_| {
+            DiscoveryError::InvalidInput(
+                "rewrite rule RHS variable does not occur in its LHS".to_owned(),
+            )
+        })
+    }
+}
+
+#[cfg(feature = "standard-probes")]
+#[derive(Clone, Copy, Debug)]
+struct RewriteBounds {
+    max_request_bytes: u64,
+    max_output_bytes: u64,
+    max_term_depth: u64,
+    max_term_nodes: u64,
+    max_rules: u64,
+}
+
+#[cfg(feature = "standard-probes")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RewriteInputAnalysis {
+    request_bytes: u64,
+    input_nodes: u64,
+    max_input_depth: u64,
+    rule_count: u64,
+    max_forward_constant: u64,
+    max_backward_constant: u64,
+    lhs_duplicates_variable: bool,
+}
+
+#[cfg(feature = "standard-probes")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RuleGrowth {
+    forward_constant: u64,
+    backward_constant: u64,
+    lhs_duplicates_variable: bool,
+    rhs_duplicates_variable: bool,
+}
+
+#[cfg(feature = "standard-probes")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TermStats {
+    nodes: u64,
+    depth: u64,
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_rewrite_request<'a, S, I>(
+    request: &S,
+    terms: I,
+    rules: &[RewriteRule],
+    bounds: RewriteBounds,
+) -> DiscoveryResult<RewriteInputAnalysis>
+where
+    S: Serialize,
+    I: IntoIterator<Item = &'a RewriteTerm>,
+{
+    let request_bytes = encoded_bytes(request, "rewrite request")?;
+    enforce("request bytes", request_bytes, bounds.max_request_bytes)?;
+
+    let rule_count = u64::try_from(rules.len())
+        .map_err(|_| DiscoveryError::LimitExceeded("rewrite rule count overflow".to_owned()))?;
+    enforce("rule count", rule_count, bounds.max_rules)?;
+
+    let mut input_nodes = 0_u64;
+    let mut max_input_depth = 0_u64;
+    for term in terms {
+        let stats = term_stats(term, bounds.max_term_depth, bounds.max_term_nodes)?;
+        input_nodes = input_nodes.checked_add(stats.nodes).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite input node count overflow".to_owned())
+        })?;
+        max_input_depth = max_input_depth.max(stats.depth);
+    }
+
+    let mut max_forward_constant = 0_u64;
+    let mut max_backward_constant = 0_u64;
+    let mut lhs_duplicates_variable = false;
+    for rule in rules {
+        let lhs = term_stats(&rule.lhs, bounds.max_term_depth, bounds.max_term_nodes)?;
+        let rhs = term_stats(&rule.rhs, bounds.max_term_depth, bounds.max_term_nodes)?;
+        max_input_depth = max_input_depth.max(lhs.depth).max(rhs.depth);
+        rule.to_rule()?;
+        let growth = analyze_rule_growth(rule)?;
+        if growth.rhs_duplicates_variable {
+            return Err(DiscoveryError::InvalidInput(
+                "rewrite rule RHS duplicates variable occurrences".to_owned(),
+            ));
+        }
+        max_forward_constant = max_forward_constant.max(growth.forward_constant);
+        max_backward_constant = max_backward_constant.max(growth.backward_constant);
+        lhs_duplicates_variable |= growth.lhs_duplicates_variable;
+    }
+
+    Ok(RewriteInputAnalysis {
+        request_bytes,
+        input_nodes,
+        max_input_depth,
+        rule_count,
+        max_forward_constant,
+        max_backward_constant,
+        lhs_duplicates_variable,
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn term_stats(term: &RewriteTerm, max_depth: u64, max_nodes: u64) -> DiscoveryResult<TermStats> {
+    fn visit(
+        term: &RewriteTerm,
+        depth: u64,
+        nodes: &mut u64,
+        deepest: &mut u64,
+        max_depth: u64,
+        max_nodes: u64,
+    ) -> DiscoveryResult<()> {
+        if depth > max_depth {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "rewrite term depth {depth} exceeds limit {max_depth}"
+            )));
+        }
+        *nodes = nodes.checked_add(1).ok_or_else(|| {
+            DiscoveryError::LimitExceeded("rewrite term node count overflow".to_owned())
+        })?;
+        enforce("term nodes", *nodes, max_nodes)?;
+        *deepest = (*deepest).max(depth);
+
+        match term {
+            RewriteTerm::Variable { name } => validate_name(name),
+            RewriteTerm::Symbol { name, arguments } => {
+                validate_name(name)?;
+                let child_depth = depth.checked_add(1).ok_or_else(|| {
+                    DiscoveryError::LimitExceeded("rewrite term depth overflow".to_owned())
+                })?;
+                for argument in arguments {
+                    visit(argument, child_depth, nodes, deepest, max_depth, max_nodes)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    let mut nodes = 0;
+    let mut depth = 0;
+    visit(term, 1, &mut nodes, &mut depth, max_depth, max_nodes)?;
+    Ok(TermStats { nodes, depth })
+}
+
+#[cfg(feature = "standard-probes")]
+fn analyze_rule_growth(rule: &RewriteRule) -> DiscoveryResult<RuleGrowth> {
+    let lhs_nodes = count_nodes(&rule.lhs)?;
+    let rhs_nodes = count_nodes(&rule.rhs)?;
+    let mut lhs_variables = BTreeMap::new();
+    let mut rhs_variables = BTreeMap::new();
+    count_variables(&rule.lhs, &mut lhs_variables)?;
+    count_variables(&rule.rhs, &mut rhs_variables)?;
+
+    Ok(RuleGrowth {
+        forward_constant: rhs_nodes.saturating_sub(lhs_nodes),
+        backward_constant: lhs_nodes.saturating_sub(rhs_nodes),
+        lhs_duplicates_variable: lhs_variables.values().any(|count| *count > 1),
+        rhs_duplicates_variable: rhs_variables.values().any(|count| *count > 1),
+    })
+}
+
+#[cfg(feature = "standard-probes")]
+fn count_nodes(term: &RewriteTerm) -> DiscoveryResult<u64> {
+    match term {
+        RewriteTerm::Variable { .. } => Ok(1),
+        RewriteTerm::Symbol { arguments, .. } => arguments.iter().try_fold(1_u64, |total, term| {
+            total.checked_add(count_nodes(term)?).ok_or_else(|| {
+                DiscoveryError::LimitExceeded("rewrite term node count overflow".to_owned())
+            })
+        }),
+    }
+}
+
+#[cfg(feature = "standard-probes")]
+fn count_variables<'a>(
+    term: &'a RewriteTerm,
+    counts: &mut BTreeMap<&'a str, u64>,
+) -> DiscoveryResult<()> {
+    match term {
+        RewriteTerm::Variable { name } => {
+            let count = counts.entry(name.as_str()).or_default();
+            *count = count.checked_add(1).ok_or_else(|| {
+                DiscoveryError::LimitExceeded("rewrite variable count overflow".to_owned())
+            })?;
+        }
+        RewriteTerm::Symbol { arguments, .. } => {
+            for argument in arguments {
+                count_variables(argument, counts)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "standard-probes")]
+fn checked_growth_bound(initial: u64, steps: u64, growth_per_step: u64) -> DiscoveryResult<u64> {
+    steps
+        .checked_mul(growth_per_step)
+        .and_then(|growth| initial.checked_add(growth))
+        .ok_or_else(|| DiscoveryError::LimitExceeded("rewrite growth bound overflow".to_owned()))
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_encoded_output<T: Serialize>(
+    output: &T,
+    bounds: RewriteBounds,
+) -> DiscoveryResult<u64> {
+    let bytes = encoded_bytes(output, "rewrite output")?;
+    enforce("output bytes", bytes, bounds.max_output_bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(feature = "standard-probes")]
+fn encoded_bytes<T: Serialize>(value: &T, context: &str) -> DiscoveryResult<u64> {
+    let bytes = serde_json::to_vec(value)?;
+    u64::try_from(bytes.len())
+        .map_err(|_| DiscoveryError::LimitExceeded(format!("{context} byte count overflow")))
+}
+
+#[cfg(feature = "standard-probes")]
+fn validate_name(name: &str) -> DiscoveryResult<()> {
+    if name.is_empty() || name.len() > MAX_NAME_BYTES {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "rewrite name length {} is outside 1..={MAX_NAME_BYTES}",
+            name.len()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "standard-probes")]
+fn enforce(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
+    if observed <= maximum {
+        Ok(())
+    } else {
+        Err(DiscoveryError::LimitExceeded(format!(
+            "rewrite {kind} {observed} exceeds limit {maximum}"
+        )))
+    }
+}
+
+#[cfg(all(test, feature = "standard-probes"))]
+mod tests {
+    use amari_rewrite::trs::{Term, Variable};
+    use serde::Serialize;
+
+    use super::*;
+    use crate::DiscoveryError;
+
+    fn var(name: &str) -> RewriteTerm {
+        RewriteTerm::Variable {
+            name: name.to_owned(),
+        }
+    }
+
+    fn sym(name: &str, arguments: Vec<RewriteTerm>) -> RewriteTerm {
+        RewriteTerm::Symbol {
+            name: name.to_owned(),
+            arguments,
+        }
+    }
+
+    fn rule(lhs: RewriteTerm, rhs: RewriteTerm) -> RewriteRule {
+        RewriteRule { lhs, rhs }
+    }
+
+    fn bounds() -> RewriteBounds {
+        RewriteBounds {
+            max_request_bytes: 65_536,
+            max_output_bytes: 65_536,
+            max_term_depth: 64,
+            max_term_nodes: 4_096,
+            max_rules: 256,
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Request<'a> {
+        term: &'a RewriteTerm,
+        rules: &'a [RewriteRule],
+    }
+
+    #[test]
+    fn recursive_term_and_rule_dtos_convert_to_checked_trs_values() {
+        let term = sym("f", vec![var("X"), sym("g", vec![sym("a", Vec::new())])]);
+        let dto_rule = rule(
+            sym("f", vec![var("X"), var("Y")]),
+            sym("pair", vec![var("X"), var("Y")]),
+        );
+
+        assert_eq!(
+            term.to_term().unwrap(),
+            Term::sym(
+                "f",
+                [
+                    Term::Var(Variable::new("X")),
+                    Term::sym("g", [Term::constant("a")])
+                ]
+            )
+        );
+        let converted = dto_rule.to_rule().unwrap();
+        assert_eq!(converted.lhs(), &dto_rule.lhs.to_term().unwrap());
+        assert_eq!(converted.rhs(), &dto_rule.rhs.to_term().unwrap());
+    }
+
+    #[test]
+    fn validation_counts_request_bytes_term_depth_nodes_and_rules() {
+        let term = sym("f", vec![sym("g", vec![var("X")]), sym("a", vec![])]);
+        let rules = vec![rule(sym("g", vec![var("X")]), var("X"))];
+        let request = Request {
+            term: &term,
+            rules: &rules,
+        };
+        let encoded = serde_json::to_vec(&request).unwrap().len() as u64;
+        let analysis = validate_rewrite_request(&request, [&term], &rules, bounds()).unwrap();
+
+        assert_eq!(analysis.request_bytes, encoded);
+        assert_eq!(analysis.input_nodes, 4);
+        assert_eq!(analysis.max_input_depth, 3);
+        assert_eq!(analysis.rule_count, 1);
+
+        let mut too_few_bytes = bounds();
+        too_few_bytes.max_request_bytes = encoded - 1;
+        assert!(matches!(
+            validate_rewrite_request(&request, [&term], &rules, too_few_bytes),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("request bytes")
+        ));
+
+        let mut too_shallow = bounds();
+        too_shallow.max_term_depth = 2;
+        assert!(matches!(
+            validate_rewrite_request(&request, [&term], &rules, too_shallow),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("depth")
+        ));
+
+        let mut too_few_nodes = bounds();
+        too_few_nodes.max_term_nodes = 3;
+        assert!(matches!(
+            validate_rewrite_request(&request, [&term], &rules, too_few_nodes),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("nodes")
+        ));
+
+        let mut too_few_rules = bounds();
+        too_few_rules.max_rules = 0;
+        assert!(matches!(
+            validate_rewrite_request(&request, [&term], &rules, too_few_rules),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("rule count")
+        ));
+    }
+
+    #[test]
+    fn encoded_output_bytes_are_checked_before_return() {
+        let output = sym("result", vec![sym("a", vec![]), sym("b", vec![])]);
+        let bytes = serde_json::to_vec(&output).unwrap().len() as u64;
+
+        let mut exact = bounds();
+        exact.max_output_bytes = bytes;
+        assert_eq!(validate_encoded_output(&output, exact).unwrap(), bytes);
+        exact.max_output_bytes = bytes - 1;
+        assert!(matches!(
+            validate_encoded_output(&output, exact),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("output bytes")
+        ));
+    }
+
+    #[test]
+    fn duplicate_rhs_variables_and_unbound_rhs_variables_are_rejected() {
+        let duplicate = vec![rule(
+            sym("f", vec![var("X")]),
+            sym("pair", vec![var("X"), var("X")]),
+        )];
+        let request = Request {
+            term: &duplicate[0].lhs,
+            rules: &duplicate,
+        };
+        assert!(matches!(
+            validate_rewrite_request(&request, [&duplicate[0].lhs], &duplicate, bounds()),
+            Err(DiscoveryError::InvalidInput(message)) if message.contains("duplicates variable")
+        ));
+
+        let unbound = rule(sym("f", vec![var("X")]), var("Y"));
+        assert!(matches!(
+            unbound.to_rule(),
+            Err(DiscoveryError::InvalidInput(message)) if message.contains("does not occur")
+        ));
+    }
+
+    #[test]
+    fn constant_growth_is_directional_and_checked() {
+        let expanding = rule(
+            sym("f", vec![var("X")]),
+            sym("g", vec![sym("a", vec![]), var("X")]),
+        );
+        let contracting = rule(expanding.rhs.clone(), expanding.lhs.clone());
+
+        assert_eq!(analyze_rule_growth(&expanding).unwrap().forward_constant, 1);
+        assert_eq!(
+            analyze_rule_growth(&expanding).unwrap().backward_constant,
+            0
+        );
+        assert_eq!(
+            analyze_rule_growth(&contracting).unwrap().forward_constant,
+            0
+        );
+        assert_eq!(
+            analyze_rule_growth(&contracting).unwrap().backward_constant,
+            1
+        );
+        assert_eq!(checked_growth_bound(3, 4, 2).unwrap(), 11);
+        assert!(matches!(
+            checked_growth_bound(u64::MAX, 1, 1),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("growth")
+        ));
+        assert!(matches!(
+            checked_growth_bound(1, u64::MAX, 2),
+            Err(DiscoveryError::LimitExceeded(message)) if message.contains("growth")
+        ));
+    }
+
+    #[test]
+    fn empty_and_oversized_names_are_rejected_without_conversion() {
+        for term in [var(""), sym(&"x".repeat(257), vec![])] {
+            let request = Request {
+                term: &term,
+                rules: &[],
+            };
+            assert!(matches!(
+                validate_rewrite_request(&request, [&term], &[], bounds()),
+                Err(DiscoveryError::InvalidInput(message)) if message.contains("name")
+            ));
+        }
+    }
+}

--- a/amari-discovery/tests/catalog_generation.rs
+++ b/amari-discovery/tests/catalog_generation.rs
@@ -402,8 +402,8 @@ timeout_millis = 1000
 fn probe_descriptors_equal_manifest() {
     let catalog = generate_workspace_catalog(workspace_root()).unwrap();
 
-    // probes.toml has 13 probes.
-    assert_eq!(catalog.probe_descriptors.len(), 13);
+    // probes.toml has 14 probes.
+    assert_eq!(catalog.probe_descriptors.len(), 14);
 
     let ids: BTreeSet<String> = catalog
         .probe_descriptors
@@ -413,6 +413,7 @@ fn probe_descriptors_equal_manifest() {
     assert!(ids.contains("amari-probe:core:geometric-product:v1"));
     assert!(ids.contains("amari-probe:tropical:shortest-path:v1"));
     assert!(ids.contains("amari-probe:tropical:viterbi:v1"));
+    assert!(ids.contains("amari-probe:rewrite:predecessors:v1"));
 }
 
 // ============================================================================

--- a/amari-discovery/tests/catalog_integrity.rs
+++ b/amari-discovery/tests/catalog_integrity.rs
@@ -68,6 +68,34 @@ fn semantic_capabilities_distinguish_planned_and_implemented_surfaces() {
 }
 
 #[test]
+fn inverse_predecessor_probe_has_explicit_catalog_authority() {
+    let catalog = Catalog::embedded().unwrap();
+    let capability = catalog
+        .capabilities()
+        .iter()
+        .find(|capability| capability.id.to_string() == "amari:amari-rewrite:inverse:predecessors")
+        .expect("bounded inverse-search capability must exist");
+    assert_eq!(
+        capability.probe_refs[0].to_string(),
+        "amari-probe:rewrite:predecessors:v1"
+    );
+    let probe = catalog
+        .probes()
+        .iter()
+        .find(|probe| probe.id.to_string() == "amari-probe:rewrite:predecessors:v1")
+        .expect("bounded predecessor descriptor must exist");
+    assert_eq!(probe.capability_id, capability.id);
+    assert_eq!(
+        probe.input_schema,
+        "amari.discovery/probe/rewrite-predecessors/input/v1"
+    );
+    assert_eq!(
+        probe.output_schema,
+        "amari.discovery/probe/rewrite-predecessors/output/v1"
+    );
+}
+
+#[test]
 fn semantic_references_resolve_to_structural_or_probe_records() {
     let catalog = Catalog::embedded().unwrap();
     let crate_names: HashSet<_> = catalog

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -82,6 +82,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                         | "amari-probe:network:shortest-path:v1"
                         | "amari-probe:optimization:pareto-front:v1"
                         | "amari-probe:rewrite:normalize:v1"
+                        | "amari-probe:rewrite:predecessors:v1"
                         | "amari-probe:surcomplex:rational-division:v1"
                         | "amari-probe:surreal:rational-arithmetic:v1"
                         | "amari-probe:tropical:viterbi:v1"

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -81,6 +81,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                         | "amari-probe:holographic:superposition:v1"
                         | "amari-probe:network:shortest-path:v1"
                         | "amari-probe:optimization:pareto-front:v1"
+                        | "amari-probe:rewrite:infer-rule:v1"
                         | "amari-probe:rewrite:normalize:v1"
                         | "amari-probe:rewrite:predecessors:v1"
                         | "amari-probe:surcomplex:rational-division:v1"

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -81,6 +81,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
                         | "amari-probe:holographic:superposition:v1"
                         | "amari-probe:network:shortest-path:v1"
                         | "amari-probe:optimization:pareto-front:v1"
+                        | "amari-probe:rewrite:normalize:v1"
                         | "amari-probe:surcomplex:rational-division:v1"
                         | "amari-probe:surreal:rational-arithmetic:v1"
                         | "amari-probe:tropical:viterbi:v1"

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -13,12 +13,13 @@ const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
 const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
 const REWRITE_NORMALIZE: &str = "amari-probe:rewrite:normalize:v1";
+const REWRITE_PREDECESSORS: &str = "amari-probe:rewrite:predecessors:v1";
 const RECALL: &str = "amari-probe:holographic:recall:v1";
 const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 const RATIONAL_ARITHMETIC: &str = "amari-probe:surreal:rational-arithmetic:v1";
 const SURCOMPLEX_DIVISION: &str = "amari-probe:surcomplex:rational-division:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:rewrite:predecessors:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:rewrite:infer-rule:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -37,6 +38,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let network = SHORTEST_PATH.parse().unwrap();
     let optimization = PARETO_FRONT.parse().unwrap();
     let rewrite_normalize = REWRITE_NORMALIZE.parse().unwrap();
+    let rewrite_predecessors = REWRITE_PREDECESSORS.parse().unwrap();
     let recall = RECALL.parse().unwrap();
     let superposition = SUPERPOSITION.parse().unwrap();
     let surreal = RATIONAL_ARITHMETIC.parse().unwrap();
@@ -77,6 +79,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
+        engine.is_executable(&rewrite_predecessors),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
         engine.is_executable(&surreal),
         cfg!(feature = "standard-probes")
     );
@@ -101,6 +107,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
                 network,
                 optimization,
                 rewrite_normalize,
+                rewrite_predecessors,
                 surcomplex,
                 surreal,
                 viterbi,

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -12,6 +12,7 @@ const CORE_PRODUCT: &str = "amari-probe:core:geometric-product:v1";
 const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
 const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
+const REWRITE_INFER_RULE: &str = "amari-probe:rewrite:infer-rule:v1";
 const REWRITE_NORMALIZE: &str = "amari-probe:rewrite:normalize:v1";
 const REWRITE_PREDECESSORS: &str = "amari-probe:rewrite:predecessors:v1";
 const RECALL: &str = "amari-probe:holographic:recall:v1";
@@ -19,7 +20,7 @@ const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 const RATIONAL_ARITHMETIC: &str = "amari-probe:surreal:rational-arithmetic:v1";
 const SURCOMPLEX_DIVISION: &str = "amari-probe:surcomplex:rational-division:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:rewrite:infer-rule:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:tropical:shortest-path:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -37,6 +38,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let dual = POLYNOMIAL_DERIVATIVE.parse().unwrap();
     let network = SHORTEST_PATH.parse().unwrap();
     let optimization = PARETO_FRONT.parse().unwrap();
+    let rewrite_infer_rule = REWRITE_INFER_RULE.parse().unwrap();
     let rewrite_normalize = REWRITE_NORMALIZE.parse().unwrap();
     let rewrite_predecessors = REWRITE_PREDECESSORS.parse().unwrap();
     let recall = RECALL.parse().unwrap();
@@ -75,6 +77,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
+        engine.is_executable(&rewrite_infer_rule),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
         engine.is_executable(&rewrite_normalize),
         cfg!(feature = "standard-probes")
     );
@@ -106,6 +112,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
                 superposition,
                 network,
                 optimization,
+                rewrite_infer_rule,
                 rewrite_normalize,
                 rewrite_predecessors,
                 surcomplex,

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -12,12 +12,13 @@ const CORE_PRODUCT: &str = "amari-probe:core:geometric-product:v1";
 const POLYNOMIAL_DERIVATIVE: &str = "amari-probe:dual:polynomial-derivative:v1";
 const SHORTEST_PATH: &str = "amari-probe:network:shortest-path:v1";
 const PARETO_FRONT: &str = "amari-probe:optimization:pareto-front:v1";
+const REWRITE_NORMALIZE: &str = "amari-probe:rewrite:normalize:v1";
 const RECALL: &str = "amari-probe:holographic:recall:v1";
 const SUPERPOSITION: &str = "amari-probe:holographic:superposition:v1";
 const RATIONAL_ARITHMETIC: &str = "amari-probe:surreal:rational-arithmetic:v1";
 const SURCOMPLEX_DIVISION: &str = "amari-probe:surcomplex:rational-division:v1";
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
-const KNOWN_UNREGISTERED: &str = "amari-probe:rewrite:normalize:v1";
+const KNOWN_UNREGISTERED: &str = "amari-probe:rewrite:predecessors:v1";
 
 fn request() -> TropicalViterbiRequest {
     TropicalViterbiRequest {
@@ -35,6 +36,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
     let dual = POLYNOMIAL_DERIVATIVE.parse().unwrap();
     let network = SHORTEST_PATH.parse().unwrap();
     let optimization = PARETO_FRONT.parse().unwrap();
+    let rewrite_normalize = REWRITE_NORMALIZE.parse().unwrap();
     let recall = RECALL.parse().unwrap();
     let superposition = SUPERPOSITION.parse().unwrap();
     let surreal = RATIONAL_ARITHMETIC.parse().unwrap();
@@ -71,6 +73,10 @@ fn engine_derives_executable_state_from_the_private_registry() {
         cfg!(feature = "standard-probes")
     );
     assert_eq!(
+        engine.is_executable(&rewrite_normalize),
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(
         engine.is_executable(&surreal),
         cfg!(feature = "standard-probes")
     );
@@ -94,6 +100,7 @@ fn engine_derives_executable_state_from_the_private_registry() {
                 superposition,
                 network,
                 optimization,
+                rewrite_normalize,
                 surcomplex,
                 surreal,
                 viterbi,

--- a/amari-discovery/tests/probe_rewrite_infer.rs
+++ b/amari-discovery/tests/probe_rewrite_infer.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded rewrite-rule inference probe parity and limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, ProbeEngine, ProbeEngineLimits, ProbeExecution, RewriteExample,
+    RewriteInferRuleOutput, RewriteInferRuleRequest, RewriteRule, RewriteTerm,
+};
+use amari_rewrite::{synthesis::infer_rule, trs::Term};
+use serde_json::json;
+
+const INFER_RULE: &str = "amari-probe:rewrite:infer-rule:v1";
+
+fn sym(name: &str, arguments: Vec<RewriteTerm>) -> RewriteTerm {
+    RewriteTerm::Symbol {
+        name: name.to_owned(),
+        arguments,
+    }
+}
+
+fn example(symbol: &str) -> RewriteExample {
+    RewriteExample {
+        before: sym("add", vec![sym("zero", vec![]), sym(symbol, vec![])]),
+        after: sym(symbol, vec![]),
+    }
+}
+
+fn request() -> RewriteInferRuleRequest {
+    RewriteInferRuleRequest {
+        examples: vec![example("a"), example("b")],
+    }
+}
+
+fn execute(engine: &ProbeEngine, request: RewriteInferRuleRequest) -> ProbeExecution {
+    engine
+        .execute(
+            &INFER_RULE.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+#[test]
+fn inferred_rule_matches_direct_amari_rewrite_inference() {
+    let direct_examples = vec![
+        (
+            Term::sym("add", [Term::constant("zero"), Term::constant("a")]),
+            Term::constant("a"),
+        ),
+        (
+            Term::sym("add", [Term::constant("zero"), Term::constant("b")]),
+            Term::constant("b"),
+        ),
+    ];
+    let direct = infer_rule(&direct_examples).unwrap();
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute(&engine, request());
+    let second = execute(&engine, request());
+    let output: RewriteInferRuleOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        direct.lhs(),
+        &Term::sym("add", [Term::constant("zero"), Term::var("_I0")])
+    );
+    assert_eq!(direct.rhs(), &Term::var("_I0"));
+    assert_eq!(
+        output.rule,
+        RewriteRule {
+            lhs: sym(
+                "add",
+                vec![
+                    sym("zero", vec![]),
+                    RewriteTerm::Variable {
+                        name: "_I0".to_owned(),
+                    },
+                ],
+            ),
+            rhs: RewriteTerm::Variable {
+                name: "_I0".to_owned(),
+            },
+        }
+    );
+    assert_eq!(first.resources.operations, 16);
+    assert_eq!(first.resources.nodes, 12);
+    assert_eq!(first.resources.iterations, 2);
+}
+
+#[test]
+fn empty_and_oversized_example_sets_are_rejected() {
+    let empty = RewriteInferRuleRequest {
+        examples: Vec::new(),
+    };
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &INFER_RULE.parse().unwrap(),
+            &serde_json::to_value(empty).unwrap()
+        ),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("at least one")
+    ));
+
+    let oversized = RewriteInferRuleRequest {
+        examples: vec![example("a"); 257],
+    };
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &INFER_RULE.parse().unwrap(),
+            &serde_json::to_value(oversized).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("example count")
+    ));
+}
+
+#[test]
+fn generated_rules_with_duplicate_rhs_variables_are_rejected() {
+    let request = RewriteInferRuleRequest {
+        examples: vec![
+            RewriteExample {
+                before: sym("f", vec![sym("a", vec![])]),
+                after: sym("pair", vec![sym("a", vec![]), sym("a", vec![])]),
+            },
+            RewriteExample {
+                before: sym("f", vec![sym("b", vec![])]),
+                after: sym("pair", vec![sym("b", vec![]), sym("b", vec![])]),
+            },
+        ],
+    };
+
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &INFER_RULE.parse().unwrap(),
+            &serde_json::to_value(request).unwrap()
+        ),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("duplicates variable")
+    ));
+}
+
+#[test]
+fn generated_rule_nodes_are_included_in_the_cooperative_limit() {
+    let input = serde_json::to_value(request()).unwrap();
+    assert!(matches!(
+        ProbeEngine::with_limits(ProbeEngineLimits {
+            max_nodes: 11,
+            ..ProbeEngineLimits::default()
+        })
+        .unwrap()
+        .execute(&INFER_RULE.parse().unwrap(), &input),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("generated rule nodes")
+    ));
+}
+
+#[test]
+fn malformed_examples_and_deep_terms_are_rejected() {
+    let malformed = json!({
+        "examples": [{
+            "before": { "kind": "unknown", "name": "a" },
+            "after": { "kind": "symbol", "name": "a", "arguments": [] }
+        }]
+    });
+    assert!(matches!(
+        ProbeEngine::new()
+            .unwrap()
+            .execute(&INFER_RULE.parse().unwrap(), &malformed),
+        Err(DiscoveryError::InvalidInput(_))
+    ));
+
+    let mut deep = sym("leaf", vec![]);
+    for _ in 0..64 {
+        deep = sym("f", vec![deep]);
+    }
+    let deep_request = RewriteInferRuleRequest {
+        examples: vec![RewriteExample {
+            before: deep,
+            after: sym("a", vec![]),
+        }],
+    };
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &INFER_RULE.parse().unwrap(),
+            &serde_json::to_value(deep_request).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("depth")
+    ));
+}
+
+#[test]
+fn cooperative_input_work_iteration_and_output_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 15,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let error = ProbeEngine::with_limits(limits)
+            .unwrap()
+            .execute(&INFER_RULE.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
+    }
+}

--- a/amari-discovery/tests/probe_rewrite_normalize.rs
+++ b/amari-discovery/tests/probe_rewrite_normalize.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded rewrite-normalization probe parity and limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, ProbeEngine, ProbeEngineLimits, ProbeExecution, RewriteNormalizeOutput,
+    RewriteNormalizeRequest, RewriteRule, RewriteTerm,
+};
+use amari_rewrite::trs::{Rule, Term, TermSystem};
+use serde_json::json;
+
+const NORMALIZE: &str = "amari-probe:rewrite:normalize:v1";
+
+fn var(name: &str) -> RewriteTerm {
+    RewriteTerm::Variable {
+        name: name.to_owned(),
+    }
+}
+
+fn sym(name: &str, arguments: Vec<RewriteTerm>) -> RewriteTerm {
+    RewriteTerm::Symbol {
+        name: name.to_owned(),
+        arguments,
+    }
+}
+
+fn rule(lhs: RewriteTerm, rhs: RewriteTerm) -> RewriteRule {
+    RewriteRule { lhs, rhs }
+}
+
+fn request() -> RewriteNormalizeRequest {
+    RewriteNormalizeRequest {
+        term: sym("add", vec![sym("zero", vec![]), sym("a", vec![])]),
+        rules: vec![rule(
+            sym("add", vec![sym("zero", vec![]), var("X")]),
+            var("X"),
+        )],
+        max_steps: 1,
+    }
+}
+
+fn execute(engine: &ProbeEngine, request: RewriteNormalizeRequest) -> ProbeExecution {
+    engine
+        .execute(
+            &NORMALIZE.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+#[test]
+fn one_step_output_matches_term_system_apply_once() {
+    let direct_term = Term::sym("add", [Term::constant("zero"), Term::constant("a")]);
+    let direct_rule = Rule::new(
+        Term::sym("add", [Term::constant("zero"), Term::var("X")]),
+        Term::var("X"),
+    )
+    .unwrap();
+    let expected = TermSystem::new(vec![direct_rule])
+        .apply_once(&direct_term)
+        .unwrap()
+        .unwrap();
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute(&engine, request());
+    let second = execute(&engine, request());
+    let output: RewriteNormalizeOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(expected, Term::constant("a"));
+    assert_eq!(output.normal_form, sym("a", vec![]));
+    assert_eq!(output.steps, 1);
+    assert_eq!(first.resources.operations, 4);
+    assert_eq!(first.resources.nodes, 3);
+    assert_eq!(first.resources.iterations, 2);
+}
+
+#[test]
+fn invalid_and_expanding_rules_are_rejected_before_execution() {
+    for (input, expected) in [
+        (
+            json!({
+                "term": { "kind": "symbol", "name": "a", "arguments": [] },
+                "rules": [{
+                    "lhs": { "kind": "variable", "name": "X" },
+                    "rhs": { "kind": "variable", "name": "Y" }
+                }],
+                "max_steps": 1
+            }),
+            "does not occur",
+        ),
+        (
+            json!({
+                "term": { "kind": "symbol", "name": "a", "arguments": [] },
+                "rules": [{
+                    "lhs": { "kind": "variable", "name": "X" },
+                    "rhs": { "kind": "symbol", "name": "f", "arguments": [
+                        { "kind": "variable", "name": "X" }
+                    ] }
+                }],
+                "max_steps": 1
+            }),
+            "expanding",
+        ),
+    ] {
+        assert!(matches!(
+            ProbeEngine::new()
+                .unwrap()
+                .execute(&NORMALIZE.parse().unwrap(), &input),
+            Err(DiscoveryError::InvalidInput(message)) if message.contains(expected)
+        ));
+    }
+}
+
+#[test]
+fn step_exhaustion_is_a_typed_limit_error() {
+    let request = RewriteNormalizeRequest {
+        term: sym("a", vec![]),
+        rules: vec![
+            rule(sym("a", vec![]), sym("b", vec![])),
+            rule(sym("b", vec![]), sym("a", vec![])),
+        ],
+        max_steps: 1,
+    };
+
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &NORMALIZE.parse().unwrap(),
+            &serde_json::to_value(request).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("step limit")
+    ));
+}
+
+#[test]
+fn term_node_and_depth_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    assert!(matches!(
+        ProbeEngine::with_limits(ProbeEngineLimits {
+            max_nodes: 2,
+            ..ProbeEngineLimits::default()
+        })
+        .unwrap()
+        .execute(&NORMALIZE.parse().unwrap(), &input),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("nodes")
+    ));
+
+    let mut deep = sym("leaf", vec![]);
+    for _ in 0..64 {
+        deep = sym("f", vec![deep]);
+    }
+    let deep_request = RewriteNormalizeRequest {
+        term: deep,
+        rules: Vec::new(),
+        max_steps: 1,
+    };
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &NORMALIZE.parse().unwrap(),
+            &serde_json::to_value(deep_request).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("depth")
+    ));
+}
+
+#[test]
+fn zero_and_oversized_step_limits_are_rejected() {
+    for max_steps in [0, 4_097] {
+        let mut request = request();
+        request.max_steps = max_steps;
+        assert!(matches!(
+            ProbeEngine::new().unwrap().execute(
+                &NORMALIZE.parse().unwrap(),
+                &serde_json::to_value(request).unwrap()
+            ),
+            Err(DiscoveryError::InvalidInput(message) | DiscoveryError::LimitExceeded(message))
+                if message.contains("steps")
+        ));
+    }
+}
+
+#[test]
+fn cooperative_input_work_iteration_and_output_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 3,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        let error = ProbeEngine::with_limits(limits)
+            .unwrap()
+            .execute(&NORMALIZE.parse().unwrap(), &input)
+            .unwrap_err();
+        assert!(
+            matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+            "unexpected error for {expected}: {error}"
+        );
+    }
+}

--- a/amari-discovery/tests/probe_rewrite_predecessors.rs
+++ b/amari-discovery/tests/probe_rewrite_predecessors.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bounded inverse-rewrite predecessor probe parity and limits.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{
+    DiscoveryError, ProbeEngine, ProbeEngineLimits, ProbeExecution, RewritePredecessorsOutput,
+    RewritePredecessorsRequest, RewriteRule, RewriteTerm,
+};
+use amari_rewrite::{
+    inverse::BackwardSearch,
+    trs::{Rule, Term, TermSystem},
+};
+use serde_json::json;
+
+const PREDECESSORS: &str = "amari-probe:rewrite:predecessors:v1";
+
+fn var(name: &str) -> RewriteTerm {
+    RewriteTerm::Variable {
+        name: name.to_owned(),
+    }
+}
+
+fn sym(name: &str, arguments: Vec<RewriteTerm>) -> RewriteTerm {
+    RewriteTerm::Symbol {
+        name: name.to_owned(),
+        arguments,
+    }
+}
+
+fn rule(lhs: RewriteTerm, rhs: RewriteTerm) -> RewriteRule {
+    RewriteRule { lhs, rhs }
+}
+
+fn request() -> RewritePredecessorsRequest {
+    RewritePredecessorsRequest {
+        target: sym("a", vec![]),
+        rules: vec![rule(
+            sym("add", vec![sym("zero", vec![]), var("X")]),
+            var("X"),
+        )],
+        max_depth: 1,
+        max_results: 16,
+        max_frontier: 16,
+    }
+}
+
+fn execute(engine: &ProbeEngine, request: RewritePredecessorsRequest) -> ProbeExecution {
+    engine
+        .execute(
+            &PREDECESSORS.parse().unwrap(),
+            &serde_json::to_value(request).unwrap(),
+        )
+        .unwrap()
+}
+
+#[test]
+fn one_step_predecessors_match_bounded_backward_search() {
+    let system = TermSystem::new(vec![Rule::new(
+        Term::sym("add", [Term::constant("zero"), Term::var("X")]),
+        Term::var("X"),
+    )
+    .unwrap()]);
+    let expected = BackwardSearch::new(&system, Term::constant("a"))
+        .max_depth(1)
+        .max_nodes(16)
+        .collect::<Vec<_>>();
+    let engine = ProbeEngine::new().unwrap();
+    let first = execute(&engine, request());
+    let second = execute(&engine, request());
+    let output: RewritePredecessorsOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(expected.len(), 1);
+    assert_eq!(
+        output.predecessors,
+        vec![sym("add", vec![sym("zero", vec![]), sym("a", vec![])])]
+    );
+    assert!(!output.truncated);
+    assert_eq!(first.resources.operations, 1);
+    assert_eq!(first.resources.nodes, 4);
+    assert_eq!(first.resources.iterations, 1);
+}
+
+#[test]
+fn output_is_deduplicated_and_canonically_ordered() {
+    let duplicate = rule(sym("add", vec![sym("zero", vec![]), var("X")]), var("X"));
+    let request = RewritePredecessorsRequest {
+        target: sym("a", vec![]),
+        rules: vec![
+            rule(sym("add", vec![var("X"), sym("zero", vec![])]), var("X")),
+            duplicate.clone(),
+            duplicate,
+        ],
+        max_depth: 1,
+        max_results: 16,
+        max_frontier: 16,
+    };
+    let output: RewritePredecessorsOutput =
+        serde_json::from_value(execute(&ProbeEngine::new().unwrap(), request).output).unwrap();
+
+    assert_eq!(output.predecessors.len(), 2);
+    assert!(output.predecessors[0] < output.predecessors[1]);
+}
+
+#[test]
+fn result_cap_returns_a_typed_deterministic_truncation() {
+    let request = RewritePredecessorsRequest {
+        target: sym("a", vec![]),
+        rules: vec![
+            rule(sym("left", vec![var("X")]), var("X")),
+            rule(sym("right", vec![var("X")]), var("X")),
+        ],
+        max_depth: 1,
+        max_results: 1,
+        max_frontier: 16,
+    };
+    let first = execute(&ProbeEngine::new().unwrap(), request.clone());
+    let second = execute(&ProbeEngine::new().unwrap(), request);
+    let output: RewritePredecessorsOutput = serde_json::from_value(first.output.clone()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(output.predecessors.len(), 1);
+    assert!(output.truncated);
+}
+
+#[test]
+fn depth_result_and_frontier_bounds_are_enforced() {
+    for (mut request, expected) in [
+        (
+            {
+                let mut request = request();
+                request.max_depth = 17;
+                request
+            },
+            "depth",
+        ),
+        (
+            {
+                let mut request = request();
+                request.max_results = 0;
+                request
+            },
+            "results",
+        ),
+        (
+            {
+                let mut request = request();
+                request.max_frontier = 0;
+                request
+            },
+            "frontier",
+        ),
+    ] {
+        assert!(matches!(
+            ProbeEngine::new().unwrap().execute(
+                &PREDECESSORS.parse().unwrap(),
+                &serde_json::to_value(&mut request).unwrap()
+            ),
+            Err(DiscoveryError::InvalidInput(message) | DiscoveryError::LimitExceeded(message))
+                if message.contains(expected)
+        ));
+    }
+
+    let mut frontier = request();
+    frontier.max_depth = 3;
+    frontier.max_frontier = 1;
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &PREDECESSORS.parse().unwrap(),
+            &serde_json::to_value(frontier).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("frontier")
+    ));
+}
+
+#[test]
+fn cumulative_node_and_term_depth_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    assert!(matches!(
+        ProbeEngine::with_limits(ProbeEngineLimits {
+            max_nodes: 3,
+            ..ProbeEngineLimits::default()
+        })
+        .unwrap()
+        .execute(&PREDECESSORS.parse().unwrap(), &input),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("nodes")
+    ));
+
+    let mut deep = sym("leaf", vec![]);
+    for _ in 0..64 {
+        deep = sym("f", vec![deep]);
+    }
+    let deep_request = RewritePredecessorsRequest {
+        target: deep,
+        rules: Vec::new(),
+        max_depth: 1,
+        max_results: 1,
+        max_frontier: 1,
+    };
+    assert!(matches!(
+        ProbeEngine::new().unwrap().execute(
+            &PREDECESSORS.parse().unwrap(),
+            &serde_json::to_value(deep_request).unwrap()
+        ),
+        Err(DiscoveryError::LimitExceeded(message)) if message.contains("depth")
+    ));
+}
+
+#[test]
+fn reverse_variable_duplication_is_rejected_as_unbounded_growth() {
+    let input = json!({
+        "target": { "kind": "symbol", "name": "a", "arguments": [] },
+        "rules": [{
+            "lhs": { "kind": "symbol", "name": "pair", "arguments": [
+                { "kind": "variable", "name": "X" },
+                { "kind": "variable", "name": "X" }
+            ] },
+            "rhs": { "kind": "variable", "name": "X" }
+        }],
+        "max_depth": 1,
+        "max_results": 16,
+        "max_frontier": 16
+    });
+
+    assert!(matches!(
+        ProbeEngine::new()
+            .unwrap()
+            .execute(&PREDECESSORS.parse().unwrap(), &input),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("duplicates")
+    ));
+}
+
+#[test]
+fn cooperative_input_work_iteration_and_output_limits_are_enforced() {
+    let input = serde_json::to_value(request()).unwrap();
+    for (limits, expected) in [
+        (
+            ProbeEngineLimits {
+                max_input_bytes: 8,
+                ..ProbeEngineLimits::default()
+            },
+            "input bytes",
+        ),
+        (
+            ProbeEngineLimits {
+                max_operations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "operations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_iterations: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "iterations",
+        ),
+        (
+            ProbeEngineLimits {
+                max_output_bytes: 1,
+                ..ProbeEngineLimits::default()
+            },
+            "output bytes",
+        ),
+    ] {
+        if expected == "operations" || expected == "iterations" {
+            let mut deeper = request();
+            deeper.max_depth = 2;
+            let error = ProbeEngine::with_limits(limits)
+                .unwrap()
+                .execute(
+                    &PREDECESSORS.parse().unwrap(),
+                    &serde_json::to_value(deeper).unwrap(),
+                )
+                .unwrap_err();
+            assert!(
+                matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+                "unexpected error for {expected}: {error}"
+            );
+        } else {
+            let error = ProbeEngine::with_limits(limits)
+                .unwrap()
+                .execute(&PREDECESSORS.parse().unwrap(), &input)
+                .unwrap_err();
+            assert!(
+                matches!(error, DiscoveryError::LimitExceeded(ref message) if message.contains(expected)),
+                "unexpected error for {expected}: {error}"
+            );
+        }
+    }
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -55,6 +55,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_holographic",
         "probe_network",
         "probe_optimization",
+        "probe_rewrite_normalize",
         "probe_surreal",
         "probe_tropical",
     ),

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -56,6 +56,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_network",
         "probe_optimization",
         "probe_rewrite_normalize",
+        "probe_rewrite_predecessors",
         "probe_surreal",
         "probe_tropical",
     ),

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -55,6 +55,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_holographic",
         "probe_network",
         "probe_optimization",
+        "probe_rewrite_infer",
         "probe_rewrite_normalize",
         "probe_rewrite_predecessors",
         "probe_surreal",


### PR DESCRIPTION
## Summary

This grouped cohort completes discovery Tasks 20A–20D with bounded rewrite validation, normalization, inverse predecessor search, and rule inference.

### Task 20A — bounded DTO conversion and growth analysis (`cf44866`)
- add recursive, documented `RewriteTerm` and checked `RewriteRule` DTOs
- validate request bytes, term names/depth/nodes, rule count, output bytes, and checked arithmetic
- reject unbound and duplicated RHS variables before execution
- compute directional constant-growth bounds and detect reverse variable duplication
- add the missing predecessor capability/descriptor authority approved during implementation
- regenerate deterministic catalog authority

Catalog content hash: `de814314e5f12b4e8170074edc15dfc09c6a9669f25f42bc3f492c9949cf7e11`

### Task 20B — bounded normalization (`3bfaa63`)
- add typed `RewriteNormalizeRequest` / `RewriteNormalizeOutput`
- register `amari-probe:rewrite:normalize:v1` behind `standard-probes`
- use checked `TermSystem::apply_once` iterations to fixed point
- reject invalid, variable-duplicating, and expanding rules
- enforce step, operation, node, depth, input/output byte, and iteration limits
- test exact one-step parity and fixed-point/step-exhaustion semantics

### Task 20C — bounded predecessor search (`93514dd`)
- add `amari:amari-rewrite:inverse:predecessors` and `amari-probe:rewrite:predecessors:v1`
- implement explicit bounded BFS matching upstream `BackwardSearch` semantics
- never collect an unbounded iterator
- enforce depth, result, frontier, cumulative-node, term-depth, operation, iteration, and byte limits
- reject reverse variable duplication that would invalidate constant-growth bounds
- deduplicate via visited terms and return canonical deterministic ordering
- expose deterministic typed result-cap truncation

### Task 20D — bounded rule inference (`141105d`)
- add typed positive-example and inferred-rule DTOs
- register `amari-probe:rewrite:infer-rule:v1` behind `standard-probes`
- call `amari_rewrite::synthesis::infer_rule` directly
- bound example count, total input work/nodes, generated rule depth/nodes, output bytes, and iterations
- reject generated rules with invalid or duplicated RHS variables
- test exact anti-unification parity, malformed/deep input, empty/oversized examples, and generated-rule limits

### Integration correction (`191a9d8`)
- update the catalog generation test from 13 to 14 descriptors and assert the new predecessor descriptor explicitly

### Shared integration
- preserve known-but-non-executable behavior without `standard-probes`
- validate exact private-registry descriptor mappings
- update public capabilities and engine expectations
- assign all three new integration targets exactly once in discovery CI sharding

## Decision note

The plan required Task 20C to register an already-known predecessor descriptor, but the existing catalog had no such authority. The approved resolution was to add the dedicated semantic capability and declarative descriptor rather than conflate inverse search with normalization or defer the task.

## TDD

Each canonical task began RED before implementation:
- Task 20A failed on absent DTO/validation APIs and absent predecessor catalog authority.
- Tasks 20B–20D failed through public `ProbeEngine` imports/execution before their DTOs/adapters existed.
- Focused default/no-default tests, Clippy, formatting, registry/capability tests, and shard verification passed at each task boundary.

## Review

A read-only independent DeepSeek review returned **APPROVE** with no Critical or Important findings.

## Verification

- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --no-default-features --no-deps`
- `cargo fmt --all --check`
- `python3 scripts/verify-discovery-ci-sharding.py`
- `python3 -m py_compile scripts/run-discovery-test-shard.py scripts/verify-discovery-ci-sharding.py`
- `git diff --check origin/develop...HEAD`

The shard verifier reports **41 flat integration targets across 3 unique shards**.

## Hook note

Focused commits used the established `--no-verify` exception after scoped checks because the whole-workspace hook remains blocked by unrelated existing `amari-core/src/generic.rs` Clippy warnings.
