### PR TITLE
feat(discovery): add isolated probe CLI and agent contracts

### DIFF
--- a/amari-discovery/schemas/goal-v1.json
+++ b/amari-discovery/schemas/goal-v1.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/goal/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "constraints": {
+      "items": {
+        "maxLength": 4096,
+        "minLength": 1,
+        "type": "string"
+      },
+      "maxItems": 64,
+      "type": "array"
+    },
+    "statement": {
+      "maxLength": 65536,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "statement"
+  ],
+  "title": "Amari Discovery Goal v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/schemas/plan-v1.json
+++ b/amari-discovery/schemas/plan-v1.json
@@ -1,0 +1,254 @@
+{
+  "$defs": {
+    "capability_id": {
+      "pattern": "^amari:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*",
+      "type": "string"
+    },
+    "compatibility": {
+      "additionalProperties": false,
+      "properties": {
+        "catalog": {
+          "additionalProperties": false,
+          "properties": {
+            "hash": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "hash"
+          ],
+          "type": "object"
+        },
+        "input_hash": {
+          "type": "string"
+        },
+        "probe_results": {
+          "maxItems": 256,
+          "type": "array"
+        },
+        "project_hash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "catalog",
+        "project_hash",
+        "input_hash"
+      ],
+      "type": "object"
+    },
+    "plan_step": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "dependency"
+            },
+            "package": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "version"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "feature": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "feature"
+            },
+            "package": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "feature"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "symbol"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "example": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "example"
+            },
+            "package": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "example"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "probe"
+            },
+            "probe_id": {
+              "$ref": "#/$defs/probe_id"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "probe_id"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "test"
+            },
+            "package": {
+              "type": "string"
+            },
+            "target": {
+              "enum": [
+                "all_targets",
+                "npm_package"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "target"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "probe_id": {
+      "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
+      "type": "string"
+    }
+  },
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/plan/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "capability_id": {
+      "$ref": "#/$defs/capability_id"
+    },
+    "compatibility": {
+      "$ref": "#/$defs/compatibility"
+    },
+    "normalization": {
+      "additionalProperties": false,
+      "properties": {
+        "max_rewrites": {
+          "maximum": 4096,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "normalized": {
+          "type": "boolean"
+        },
+        "trace": {
+          "maxItems": 4096,
+          "type": "array"
+        }
+      },
+      "required": [
+        "normalized",
+        "max_rewrites"
+      ],
+      "type": "object"
+    },
+    "plan_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "prerequisite_order": {
+      "items": {
+        "$ref": "#/$defs/capability_id"
+      },
+      "maxItems": 64,
+      "type": "array"
+    },
+    "steps": {
+      "items": {
+        "$ref": "#/$defs/plan_step"
+      },
+      "maxItems": 64,
+      "type": "array"
+    }
+  },
+  "required": [
+    "capability_id",
+    "prerequisite_order",
+    "steps",
+    "compatibility",
+    "normalization",
+    "plan_hash"
+  ],
+  "title": "Amari Discovery Candidate Plan v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/schemas/plan-v1.json
+++ b/amari-discovery/schemas/plan-v1.json
@@ -27,6 +27,9 @@
           "type": "string"
         },
         "probe_results": {
+          "items": {
+            "$ref": "#/$defs/probe_replay_hash"
+          },
           "maxItems": 256,
           "type": "array"
         },
@@ -38,6 +41,30 @@
         "catalog",
         "project_hash",
         "input_hash"
+      ],
+      "type": "object"
+    },
+    "normalization_trace": {
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/$defs/plan_step"
+          },
+          "maxItems": 64,
+          "type": "array"
+        },
+        "before": {
+          "items": {
+            "$ref": "#/$defs/plan_step"
+          },
+          "maxItems": 64,
+          "type": "array"
+        }
+      },
+      "required": [
+        "before",
+        "after"
       ],
       "type": "object"
     },
@@ -187,6 +214,28 @@
     "probe_id": {
       "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
       "type": "string"
+    },
+    "probe_replay_hash": {
+      "additionalProperties": false,
+      "properties": {
+        "input_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "probe_id": {
+          "$ref": "#/$defs/probe_id"
+        },
+        "result_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "probe_id",
+        "input_hash",
+        "result_hash"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://industrialalgebra.com/schemas/amari.discovery/plan/v1",
@@ -211,13 +260,16 @@
           "type": "boolean"
         },
         "trace": {
+          "items": {
+            "$ref": "#/$defs/normalization_trace"
+          },
           "maxItems": 4096,
           "type": "array"
         }
       },
       "required": [
-        "normalized",
-        "max_rewrites"
+        "max_rewrites",
+        "normalized"
       ],
       "type": "object"
     },

--- a/amari-discovery/schemas/probe-v1.json
+++ b/amari-discovery/schemas/probe-v1.json
@@ -1,0 +1,106 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/probe/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "backend": {
+      "const": "cpu"
+    },
+    "catalog_hash": {
+      "type": "string"
+    },
+    "duration_micros": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "input_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "output": true,
+    "probe_id": {
+      "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
+      "type": "string"
+    },
+    "project_hash": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "refuted_assumptions": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "resources": {
+      "additionalProperties": false,
+      "properties": {
+        "bytes": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "iterations": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nodes": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "operations": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "operations",
+        "nodes",
+        "iterations",
+        "bytes"
+      ],
+      "type": "object"
+    },
+    "seed": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "validated_assumptions": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "warnings": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    }
+  },
+  "required": [
+    "probe_id",
+    "backend",
+    "duration_micros",
+    "resources",
+    "catalog_hash",
+    "input_hash",
+    "validated_assumptions",
+    "refuted_assumptions",
+    "warnings",
+    "output"
+  ],
+  "title": "Amari Discovery Probe Result v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/schemas/request-v1.json
+++ b/amari-discovery/schemas/request-v1.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/request/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "arguments": {
+      "maxProperties": 32,
+      "type": "object"
+    },
+    "command": {
+      "enum": [
+        "capabilities",
+        "discover.search",
+        "discover.detail",
+        "discover.graph",
+        "discover.example",
+        "inspect",
+        "recommend",
+        "plan",
+        "probe.list",
+        "probe.describe",
+        "probe.run",
+        "schema"
+      ],
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "amari.discovery/v1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "command",
+    "arguments"
+  ],
+  "title": "Amari Discovery Request v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/schemas/response-v1.json
+++ b/amari-discovery/schemas/response-v1.json
@@ -1,0 +1,134 @@
+{
+  "$defs": {
+    "provenance": {
+      "additionalProperties": false,
+      "properties": {
+        "catalog": {
+          "additionalProperties": false,
+          "properties": {
+            "hash": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "hash"
+          ],
+          "type": "object"
+        },
+        "compatibility": {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        },
+        "input_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "project_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay": {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "replayable": {
+              "type": "boolean"
+            },
+            "required_hashes": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array"
+            }
+          },
+          "required": [
+            "replayable",
+            "required_hashes",
+            "reasons"
+          ],
+          "type": "object"
+        },
+        "seed": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tool_version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool_version",
+        "catalog",
+        "compatibility",
+        "replay",
+        "project_hash",
+        "input_hash",
+        "seed"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/response/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "data": true,
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "schema_version": {
+      "const": "amari.discovery/v1"
+    },
+    "warnings": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "provenance",
+    "warnings",
+    "data"
+  ],
+  "title": "Amari Discovery Response Envelope v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/src/capabilities.rs
+++ b/amari-discovery/src/capabilities.rs
@@ -243,7 +243,7 @@ impl Capabilities {
                 hash: catalog.content_hash().into(),
                 available: true,
             },
-            output_modes: vec!["human".into(), "json".into()],
+            output_modes: vec!["human".into(), "json".into(), "ndjson".into()],
             resource_limits: ResourceLimits::default(),
             host: detect_host(),
             target: compilation_target(),

--- a/amari-discovery/src/capabilities.rs
+++ b/amari-discovery/src/capabilities.rs
@@ -223,10 +223,10 @@ impl Capabilities {
                             missing_features.join(", ")
                         )
                     } else if executable && probe.deterministic {
-                        "registered deterministic adapter is available with cooperative isolation"
+                        "registered deterministic adapter is available; library execution is cooperative and CLI execution is process-isolated"
                             .into()
                     } else if executable {
-                        "registered adapter is available with cooperative isolation".into()
+                        "registered adapter is available; library execution is cooperative and CLI execution is process-isolated".into()
                     } else {
                         "required features are compiled; probe adapter is not registered yet".into()
                     }),

--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -2,7 +2,10 @@
 
 //! Command-line parsing and dispatch for the `amari` binary.
 
-use std::{io, path::PathBuf};
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+};
 
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -263,11 +266,94 @@ pub fn run() -> DiscoveryResult<()> {
             recommendation,
             project,
         } => run_plan(candidate_id, recommendation, project, cli.json),
+        Command::Probe { command } => run_probe(command, cli.json),
         Command::ProbeWorker => crate::probes::worker::run_stdio(),
         command => Err(DiscoveryError::NotImplemented(format!(
             "{} is not implemented in this build",
             command.unavailable_name()
         ))),
+    }
+}
+
+/// Renders a process-level error according to the selected machine mode.
+///
+/// JSON mode emits one structured object on stderr. Human mode emits the
+/// stable error kind and message. Rendering failures are intentionally ignored
+/// because the original process error determines the exit status.
+pub fn report_error(error: &DiscoveryError) {
+    let json = std::env::args_os().any(|argument| argument == "--json");
+    let mut stderr = io::stderr().lock();
+    if json {
+        let payload = serde_json::json!({
+            "kind": error.kind(),
+            "message": error.to_string(),
+            "details": { "exit_code": error.exit_code() }
+        });
+        let _ = serde_json::to_writer(&mut stderr, &payload);
+        let _ = writeln!(stderr);
+    } else {
+        let _ = writeln!(stderr, "{}: {error}", error.kind());
+    }
+}
+
+fn run_probe(command: ProbeCommand, json: bool) -> DiscoveryResult<()> {
+    let catalog = Catalog::embedded()?;
+    let mut stdout = io::stdout().lock();
+    match command {
+        ProbeCommand::List => {
+            let envelope = commands::probe::list_envelope(&catalog)?;
+            if json {
+                render::write_json(&mut stdout, &envelope)
+            } else {
+                render::write_probe_list_human(&mut stdout, &envelope)
+            }
+        }
+        ProbeCommand::Describe { probe_id } => {
+            let probe_id = probe_id.parse()?;
+            let envelope = commands::probe::describe_envelope(&catalog, &probe_id)?;
+            if json {
+                render::write_json(&mut stdout, &envelope)
+            } else {
+                render::write_probe_description_human(&mut stdout, &envelope)
+            }
+        }
+        ProbeCommand::Run {
+            probe_id,
+            input,
+            plan,
+            dry_run,
+        } => {
+            let probe_id = probe_id.parse()?;
+            match (input, plan, dry_run) {
+                (Some(_), None, true) => Err(DiscoveryError::InvalidInput(
+                    "probe dry-run requires --plan and never accepts --input".to_owned(),
+                )),
+                (None, Some(_), false) => Err(DiscoveryError::InvalidInput(
+                    "probe plan execution is disabled; provide explicit typed input with --input"
+                        .to_owned(),
+                )),
+                (Some(path), None, false) => {
+                    let envelope = commands::probe::run_input_envelope(&catalog, &probe_id, &path)?;
+                    if json {
+                        render::write_json(&mut stdout, &envelope)
+                    } else {
+                        render::write_probe_run_human(&mut stdout, &envelope)
+                    }
+                }
+                (None, Some(path), true) => {
+                    let envelope =
+                        commands::probe::dry_run_plan_envelope(&catalog, &probe_id, &path)?;
+                    if json {
+                        render::write_json(&mut stdout, &envelope)
+                    } else {
+                        render::write_probe_dry_run_human(&mut stdout, &envelope)
+                    }
+                }
+                _ => Err(DiscoveryError::InvalidInput(
+                    "probe run requires exactly one of --input or --plan".to_owned(),
+                )),
+            }
+        }
     }
 }
 

--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -10,7 +10,10 @@ use std::{
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::inspect::{inspect_project_envelope, InspectionLimits};
-use crate::{commands, render, Capabilities, Catalog, DiscoveryError, DiscoveryResult, GoalSpec};
+use crate::{
+    commands, render, Capabilities, Catalog, CatalogIdentity, Compatibility, DiscoveryError,
+    DiscoveryResult, Envelope, GoalSpec, ReplayMetadata,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -22,8 +25,21 @@ struct Cli {
     #[command(subcommand)]
     command: Command,
 
-    #[arg(long, global = true, help = "Emit a versioned JSON response")]
+    #[arg(
+        long,
+        global = true,
+        conflicts_with = "ndjson",
+        help = "Emit a versioned JSON response"
+    )]
     json: bool,
+
+    #[arg(
+        long,
+        global = true,
+        conflicts_with = "json",
+        help = "Emit one versioned NDJSON response record"
+    )]
+    ndjson: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -240,33 +256,42 @@ impl ProbeCommand {
 /// not executable in the current bootstrap implementation.
 pub fn run() -> DiscoveryResult<()> {
     let cli = Cli::parse();
+    let mode = if cli.ndjson {
+        render::OutputMode::Ndjson
+    } else if cli.json {
+        render::OutputMode::Json
+    } else {
+        render::OutputMode::Human
+    };
     match cli.command {
         Command::Capabilities => {
             let envelope = Capabilities::envelope()?;
             let mut stdout = io::stdout().lock();
-            if cli.json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_capabilities_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(
+                &mut stdout,
+                &envelope,
+                mode,
+                render::write_capabilities_human,
+            )
         }
         Command::Discover { command } => {
             let catalog = Catalog::embedded()?;
-            run_discover(&catalog, command, cli.json)
+            run_discover(&catalog, command, mode)
         }
-        Command::Inspect { path } => run_inspect(path, cli.json),
+        Command::Inspect { path } => run_inspect(path, mode),
         Command::Recommend {
             path,
             goal,
             goal_file,
             probe_results,
-        } => run_recommend(path, goal, goal_file, probe_results, cli.json),
+        } => run_recommend(path, goal, goal_file, probe_results, mode),
         Command::Plan {
             candidate_id,
             recommendation,
             project,
-        } => run_plan(candidate_id, recommendation, project, cli.json),
-        Command::Probe { command } => run_probe(command, cli.json),
+        } => run_plan(candidate_id, recommendation, project, mode),
+        Command::Probe { command } => run_probe(command, mode),
+        Command::Schema { kind } => run_schema(kind, mode),
         Command::ProbeWorker => crate::probes::worker::run_stdio(),
         command => Err(DiscoveryError::NotImplemented(format!(
             "{} is not implemented in this build",
@@ -281,9 +306,10 @@ pub fn run() -> DiscoveryResult<()> {
 /// stable error kind and message. Rendering failures are intentionally ignored
 /// because the original process error determines the exit status.
 pub fn report_error(error: &DiscoveryError) {
-    let json = std::env::args_os().any(|argument| argument == "--json");
+    let machine =
+        std::env::args_os().any(|argument| argument == "--json" || argument == "--ndjson");
     let mut stderr = io::stderr().lock();
-    if json {
+    if machine {
         let payload = serde_json::json!({
             "kind": error.kind(),
             "message": error.to_string(),
@@ -296,26 +322,69 @@ pub fn report_error(error: &DiscoveryError) {
     }
 }
 
-fn run_probe(command: ProbeCommand, json: bool) -> DiscoveryResult<()> {
+fn run_schema(kind: Option<SchemaKind>, mode: render::OutputMode) -> DiscoveryResult<()> {
+    let catalog = Catalog::embedded()?;
+    let mut stdout = io::stdout().lock();
+    match kind {
+        Some(kind) => {
+            let kind = match kind {
+                SchemaKind::Request => crate::SchemaKind::Request,
+                SchemaKind::Response => crate::SchemaKind::Response,
+                SchemaKind::Goal => crate::SchemaKind::Goal,
+                SchemaKind::Plan => crate::SchemaKind::Plan,
+                SchemaKind::Probe => crate::SchemaKind::Probe,
+            };
+            let envelope = schema_envelope(&catalog, crate::protocol_schema(kind)?);
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_schema_human)
+        }
+        None => {
+            let envelope = schema_envelope(&catalog, crate::protocol_schema_catalog()?);
+            render::write_envelope(
+                &mut stdout,
+                &envelope,
+                mode,
+                render::write_schema_catalog_human,
+            )
+        }
+    }
+}
+
+fn schema_envelope<T>(catalog: &Catalog, data: T) -> Envelope<T> {
+    Envelope::new(
+        data,
+        CatalogIdentity {
+            version: catalog.version().to_owned(),
+            hash: catalog.content_hash().to_owned(),
+        },
+        Compatibility {
+            status: "compatible".to_owned(),
+            reasons: Vec::new(),
+        },
+        ReplayMetadata {
+            replayable: false,
+            required_hashes: Vec::new(),
+            reasons: vec!["schema discovery is catalog-independent".to_owned()],
+        },
+    )
+}
+
+fn run_probe(command: ProbeCommand, mode: render::OutputMode) -> DiscoveryResult<()> {
     let catalog = Catalog::embedded()?;
     let mut stdout = io::stdout().lock();
     match command {
         ProbeCommand::List => {
             let envelope = commands::probe::list_envelope(&catalog)?;
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_probe_list_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_probe_list_human)
         }
         ProbeCommand::Describe { probe_id } => {
             let probe_id = probe_id.parse()?;
             let envelope = commands::probe::describe_envelope(&catalog, &probe_id)?;
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_probe_description_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(
+                &mut stdout,
+                &envelope,
+                mode,
+                render::write_probe_description_human,
+            )
         }
         ProbeCommand::Run {
             probe_id,
@@ -334,20 +403,22 @@ fn run_probe(command: ProbeCommand, json: bool) -> DiscoveryResult<()> {
                 )),
                 (Some(path), None, false) => {
                     let envelope = commands::probe::run_input_envelope(&catalog, &probe_id, &path)?;
-                    if json {
-                        render::write_json(&mut stdout, &envelope)
-                    } else {
-                        render::write_probe_run_human(&mut stdout, &envelope)
-                    }
+                    render::write_envelope(
+                        &mut stdout,
+                        &envelope,
+                        mode,
+                        render::write_probe_run_human,
+                    )
                 }
                 (None, Some(path), true) => {
                     let envelope =
                         commands::probe::dry_run_plan_envelope(&catalog, &probe_id, &path)?;
-                    if json {
-                        render::write_json(&mut stdout, &envelope)
-                    } else {
-                        render::write_probe_dry_run_human(&mut stdout, &envelope)
-                    }
+                    render::write_envelope(
+                        &mut stdout,
+                        &envelope,
+                        mode,
+                        render::write_probe_dry_run_human,
+                    )
                 }
                 _ => Err(DiscoveryError::InvalidInput(
                     "probe run requires exactly one of --input or --plan".to_owned(),
@@ -358,18 +429,14 @@ fn run_probe(command: ProbeCommand, json: bool) -> DiscoveryResult<()> {
 }
 
 /// Runs bounded project inspection and renders the shared typed snapshot.
-fn run_inspect(path: Option<PathBuf>, json: bool) -> DiscoveryResult<()> {
+fn run_inspect(path: Option<PathBuf>, mode: render::OutputMode) -> DiscoveryResult<()> {
     let root = match path {
         Some(path) => path,
         None => std::env::current_dir()?,
     };
     let envelope = inspect_project_envelope(&root, &InspectionLimits::default())?;
     let mut stdout = io::stdout().lock();
-    if json {
-        render::write_json(&mut stdout, &envelope)
-    } else {
-        render::write_inspection_human(&mut stdout, &envelope)
-    }
+    render::write_envelope(&mut stdout, &envelope, mode, render::write_inspection_human)
 }
 
 /// Runs deterministic recommendation for a supported project.
@@ -378,7 +445,7 @@ fn run_recommend(
     goal: Option<String>,
     goal_file: Option<PathBuf>,
     probe_results: Option<PathBuf>,
-    json: bool,
+    mode: render::OutputMode,
 ) -> DiscoveryResult<()> {
     let goal = match (goal, goal_file) {
         (Some(statement), None) => GoalSpec {
@@ -409,11 +476,12 @@ fn run_recommend(
         &InspectionLimits::default(),
     )?;
     let mut stdout = io::stdout().lock();
-    if json {
-        render::write_json(&mut stdout, &envelope)
-    } else {
-        render::write_recommendation_human(&mut stdout, &envelope)
-    }
+    render::write_envelope(
+        &mut stdout,
+        &envelope,
+        mode,
+        render::write_recommendation_human,
+    )
 }
 
 /// Replays one candidate from a saved recommendation artifact.
@@ -421,7 +489,7 @@ fn run_plan(
     candidate_id: String,
     recommendation: PathBuf,
     project: PathBuf,
-    json: bool,
+    mode: render::OutputMode,
 ) -> DiscoveryResult<()> {
     let artifact = commands::plan::read_recommendation(&recommendation)?;
     let catalog = Catalog::embedded()?;
@@ -433,48 +501,32 @@ fn run_plan(
         &InspectionLimits::default(),
     )?;
     let mut stdout = io::stdout().lock();
-    if json {
-        render::write_json(&mut stdout, &envelope)
-    } else {
-        render::write_plan_human(&mut stdout, &envelope)
-    }
+    render::write_envelope(&mut stdout, &envelope, mode, render::write_plan_human)
 }
 
 /// Dispatches a discover subcommand against the embedded catalog and renders output.
-fn run_discover(catalog: &Catalog, command: DiscoverCommand, json: bool) -> DiscoveryResult<()> {
+fn run_discover(
+    catalog: &Catalog,
+    command: DiscoverCommand,
+    mode: render::OutputMode,
+) -> DiscoveryResult<()> {
     let mut stdout = io::stdout().lock();
     match command {
         DiscoverCommand::Search { query } => {
             let envelope = commands::discover::search_envelope(catalog, &query);
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_search_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_search_human)
         }
         DiscoverCommand::Detail { identifier } => {
             let envelope = commands::discover::detail_envelope(catalog, &identifier)?;
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_detail_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_detail_human)
         }
         DiscoverCommand::Graph { identifier } => {
             let envelope = commands::discover::graph_envelope(catalog, &identifier)?;
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_graph_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_graph_human)
         }
         DiscoverCommand::Example { identifier } => {
             let envelope = commands::discover::example_envelope(catalog, &identifier)?;
-            if json {
-                render::write_json(&mut stdout, &envelope)
-            } else {
-                render::write_example_human(&mut stdout, &envelope)
-            }
+            render::write_envelope(&mut stdout, &envelope, mode, render::write_example_human)
         }
     }
 }

--- a/amari-discovery/src/commands/mod.rs
+++ b/amari-discovery/src/commands/mod.rs
@@ -8,4 +8,5 @@
 
 pub mod discover;
 pub mod plan;
+pub mod probe;
 pub mod recommend;

--- a/amari-discovery/src/commands/probe.rs
+++ b/amari-discovery/src/commands/probe.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed handlers for discovering, dry-running, and executing bounded probes.
+
+use std::{path::Path, time::Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::recommend::read_bounded_input;
+use crate::{
+    CandidatePlan, Capabilities, Catalog, CatalogIdentity, Compatibility, DiscoveryError,
+    DiscoveryResult, Envelope, PlanStep, ProbeBackend, ProbeDescriptor, ProbeEngineLimits, ProbeId,
+    ProbeIsolation, ProbeResult, Provenance, ReplayMetadata, ResourceLimits, SCHEMA_V1,
+};
+
+const MAX_PROBE_INPUT_BYTES: u64 = 1_048_576;
+const MAX_PLAN_BYTES: u64 = 2 * 1_048_576;
+
+/// Runtime state for one declarative probe descriptor.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeListItem {
+    /// Stable probe identifier.
+    pub id: ProbeId,
+    /// Whether the embedded catalog recognizes this descriptor.
+    pub known: bool,
+    /// Whether required Cargo features are compiled.
+    pub available: bool,
+    /// Whether a matching adapter is registered in this binary.
+    pub executable: bool,
+    /// Qualification for the runtime state.
+    pub reason: Option<String>,
+}
+
+/// Deterministically ordered known probe states.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeList {
+    /// Catalog-backed probe states.
+    pub probes: Vec<ProbeListItem>,
+}
+
+/// Complete declarative and runtime contract for one known probe.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeDescription {
+    /// Declarative catalog descriptor.
+    pub descriptor: ProbeDescriptor,
+    /// Whether the descriptor is known.
+    pub known: bool,
+    /// Whether its required features are compiled.
+    pub available: bool,
+    /// Whether executable adapter code is registered.
+    pub executable: bool,
+    /// Isolation used by explicit CLI execution.
+    pub isolation: ProbeIsolation,
+    /// Whether the supervisor enforces a wall-clock deadline.
+    pub hard_timeout: bool,
+    /// Whether worker crashes are isolated from the CLI process.
+    pub crash_isolation: bool,
+    /// Qualification for the runtime state.
+    pub reason: Option<String>,
+}
+
+/// Compatibility-only result for a probe step in a saved plan.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeDryRun {
+    /// Requested registered probe.
+    pub probe_id: ProbeId,
+    /// Whether the plan and current catalog are compatible.
+    pub compatible: bool,
+    /// Whether adapter code exists in this binary.
+    pub executable: bool,
+    /// Dry-runs never start a worker.
+    pub would_execute: bool,
+    /// Isolation that explicit input execution would use.
+    pub planned_isolation: ProbeIsolation,
+    /// Whether explicit execution would have a hard deadline.
+    pub hard_timeout: bool,
+    /// Whether explicit execution would isolate crashes.
+    pub crash_isolation: bool,
+    /// Hash of the checked saved plan.
+    pub plan_hash: String,
+}
+
+/// Isolated CLI execution result plus truthful process guarantees.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeRunResult {
+    /// Task 2 probe result suitable for saved evidence.
+    pub result: ProbeResult,
+    /// Versioned input schema validated by the adapter.
+    pub input_schema: String,
+    /// Versioned output schema emitted by the adapter.
+    pub output_schema: String,
+    /// Isolation provided by this execution path.
+    pub isolation: ProbeIsolation,
+    /// Whether identical validated inputs produce identical mathematical output.
+    pub deterministic: bool,
+    /// Whether the supervisor enforced a hard deadline.
+    pub hard_timeout: bool,
+    /// Whether worker crashes were isolated.
+    pub crash_isolation: bool,
+    /// Supervisor wall-clock limit in milliseconds.
+    pub timeout_millis: u64,
+}
+
+/// Returns every catalog probe with dynamically derived runtime state.
+///
+/// # Errors
+///
+/// Returns a catalog or registry validation error.
+pub fn list_envelope(catalog: &Catalog) -> DiscoveryResult<Envelope<ProbeList>> {
+    let states = Capabilities::current()?.known_probes;
+    let probes = catalog
+        .probes()
+        .iter()
+        .zip(states)
+        .map(|(descriptor, state)| ProbeListItem {
+            id: descriptor.id.clone(),
+            known: state.known,
+            available: state.available,
+            executable: state.executable,
+            reason: state.reason,
+        })
+        .collect();
+    Ok(catalog_envelope(catalog, ProbeList { probes }))
+}
+
+/// Returns one complete catalog probe contract and dynamic runtime state.
+///
+/// # Errors
+///
+/// Returns invalid input for an unknown probe or a registry validation error.
+pub fn describe_envelope(
+    catalog: &Catalog,
+    probe_id: &ProbeId,
+) -> DiscoveryResult<Envelope<ProbeDescription>> {
+    let descriptor = descriptor(catalog, probe_id)?.clone();
+    let state = runtime_state(probe_id)?;
+    Ok(catalog_envelope(
+        catalog,
+        ProbeDescription {
+            descriptor,
+            known: state.known,
+            available: state.available,
+            executable: state.executable,
+            isolation: ProbeIsolation::Process,
+            hard_timeout: true,
+            crash_isolation: true,
+            reason: state.reason,
+        },
+    ))
+}
+
+/// Validates a saved plan's catalog-backed probe step without execution.
+///
+/// # Errors
+///
+/// Returns a typed file, serialization, catalog-drift, or missing-step error.
+pub fn dry_run_plan_envelope(
+    catalog: &Catalog,
+    probe_id: &ProbeId,
+    path: &Path,
+) -> DiscoveryResult<Envelope<ProbeDryRun>> {
+    let descriptor = descriptor(catalog, probe_id)?;
+    let bytes = read_bounded_input(path, MAX_PLAN_BYTES, "probe plan")?;
+    let artifact: Envelope<CandidatePlan> = serde_json::from_slice(&bytes)?;
+    if artifact.schema_version != SCHEMA_V1 {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "probe plan schema `{}` is unsupported",
+            artifact.schema_version
+        )));
+    }
+    if artifact.data.compatibility.catalog.version != catalog.version()
+        || artifact.data.compatibility.catalog.hash != catalog.content_hash()
+    {
+        return Err(DiscoveryError::ReplayDrift {
+            field: "catalog_hash".to_owned(),
+            expected: artifact.data.compatibility.catalog.hash,
+            actual: catalog.content_hash().to_owned(),
+        });
+    }
+    let matching_step = artifact.data.steps.iter().any(|step| {
+        matches!(step, PlanStep::Probe { capability_id, probe_id: planned }
+            if planned == probe_id && capability_id == &descriptor.capability_id)
+    });
+    if !matching_step {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "saved plan contains no probe step for `{probe_id}`"
+        )));
+    }
+    let state = runtime_state(probe_id)?;
+    let mut envelope = catalog_envelope(
+        catalog,
+        ProbeDryRun {
+            probe_id: probe_id.clone(),
+            compatible: true,
+            executable: state.executable,
+            would_execute: false,
+            planned_isolation: ProbeIsolation::Process,
+            hard_timeout: true,
+            crash_isolation: true,
+            plan_hash: artifact.data.plan_hash,
+        },
+    );
+    envelope.provenance.project_hash = Some(artifact.data.compatibility.project_hash);
+    envelope.provenance.input_hash = Some(artifact.data.compatibility.input_hash);
+    envelope.provenance.replay = artifact.provenance.replay;
+    Ok(envelope)
+}
+
+/// Executes explicit typed input through the fixed private process supervisor.
+///
+/// # Errors
+///
+/// Returns a typed file, input, registry, limit, worker, or protocol error.
+pub fn run_input_envelope(
+    catalog: &Catalog,
+    probe_id: &ProbeId,
+    path: &Path,
+) -> DiscoveryResult<Envelope<ProbeRunResult>> {
+    descriptor(catalog, probe_id)?;
+    let state = runtime_state(probe_id)?;
+    if !state.executable {
+        return Err(DiscoveryError::ProbeUnavailable(format!(
+            "probe `{probe_id}` has no executable adapter in this build"
+        )));
+    }
+    let bytes = read_bounded_input(path, MAX_PROBE_INPUT_BYTES, "probe input")?;
+    let input: Value = serde_json::from_slice(&bytes)?;
+    let input_hash = hash_json(&input)?;
+    let limits = ProbeEngineLimits::default();
+    let provenance = standalone_provenance(catalog, input_hash.clone());
+    let started = Instant::now();
+    let execution = crate::probes::execute_isolated(probe_id, &input, limits, provenance.clone())?;
+    let duration_micros = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+    let result = ProbeResult {
+        probe_id: probe_id.clone(),
+        backend: ProbeBackend::Cpu,
+        duration_micros,
+        resources: execution.resources.clone(),
+        seed: provenance.seed,
+        project_hash: provenance.project_hash.clone(),
+        catalog_hash: provenance.catalog.hash.clone(),
+        input_hash: input_hash.clone(),
+        validated_assumptions: Vec::new(),
+        refuted_assumptions: Vec::new(),
+        warnings: Vec::new(),
+        output: execution.output,
+    };
+    let defaults = ResourceLimits::default();
+    let mut envelope = catalog_envelope(
+        catalog,
+        ProbeRunResult {
+            result,
+            input_schema: execution.input_schema,
+            output_schema: execution.output_schema,
+            isolation: execution.isolation,
+            deterministic: execution.deterministic,
+            hard_timeout: true,
+            crash_isolation: true,
+            timeout_millis: defaults.probe_timeout_millis,
+        },
+    );
+    envelope.provenance = provenance;
+    Ok(envelope)
+}
+
+fn descriptor<'a>(
+    catalog: &'a Catalog,
+    probe_id: &ProbeId,
+) -> DiscoveryResult<&'a ProbeDescriptor> {
+    catalog
+        .probes()
+        .iter()
+        .find(|descriptor| descriptor.id == *probe_id)
+        .ok_or_else(|| DiscoveryError::InvalidInput(format!("unknown probe `{probe_id}`")))
+}
+
+fn runtime_state(probe_id: &ProbeId) -> DiscoveryResult<crate::RuntimeCapabilityState> {
+    Capabilities::current()?
+        .known_probes
+        .into_iter()
+        .find(|state| state.id == probe_id.to_string())
+        .ok_or_else(|| DiscoveryError::InvalidInput(format!("unknown probe `{probe_id}`")))
+}
+
+fn catalog_envelope<T>(catalog: &Catalog, data: T) -> Envelope<T> {
+    Envelope::new(
+        data,
+        CatalogIdentity {
+            version: catalog.version().to_owned(),
+            hash: catalog.content_hash().to_owned(),
+        },
+        Compatibility {
+            status: "compatible".to_owned(),
+            reasons: Vec::new(),
+        },
+        ReplayMetadata {
+            replayable: false,
+            required_hashes: Vec::new(),
+            reasons: vec!["catalog-only probe response".to_owned()],
+        },
+    )
+}
+
+fn standalone_provenance(catalog: &Catalog, input_hash: String) -> Provenance {
+    Provenance {
+        tool_version: env!("CARGO_PKG_VERSION").to_owned(),
+        catalog: CatalogIdentity {
+            version: catalog.version().to_owned(),
+            hash: catalog.content_hash().to_owned(),
+        },
+        compatibility: Compatibility {
+            status: "compatible".to_owned(),
+            reasons: Vec::new(),
+        },
+        replay: ReplayMetadata {
+            replayable: true,
+            required_hashes: vec!["catalog_hash".to_owned(), "input_hash".to_owned()],
+            reasons: Vec::new(),
+        },
+        project_hash: None,
+        input_hash: Some(input_hash),
+        seed: None,
+    }
+}
+
+fn hash_json(value: &Value) -> DiscoveryResult<String> {
+    Ok(hex::encode(Sha256::digest(serde_json::to_vec(value)?)))
+}

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -25,6 +25,7 @@ pub mod planner;
 mod probes;
 pub mod protocol;
 mod render;
+pub mod schema;
 
 pub use capabilities::{
     AiAdapterStatus, Capabilities, CatalogStatus, FeatureGate, PlatformInfo, ResourceLimits,
@@ -104,3 +105,4 @@ pub use protocol::{
     Provenance, Recommendation, RecommendationScore, RecommendationScoreComponents, ReplayMetadata,
     ResourceObservations, SchemaVersion, SCHEMA_V1,
 };
+pub use schema::{protocol_schema, ProtocolSchema, SchemaKind};

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cli;
 pub mod commands;
 pub mod error;
 pub mod inspect;
+pub mod ndjson;
 pub mod planner;
 mod probes;
 pub mod protocol;
@@ -76,6 +77,7 @@ pub use inspect::{
     TypeScriptRuntimeSignal, TypeScriptVocabularyEvidence, VocabularyEvidence, WasmTargetEvidence,
     WasmTargetOrigin, WorkspaceDependencyBase, WorkspaceMeta,
 };
+pub use ndjson::{NdjsonWriter, DEFAULT_MAX_NDJSON_RECORD_BYTES};
 pub use planner::{
     BlockedCandidate, CandidateRanker, CandidateRetriever, CapabilityGraphExpander,
     GraphConstraints, GraphExpansion, GraphExpansionState, GraphLimit, GraphLimits, GraphPath,

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -107,4 +107,7 @@ pub use protocol::{
     Provenance, Recommendation, RecommendationScore, RecommendationScoreComponents, ReplayMetadata,
     ResourceObservations, SchemaVersion, SCHEMA_V1,
 };
-pub use schema::{protocol_schema, ProtocolSchema, SchemaKind};
+pub use schema::{
+    protocol_schema, protocol_schema_catalog, ProtocolSchema, SchemaCatalog, SchemaKind,
+    SchemaSummary,
+};

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -49,6 +49,9 @@ pub use commands::discover::{
     DiscoveredExample, ExampleResult, GraphRelationItem, GraphResult, SearchResultItem,
     SearchResults,
 };
+pub use commands::probe::{
+    ProbeDescription, ProbeDryRun, ProbeList, ProbeListItem, ProbeRunResult,
+};
 pub use error::{DiscoveryError, DiscoveryResult};
 pub use inspect::{
     inspect_cargo_platform, inspect_cargo_project, inspect_npm_project,

--- a/amari-discovery/src/main.rs
+++ b/amari-discovery/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> ExitCode {
     match amari_discovery::cli::run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("{}: {error}", error.kind());
+            amari_discovery::cli::report_error(&error);
             ExitCode::from(error.exit_code())
         }
     }

--- a/amari-discovery/src/ndjson.rs
+++ b/amari-discovery/src/ndjson.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared bounded newline-delimited JSON record framing.
+
+use std::io::Write;
+
+use serde::Serialize;
+
+use crate::{DiscoveryError, DiscoveryResult};
+
+/// Default maximum serialized bytes for one NDJSON object, excluding newline.
+pub const DEFAULT_MAX_NDJSON_RECORD_BYTES: usize = 1024 * 1024;
+
+/// A writer that emits one bounded complete JSON object per flushed line.
+pub struct NdjsonWriter<W> {
+    writer: W,
+    max_record_bytes: usize,
+}
+
+impl<W: Write> NdjsonWriter<W> {
+    /// Creates a writer with the one-mebibyte default record ceiling.
+    ///
+    /// # Errors
+    ///
+    /// Returns invalid input only if the compiled default ceiling is zero.
+    pub fn new(writer: W) -> DiscoveryResult<Self> {
+        Self::with_max_record_bytes(writer, DEFAULT_MAX_NDJSON_RECORD_BYTES)
+    }
+
+    /// Creates a writer with an explicit serialized-record ceiling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] when `max_record_bytes` is zero.
+    pub fn with_max_record_bytes(writer: W, max_record_bytes: usize) -> DiscoveryResult<Self> {
+        if max_record_bytes == 0 {
+            return Err(DiscoveryError::InvalidInput(
+                "NDJSON record limit must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(Self {
+            writer,
+            max_record_bytes,
+        })
+    }
+
+    /// Serializes, bounds, writes, newline-terminates, and flushes one object.
+    ///
+    /// String newlines are escaped by the JSON serializer and therefore never
+    /// split a record. The size limit is checked before any bytes are written.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error, a limit error before writing, or a typed
+    /// I/O error when writing or flushing fails.
+    pub fn write<T: Serialize>(&mut self, value: &T) -> DiscoveryResult<()> {
+        let record = serde_json::to_vec(value)?;
+        if record.len() > self.max_record_bytes {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "NDJSON record bytes {} exceed limit {}",
+                record.len(),
+                self.max_record_bytes
+            )));
+        }
+        self.writer.write_all(&record)?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    /// Returns the wrapped writer after all desired records have been emitted.
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -15,8 +15,6 @@ mod network;
 mod optimization;
 mod registry;
 mod rewrite;
-// Task 21C wires this private process-isolation foundation into CLI dispatch.
-#[allow(dead_code)]
 mod supervisor;
 mod surreal;
 mod tropical;
@@ -255,6 +253,15 @@ impl ProbeEngine {
             output: result.output,
         })
     }
+}
+
+pub(crate) fn execute_isolated(
+    id: &ProbeId,
+    input: &Value,
+    limits: ProbeEngineLimits,
+    provenance: crate::Provenance,
+) -> DiscoveryResult<ProbeExecution> {
+    supervisor::execute_isolated(id, input, limits, provenance)
 }
 
 fn enforce_limit(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {

--- a/amari-discovery/src/probes/supervisor.rs
+++ b/amari-discovery/src/probes/supervisor.rs
@@ -15,7 +15,10 @@ use super::{
     worker::{self, WorkerRequest, WorkerResponse},
     ProbeIsolation,
 };
-use crate::{DiscoveryError, DiscoveryResult, Provenance};
+use crate::{
+    DiscoveryError, DiscoveryResult, ProbeEngineLimits, ProbeExecution, ProbeId, Provenance,
+    ResourceLimits,
+};
 
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
@@ -61,14 +64,10 @@ enum DrainOutcome {
     Failed(io::Error),
 }
 
-// This private foundation is wired into command dispatch by Task 21C.
-#[allow(dead_code)]
 trait WorkerLauncher {
     fn command(&self) -> DiscoveryResult<Command>;
 }
 
-// This private foundation is wired into command dispatch by Task 21C.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub(super) struct ProductionWorkerLauncher;
 
@@ -80,8 +79,6 @@ impl WorkerLauncher for ProductionWorkerLauncher {
     }
 }
 
-// This private foundation is wired into command dispatch by Task 21C.
-#[allow(dead_code)]
 fn spawn_restricted(launcher: &impl WorkerLauncher) -> DiscoveryResult<Child> {
     let mut command = launcher.command()?;
     command
@@ -96,6 +93,30 @@ fn spawn_restricted(launcher: &impl WorkerLauncher) -> DiscoveryResult<Child> {
 fn neutral_working_directory() -> PathBuf {
     let temporary = std::env::temp_dir();
     temporary.canonicalize().unwrap_or(temporary)
+}
+
+pub(super) fn execute_isolated(
+    probe_id: &ProbeId,
+    input: &serde_json::Value,
+    limits: ProbeEngineLimits,
+    provenance: Provenance,
+) -> DiscoveryResult<ProbeExecution> {
+    let defaults = ResourceLimits::default();
+    let response = supervise_worker(
+        &ProductionWorkerLauncher,
+        &WorkerRequest {
+            probe_id: probe_id.clone(),
+            input: input.clone(),
+            limits,
+            provenance,
+        },
+        SupervisorIoLimits {
+            max_stdout_bytes: 2 * 1024 * 1024,
+            max_stderr_bytes: 64 * 1024,
+        },
+        Duration::from_millis(defaults.probe_timeout_millis),
+    )?;
+    Ok(response.execution)
 }
 
 fn supervise_worker(
@@ -148,6 +169,11 @@ fn map_worker_outcome(
         });
     }
 
+    if !captured.stderr.is_empty() {
+        return Err(DiscoveryError::ProbeWorkerProtocol(
+            "successful worker emitted unexpected diagnostics".to_owned(),
+        ));
+    }
     let mut response = decode_worker_response(&captured.stdout).map_err(|error| {
         DiscoveryError::ProbeWorkerProtocol(format!("invalid framed response ({})", error.kind()))
     })?;

--- a/amari-discovery/src/probes/worker.rs
+++ b/amari-discovery/src/probes/worker.rs
@@ -52,8 +52,6 @@ fn write_response(writer: &mut impl Write, response: &WorkerResponse) -> Discove
     write_frame(writer, &body)
 }
 
-// Task 21C constructs this private request from explicit typed CLI input.
-#[allow(dead_code)]
 pub(super) fn encode_request_frame(request: &WorkerRequest) -> DiscoveryResult<Vec<u8>> {
     let body = serde_json::to_vec(request)?;
     let mut frame = Vec::with_capacity(FRAME_HEADER_BYTES.saturating_add(body.len()));
@@ -61,8 +59,6 @@ pub(super) fn encode_request_frame(request: &WorkerRequest) -> DiscoveryResult<V
     Ok(frame)
 }
 
-// Task 21C consumes supervised worker responses through this decoder.
-#[allow(dead_code)]
 pub(super) fn decode_response_frame(bytes: &[u8]) -> DiscoveryResult<WorkerResponse> {
     let mut reader = io::Cursor::new(bytes);
     let body = read_frame(&mut reader)?;

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -7,9 +7,12 @@ use std::io::Write;
 use serde::Serialize;
 
 use crate::{
-    commands::discover::{ExampleResult, GraphResult, SearchResults},
+    commands::{
+        discover::{ExampleResult, GraphResult, SearchResults},
+        probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult},
+    },
     CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
-    PlanStep, ProjectKind, ProjectSnapshot, Recommendation,
+    PlanStep, ProbeIsolation, ProjectKind, ProjectSnapshot, Recommendation,
 };
 
 pub(crate) fn write_json<T: Serialize>(
@@ -88,6 +91,106 @@ pub(crate) fn write_capabilities_human(
         rl.max_inspection_wall_millis
     )?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Probes
+// ---------------------------------------------------------------------------
+
+pub(crate) fn write_probe_list_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProbeList>,
+) -> DiscoveryResult<()> {
+    writeln!(writer, "Registered probes:")?;
+    for probe in &envelope.data.probes {
+        let state = if probe.executable {
+            "executable"
+        } else if probe.available {
+            "available, not executable"
+        } else {
+            "unavailable"
+        };
+        writeln!(writer, "  {}: {state}", probe.id)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn write_probe_description_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProbeDescription>,
+) -> DiscoveryResult<()> {
+    let description = &envelope.data;
+    writeln!(writer, "Probe: {}", description.descriptor.id)?;
+    writeln!(
+        writer,
+        "Capability: {}",
+        description.descriptor.capability_id
+    )?;
+    writeln!(
+        writer,
+        "Input schema: {}",
+        description.descriptor.input_schema
+    )?;
+    writeln!(
+        writer,
+        "Output schema: {}",
+        description.descriptor.output_schema
+    )?;
+    writeln!(writer, "Executable: {}", yes_no(description.executable))?;
+    writeln!(writer, "Process isolation: yes")?;
+    writeln!(writer, "Hard timeout: {}", yes_no(description.hard_timeout))?;
+    writeln!(
+        writer,
+        "Crash isolation: {}",
+        yes_no(description.crash_isolation)
+    )?;
+    Ok(())
+}
+
+pub(crate) fn write_probe_dry_run_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProbeDryRun>,
+) -> DiscoveryResult<()> {
+    let dry_run = &envelope.data;
+    writeln!(writer, "Probe dry-run: {}", dry_run.probe_id)?;
+    writeln!(writer, "Compatible: {}", yes_no(dry_run.compatible))?;
+    writeln!(writer, "Would execute: no")?;
+    writeln!(writer, "Plan hash: {}", dry_run.plan_hash)?;
+    writeln!(writer, "Planned isolation: process")?;
+    Ok(())
+}
+
+pub(crate) fn write_probe_run_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProbeRunResult>,
+) -> DiscoveryResult<()> {
+    let run = &envelope.data;
+    writeln!(writer, "Probe: {}", run.result.probe_id)?;
+    writeln!(writer, "Isolation: {}", isolation_name(run.isolation))?;
+    writeln!(writer, "Hard timeout: {}", yes_no(run.hard_timeout))?;
+    writeln!(writer, "Crash isolation: {}", yes_no(run.crash_isolation))?;
+    writeln!(writer, "Duration (micros): {}", run.result.duration_micros)?;
+    writeln!(
+        writer,
+        "Result: {}",
+        serde_json::to_string(&run.result.output)?
+    )?;
+    Ok(())
+}
+
+fn isolation_name(isolation: ProbeIsolation) -> &'static str {
+    match isolation {
+        ProbeIsolation::Cooperative => "cooperative",
+        ProbeIsolation::Process => "process",
+    }
+}
+
+const fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -12,8 +12,16 @@ use crate::{
         probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult},
     },
     CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
-    PlanStep, ProbeIsolation, ProjectKind, ProjectSnapshot, Recommendation,
+    NdjsonWriter, PlanStep, ProbeIsolation, ProjectKind, ProjectSnapshot, ProtocolSchema,
+    Recommendation, SchemaCatalog,
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OutputMode {
+    Human,
+    Json,
+    Ndjson,
+}
 
 pub(crate) fn write_json<T: Serialize>(
     writer: &mut impl Write,
@@ -22,6 +30,24 @@ pub(crate) fn write_json<T: Serialize>(
     serde_json::to_writer(&mut *writer, envelope)?;
     writeln!(writer)?;
     Ok(())
+}
+
+pub(crate) fn write_envelope<T, W, F>(
+    writer: &mut W,
+    envelope: &Envelope<T>,
+    mode: OutputMode,
+    human: F,
+) -> DiscoveryResult<()>
+where
+    T: Serialize,
+    W: Write,
+    F: FnOnce(&mut W, &Envelope<T>) -> DiscoveryResult<()>,
+{
+    match mode {
+        OutputMode::Human => human(writer, envelope),
+        OutputMode::Json => write_json(writer, envelope),
+        OutputMode::Ndjson => NdjsonWriter::new(writer)?.write(envelope),
+    }
 }
 
 pub(crate) fn write_capabilities_human(
@@ -90,6 +116,31 @@ pub(crate) fn write_capabilities_human(
         "  max_inspection_wall_millis: {}",
         rl.max_inspection_wall_millis
     )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+pub(crate) fn write_schema_catalog_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<SchemaCatalog>,
+) -> DiscoveryResult<()> {
+    writeln!(writer, "Available schemas:")?;
+    for schema in &envelope.data.schemas {
+        writeln!(writer, "  {}: {}", schema.kind, schema.id)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn write_schema_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProtocolSchema>,
+) -> DiscoveryResult<()> {
+    writeln!(writer, "Schema: {}", envelope.data.kind)?;
+    writeln!(writer, "ID: {}", envelope.data.id)?;
+    writeln!(writer, "Protocol: {}", envelope.data.protocol_version)?;
     Ok(())
 }
 

--- a/amari-discovery/src/schema.rs
+++ b/amari-discovery/src/schema.rs
@@ -69,6 +69,24 @@ impl fmt::Display for SchemaKind {
     }
 }
 
+/// Compact identity for one available protocol schema.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SchemaSummary {
+    /// Schema family.
+    pub kind: SchemaKind,
+    /// Stable JSON Schema `$id`.
+    pub id: String,
+    /// Discovery protocol version described by the schema.
+    pub protocol_version: String,
+}
+
+/// Deterministically ordered catalog of available protocol schemas.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SchemaCatalog {
+    /// All five v1 schema identities.
+    pub schemas: Vec<SchemaSummary>,
+}
+
 /// One parsed curated protocol schema and its stable identity.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProtocolSchema {
@@ -93,6 +111,26 @@ impl ProtocolSchema {
         bytes.push(b'\n');
         Ok(bytes)
     }
+}
+
+/// Returns all available schema identities in deterministic order.
+///
+/// # Errors
+///
+/// Returns catalog corruption when any embedded schema is invalid.
+pub fn protocol_schema_catalog() -> DiscoveryResult<SchemaCatalog> {
+    let schemas = SchemaKind::ALL
+        .into_iter()
+        .map(|kind| {
+            let schema = protocol_schema(kind)?;
+            Ok(SchemaSummary {
+                kind,
+                id: schema.id,
+                protocol_version: schema.protocol_version,
+            })
+        })
+        .collect::<DiscoveryResult<Vec<_>>>()?;
+    Ok(SchemaCatalog { schemas })
 }
 
 /// Loads and validates one embedded curated protocol schema.

--- a/amari-discovery/src/schema.rs
+++ b/amari-discovery/src/schema.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Curated JSON Schemas for the stable discovery protocol.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{DiscoveryError, DiscoveryResult, SCHEMA_V1};
+
+const REQUEST_V1: &str = include_str!("../schemas/request-v1.json");
+const RESPONSE_V1: &str = include_str!("../schemas/response-v1.json");
+const GOAL_V1: &str = include_str!("../schemas/goal-v1.json");
+const PLAN_V1: &str = include_str!("../schemas/plan-v1.json");
+const PROBE_V1: &str = include_str!("../schemas/probe-v1.json");
+
+/// One of the five stable v1 protocol schema families.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaKind {
+    /// Typed one-shot command request.
+    Request,
+    /// Versioned response envelope.
+    Response,
+    /// Normalized planner goal.
+    Goal,
+    /// Replayable candidate plan.
+    Plan,
+    /// Saved bounded probe result.
+    Probe,
+}
+
+impl SchemaKind {
+    /// Every schema family in deterministic CLI order.
+    pub const ALL: [Self; 5] = [
+        Self::Request,
+        Self::Response,
+        Self::Goal,
+        Self::Plan,
+        Self::Probe,
+    ];
+
+    /// Returns the stable lowercase schema family name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Request => "request",
+            Self::Response => "response",
+            Self::Goal => "goal",
+            Self::Plan => "plan",
+            Self::Probe => "probe",
+        }
+    }
+
+    const fn source(self) -> &'static str {
+        match self {
+            Self::Request => REQUEST_V1,
+            Self::Response => RESPONSE_V1,
+            Self::Goal => GOAL_V1,
+            Self::Plan => PLAN_V1,
+            Self::Probe => PROBE_V1,
+        }
+    }
+}
+
+impl fmt::Display for SchemaKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One parsed curated protocol schema and its stable identity.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProtocolSchema {
+    /// Schema family.
+    pub kind: SchemaKind,
+    /// Stable JSON Schema `$id`.
+    pub id: String,
+    /// Discovery protocol version described by this schema.
+    pub protocol_version: String,
+    /// Complete JSON Schema document.
+    pub document: Value,
+}
+
+impl ProtocolSchema {
+    /// Serializes the schema document as canonical pretty JSON with a newline.
+    ///
+    /// # Errors
+    ///
+    /// Returns a serialization error when the in-memory JSON cannot be encoded.
+    pub fn canonical_json(&self) -> DiscoveryResult<Vec<u8>> {
+        let mut bytes = serde_json::to_vec_pretty(&self.document)?;
+        bytes.push(b'\n');
+        Ok(bytes)
+    }
+}
+
+/// Loads and validates one embedded curated protocol schema.
+///
+/// # Errors
+///
+/// Returns catalog corruption when the checked-in schema is malformed or its
+/// `$id`/protocol marker is missing.
+pub fn protocol_schema(kind: SchemaKind) -> DiscoveryResult<ProtocolSchema> {
+    let document: Value = serde_json::from_str(kind.source()).map_err(|error| {
+        DiscoveryError::CatalogCorruption(format!(
+            "embedded {} schema is malformed: {error}",
+            kind.as_str()
+        ))
+    })?;
+    let id = document
+        .get("$id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            DiscoveryError::CatalogCorruption(format!(
+                "embedded {} schema has no `$id`",
+                kind.as_str()
+            ))
+        })?
+        .to_owned();
+    let protocol_version = document
+        .get("x-amari-protocol-version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            DiscoveryError::CatalogCorruption(format!(
+                "embedded {} schema has no protocol marker",
+                kind.as_str()
+            ))
+        })?
+        .to_owned();
+    if protocol_version != SCHEMA_V1 {
+        return Err(DiscoveryError::CatalogCorruption(format!(
+            "embedded {} schema protocol `{protocol_version}` is unsupported",
+            kind.as_str()
+        )));
+    }
+    Ok(ProtocolSchema {
+        kind,
+        id,
+        protocol_version,
+        document,
+    })
+}

--- a/amari-discovery/tests/agent_contract.rs
+++ b/amari-discovery/tests/agent_contract.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Cross-command JSON/NDJSON agent output contract before shell integration.
+
+use std::{fs, path::Path};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn output(arguments: &[&str], mode: &str) -> Vec<u8> {
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(arguments)
+        .arg(mode)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone()
+}
+
+fn machine_parity(arguments: &[&str]) -> Value {
+    let json_bytes = output(arguments, "--json");
+    let ndjson_bytes = output(arguments, "--ndjson");
+    assert_eq!(
+        ndjson_bytes.iter().filter(|byte| **byte == b'\n').count(),
+        1
+    );
+    let json: Value = serde_json::from_slice(&json_bytes).unwrap();
+    let ndjson: Value = serde_json::from_slice(&ndjson_bytes).unwrap();
+    assert_eq!(json, ndjson, "machine mode drift for {arguments:?}");
+    assert_eq!(json["schema_version"], "amari.discovery/v1");
+    assert!(json["provenance"]["catalog"]["hash"].is_string());
+    json
+}
+
+fn project() -> TempDir {
+    let temporary = tempfile::tempdir().unwrap();
+    fs::create_dir(temporary.path().join("src")).unwrap();
+    fs::write(
+        temporary.path().join("Cargo.toml"),
+        r#"[package]
+name = "agent-contract-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+amari-core = "0.23.0"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        temporary.path().join("src/lib.rs"),
+        "use amari_core::Multivector;\npub fn scalar() -> Multivector<3,0,0> { Multivector::scalar(1.0) }\n",
+    )
+    .unwrap();
+    temporary
+}
+
+fn save_recommendation(project: &Path) -> (TempDir, String, std::path::PathBuf) {
+    let artifact_dir = tempfile::tempdir().unwrap();
+    let recommendation = machine_parity(&[
+        "recommend",
+        project.to_str().unwrap(),
+        "--goal",
+        "compute a geometric product",
+    ]);
+    let candidate = recommendation["data"]["data"]["preferred"]["capability_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let path = artifact_dir.path().join("recommendation.json");
+    fs::write(&path, serde_json::to_vec(&recommendation).unwrap()).unwrap();
+    (artifact_dir, candidate, path)
+}
+
+#[test]
+fn all_schema_selections_have_human_json_and_ndjson_contracts() {
+    for kind in ["request", "response", "goal", "plan", "probe"] {
+        let value = machine_parity(&["schema", kind]);
+        assert_eq!(value["data"]["kind"], kind);
+        assert_eq!(value["data"]["protocol_version"], "amari.discovery/v1");
+        assert!(value["data"]["document"]["$id"].is_string());
+
+        Command::cargo_bin("amari")
+            .unwrap()
+            .args(["schema", kind])
+            .assert()
+            .success()
+            .stderr(predicate::str::is_empty())
+            .stdout(predicate::str::contains("Schema:"))
+            .stdout(predicate::str::contains("industrialalgebra.com/schemas"));
+    }
+
+    let listed = machine_parity(&["schema"]);
+    assert_eq!(listed["data"]["schemas"].as_array().unwrap().len(), 5);
+}
+
+#[test]
+fn existing_one_shot_command_families_share_json_ndjson_envelopes() {
+    let project = project();
+    machine_parity(&["capabilities"]);
+    machine_parity(&["discover", "search", "tropical"]);
+    machine_parity(&["inspect", project.path().to_str().unwrap()]);
+    machine_parity(&["probe", "list"]);
+    machine_parity(&["schema", "request"]);
+
+    let (_artifact_dir, candidate, recommendation) = save_recommendation(project.path());
+    machine_parity(&[
+        "plan",
+        &candidate,
+        "--recommendation",
+        recommendation.to_str().unwrap(),
+        "--project",
+        project.path().to_str().unwrap(),
+    ]);
+}
+
+#[test]
+fn capabilities_advertise_all_three_output_modes() {
+    let value = machine_parity(&["capabilities"]);
+    assert_eq!(
+        value["data"]["output_modes"],
+        serde_json::json!(["human", "json", "ndjson"])
+    );
+}
+
+#[test]
+fn machine_errors_are_single_structured_stderr_records_with_stable_codes() {
+    let mut expected = None;
+    for mode in ["--json", "--ndjson"] {
+        let output = Command::cargo_bin("amari")
+            .unwrap()
+            .args(["discover", "detail", "amari:unknown:missing:value", mode])
+            .assert()
+            .failure()
+            .code(2)
+            .stdout(predicate::str::is_empty())
+            .get_output()
+            .stderr
+            .clone();
+        assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+        let error: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(error["kind"], "invalid_id");
+        assert_eq!(error["details"]["exit_code"], 2);
+        if let Some(expected) = &expected {
+            assert_eq!(&error, expected);
+        } else {
+            expected = Some(error);
+        }
+    }
+
+    let capabilities = machine_parity(&["capabilities"]);
+    assert_eq!(capabilities["data"]["exit_codes"]["invalid_input"], 2);
+    assert_eq!(capabilities["data"]["exit_codes"]["probe_failed"], 6);
+    assert_eq!(capabilities["data"]["exit_codes"]["internal"], 70);
+}
+
+#[test]
+fn json_and_ndjson_are_mutually_exclusive_and_shell_remains_deferred() {
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["capabilities", "--json", "--ndjson"])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+
+    for mode in ["--json", "--ndjson"] {
+        let output = Command::cargo_bin("amari")
+            .unwrap()
+            .args(["shell", mode])
+            .assert()
+            .failure()
+            .code(69)
+            .stdout(predicate::str::is_empty())
+            .get_output()
+            .stderr
+            .clone();
+        let error: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(error["kind"], "not_implemented");
+        assert_eq!(error["details"]["exit_code"], 69);
+    }
+}

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -134,7 +134,7 @@ fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
 
     assert_eq!(
         value["data"]["output_modes"],
-        serde_json::json!(["human", "json"])
+        serde_json::json!(["human", "json", "ndjson"])
     );
     // Assert all five inspection resource limit fields are present with defaults
     let rl = &value["data"]["resource_limits"];

--- a/amari-discovery/tests/cli_discover.rs
+++ b/amari-discovery/tests/cli_discover.rs
@@ -22,15 +22,22 @@ fn discover_json(args: &[&str]) -> Value {
 }
 
 fn discover_fails(args: &[&str], expected_code: i32, expected_kind: &str) {
-    Command::cargo_bin("amari")
+    let stderr = Command::cargo_bin("amari")
         .unwrap()
         .args(args)
         .assert()
         .code(expected_code)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::starts_with(expected_kind))
-        .stderr(predicate::str::contains(": "))
-        .stderr(predicate::str::contains("internal").not());
+        .get_output()
+        .stderr
+        .clone();
+    let error: Value = serde_json::from_slice(&stderr).unwrap();
+    assert_eq!(error["kind"], expected_kind);
+    assert_eq!(error["details"]["exit_code"], expected_code);
+    assert!(!error["message"]
+        .as_str()
+        .unwrap()
+        .contains("internal failure"));
 }
 
 // ---------------------------------------------------------------------------
@@ -703,7 +710,7 @@ fn search_exact_id_still_case_sensitive() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn error_stderr_starts_with_stable_kind_prefix() {
+fn error_stderr_contains_stable_structured_kind() {
     // Every structured error must print "{kind}: {message}" to stderr.
     for (args, expected_kind) in [
         (

--- a/amari-discovery/tests/cli_probes.rs
+++ b/amari-discovery/tests/cli_probes.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Probe CLI discovery, dry-run, and isolated execution contract.
+
+use std::fs;
+
+#[cfg(feature = "standard-probes")]
+use amari_discovery::ProbeEngine;
+use amari_discovery::{
+    CandidatePlan, Catalog, CatalogIdentity, Compatibility, Envelope, PlanCompatibility,
+    PlanNormalization, PlanStep, ReplayMetadata,
+};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
+
+fn command_json(arguments: &[&str]) -> Value {
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(arguments)
+        .arg("--json")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn viterbi_input() -> Value {
+    json!({
+        "transitions": [[-1.0, -2.0], [-2.0, -1.0]],
+        "emissions": [[-1.0, -3.0], [-3.0, -1.0]],
+        "observations": [0, 1, 0]
+    })
+}
+
+fn write_json_file(temporary: &TempDir, name: &str, value: &Value) -> std::path::PathBuf {
+    let path = temporary.path().join(name);
+    fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+    path
+}
+
+fn plan_envelope(probe_id: &str) -> Envelope<CandidatePlan> {
+    let catalog = Catalog::embedded().unwrap();
+    let descriptor = catalog
+        .probes()
+        .iter()
+        .find(|probe| probe.id.to_string() == probe_id)
+        .unwrap();
+    let identity = CatalogIdentity {
+        version: catalog.version().to_owned(),
+        hash: catalog.content_hash().to_owned(),
+    };
+    Envelope::new(
+        CandidatePlan {
+            capability_id: descriptor.capability_id.clone(),
+            prerequisite_order: vec![descriptor.capability_id.clone()],
+            steps: vec![PlanStep::Probe {
+                capability_id: descriptor.capability_id.clone(),
+                probe_id: descriptor.id.clone(),
+            }],
+            compatibility: PlanCompatibility {
+                catalog: identity.clone(),
+                project_hash: "fixture-project-hash".to_owned(),
+                input_hash: "fixture-plan-input-hash".to_owned(),
+                probe_results: Vec::new(),
+            },
+            normalization: PlanNormalization {
+                normalized: true,
+                max_rewrites: 1,
+                trace: Vec::new(),
+            },
+            plan_hash: "0".repeat(64),
+        },
+        identity,
+        Compatibility {
+            status: "compatible".to_owned(),
+            reasons: Vec::new(),
+        },
+        ReplayMetadata {
+            replayable: true,
+            required_hashes: vec!["catalog_hash".to_owned(), "project_hash".to_owned()],
+            reasons: Vec::new(),
+        },
+    )
+}
+
+#[test]
+fn list_reports_every_catalog_probe_with_dynamic_execution_state() {
+    let listed = command_json(&["probe", "list"]);
+    let capabilities = command_json(&["capabilities"]);
+    let probes = listed["data"]["probes"].as_array().unwrap();
+    let states = capabilities["data"]["known_probes"].as_array().unwrap();
+    let catalog = Catalog::embedded().unwrap();
+
+    assert_eq!(probes.len(), catalog.probes().len());
+    assert_eq!(probes.len(), states.len());
+    for (probe, state) in probes.iter().zip(states) {
+        assert_eq!(probe["id"], state["id"]);
+        assert_eq!(probe["known"], true);
+        assert_eq!(probe["available"], state["available"]);
+        assert_eq!(probe["executable"], state["executable"]);
+    }
+}
+
+#[test]
+fn describe_returns_the_catalog_contract_and_process_guarantees() {
+    let value = command_json(&["probe", "describe", VITERBI]);
+
+    assert_eq!(value["data"]["descriptor"]["id"], VITERBI);
+    assert_eq!(
+        value["data"]["descriptor"]["input_schema"],
+        "amari.discovery/probe/tropical-viterbi/input/v1"
+    );
+    assert_eq!(value["data"]["known"], true);
+    assert_eq!(
+        value["data"]["executable"],
+        cfg!(feature = "standard-probes")
+    );
+    assert_eq!(value["data"]["isolation"], "process");
+    assert_eq!(value["data"]["hard_timeout"], true);
+    assert_eq!(value["data"]["crash_isolation"], true);
+}
+
+#[test]
+fn list_and_describe_human_output_are_concise() {
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["probe", "list"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Registered probes"))
+        .stdout(predicate::str::contains(VITERBI));
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["probe", "describe", VITERBI])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Process isolation"))
+        .stdout(predicate::str::contains("Hard timeout: yes"));
+}
+
+#[cfg(feature = "standard-probes")]
+#[test]
+fn explicit_input_routes_through_process_supervisor_with_math_parity() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = viterbi_input();
+    let input_path = write_json_file(&temporary, "input.json", &input);
+    let path = input_path.to_str().unwrap();
+    let value = command_json(&["probe", "run", VITERBI, "--input", path]);
+    let direct = ProbeEngine::new()
+        .unwrap()
+        .execute(&VITERBI.parse().unwrap(), &input)
+        .unwrap();
+
+    assert_eq!(value["data"]["result"]["output"], direct.output);
+    assert_eq!(
+        value["data"]["result"]["resources"],
+        serde_json::to_value(direct.resources).unwrap()
+    );
+    assert_eq!(value["data"]["result"]["backend"], "cpu");
+    assert_eq!(value["data"]["isolation"], "process");
+    assert_eq!(value["data"]["hard_timeout"], true);
+    assert_eq!(value["data"]["crash_isolation"], true);
+    assert_eq!(value["data"]["timeout_millis"], 5_000);
+    assert_eq!(
+        value["provenance"]["catalog"]["hash"],
+        value["data"]["result"]["catalog_hash"]
+    );
+    assert_eq!(
+        value["provenance"]["input_hash"],
+        value["data"]["result"]["input_hash"]
+    );
+    assert_eq!(
+        value["data"]["result"]["input_hash"]
+            .as_str()
+            .unwrap()
+            .len(),
+        64
+    );
+    assert_eq!(
+        direct.isolation,
+        amari_discovery::ProbeIsolation::Cooperative
+    );
+}
+
+#[cfg(feature = "standard-probes")]
+#[test]
+fn explicit_input_human_output_reports_process_guarantees() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input_path = write_json_file(&temporary, "input.json", &viterbi_input());
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "probe",
+            "run",
+            VITERBI,
+            "--input",
+            input_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Isolation: process"))
+        .stdout(predicate::str::contains("Hard timeout: yes"));
+}
+
+#[test]
+fn plan_dry_run_is_compatibility_only_and_never_requires_probe_input() {
+    let temporary = tempfile::tempdir().unwrap();
+    let plan = serde_json::to_value(plan_envelope(VITERBI)).unwrap();
+    let plan_path = write_json_file(&temporary, "plan.json", &plan);
+    let value = command_json(&[
+        "probe",
+        "run",
+        VITERBI,
+        "--plan",
+        plan_path.to_str().unwrap(),
+        "--dry-run",
+    ]);
+
+    assert_eq!(value["data"]["probe_id"], VITERBI);
+    assert_eq!(value["data"]["compatible"], true);
+    assert_eq!(value["data"]["would_execute"], false);
+    assert_eq!(value["data"]["plan_hash"], "0".repeat(64));
+    assert_eq!(value["data"]["planned_isolation"], "process");
+    assert!(value["data"].get("output").is_none());
+}
+
+#[test]
+fn plan_without_dry_run_is_rejected_with_explicit_input_guidance() {
+    let temporary = tempfile::tempdir().unwrap();
+    let plan_path = write_json_file(
+        &temporary,
+        "plan.json",
+        &serde_json::to_value(plan_envelope(VITERBI)).unwrap(),
+    );
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "probe",
+            "run",
+            VITERBI,
+            "--plan",
+            plan_path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("provide explicit typed input"));
+}
+
+#[test]
+fn json_probe_errors_are_structured_on_stderr() {
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "probe",
+            "describe",
+            "amari-probe:tropical:does-not-exist:v1",
+            "--json",
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .stderr
+        .clone();
+    let error: Value = serde_json::from_slice(&output).unwrap();
+
+    assert_eq!(error["kind"], "invalid_input");
+    assert!(error["message"].as_str().unwrap().contains("unknown probe"));
+    assert_eq!(error["details"]["exit_code"], 2);
+}
+
+#[test]
+fn dry_run_requires_plan_and_unknown_probe_is_typed() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input_path = write_json_file(&temporary, "input.json", &viterbi_input());
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "probe",
+            "run",
+            VITERBI,
+            "--input",
+            input_path.to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("dry-run requires --plan"));
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["probe", "describe", "amari-probe:tropical:unknown:v1"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("unknown probe"));
+}

--- a/amari-discovery/tests/cli_recommend_rust.rs
+++ b/amari-discovery/tests/cli_recommend_rust.rs
@@ -291,7 +291,7 @@ fn symlinked_probe_result_file_is_rejected_without_project_mutation() {
         .assert()
         .code(2)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::starts_with("invalid_input:"));
+        .stderr(predicate::str::contains("\"kind\":\"invalid_input\""));
 
     assert_eq!(tree_contents(fixture.path()), before);
 }
@@ -313,7 +313,7 @@ fn malformed_probe_result_file_is_rejected_without_project_mutation() {
         .assert()
         .code(9)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::starts_with("serialization:"));
+        .stderr(predicate::str::contains("\"kind\":\"serialization\""));
 
     assert_eq!(tree_contents(fixture.path()), before);
 }

--- a/amari-discovery/tests/cli_recommend_ts.rs
+++ b/amari-discovery/tests/cli_recommend_ts.rs
@@ -351,7 +351,7 @@ fn malformed_and_semantically_empty_goal_files_are_typed_errors() {
         .assert()
         .code(9)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::starts_with("serialization:"));
+        .stderr(predicate::str::contains("\"kind\":\"serialization\""));
 
     Command::cargo_bin("amari")
         .unwrap()
@@ -363,5 +363,5 @@ fn malformed_and_semantically_empty_goal_files_are_typed_errors() {
         .assert()
         .code(2)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::starts_with("invalid_input:"));
+        .stderr(predicate::str::contains("\"kind\":\"invalid_input\""));
 }

--- a/amari-discovery/tests/golden/schemas/goal-v1.json
+++ b/amari-discovery/tests/golden/schemas/goal-v1.json
@@ -1,0 +1,27 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/goal/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "constraints": {
+      "items": {
+        "maxLength": 4096,
+        "minLength": 1,
+        "type": "string"
+      },
+      "maxItems": 64,
+      "type": "array"
+    },
+    "statement": {
+      "maxLength": 65536,
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "statement"
+  ],
+  "title": "Amari Discovery Goal v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/tests/golden/schemas/plan-v1.json
+++ b/amari-discovery/tests/golden/schemas/plan-v1.json
@@ -1,0 +1,254 @@
+{
+  "$defs": {
+    "capability_id": {
+      "pattern": "^amari:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*",
+      "type": "string"
+    },
+    "compatibility": {
+      "additionalProperties": false,
+      "properties": {
+        "catalog": {
+          "additionalProperties": false,
+          "properties": {
+            "hash": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "hash"
+          ],
+          "type": "object"
+        },
+        "input_hash": {
+          "type": "string"
+        },
+        "probe_results": {
+          "maxItems": 256,
+          "type": "array"
+        },
+        "project_hash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "catalog",
+        "project_hash",
+        "input_hash"
+      ],
+      "type": "object"
+    },
+    "plan_step": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "dependency"
+            },
+            "package": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "version"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "feature": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "feature"
+            },
+            "package": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "feature"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "symbol"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "path"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "example": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "example"
+            },
+            "package": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "example"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "probe"
+            },
+            "probe_id": {
+              "$ref": "#/$defs/probe_id"
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "probe_id"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "capability_id": {
+              "$ref": "#/$defs/capability_id"
+            },
+            "kind": {
+              "const": "test"
+            },
+            "package": {
+              "type": "string"
+            },
+            "target": {
+              "enum": [
+                "all_targets",
+                "npm_package"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "capability_id",
+            "package",
+            "target"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "probe_id": {
+      "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
+      "type": "string"
+    }
+  },
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/plan/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "capability_id": {
+      "$ref": "#/$defs/capability_id"
+    },
+    "compatibility": {
+      "$ref": "#/$defs/compatibility"
+    },
+    "normalization": {
+      "additionalProperties": false,
+      "properties": {
+        "max_rewrites": {
+          "maximum": 4096,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "normalized": {
+          "type": "boolean"
+        },
+        "trace": {
+          "maxItems": 4096,
+          "type": "array"
+        }
+      },
+      "required": [
+        "normalized",
+        "max_rewrites"
+      ],
+      "type": "object"
+    },
+    "plan_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "prerequisite_order": {
+      "items": {
+        "$ref": "#/$defs/capability_id"
+      },
+      "maxItems": 64,
+      "type": "array"
+    },
+    "steps": {
+      "items": {
+        "$ref": "#/$defs/plan_step"
+      },
+      "maxItems": 64,
+      "type": "array"
+    }
+  },
+  "required": [
+    "capability_id",
+    "prerequisite_order",
+    "steps",
+    "compatibility",
+    "normalization",
+    "plan_hash"
+  ],
+  "title": "Amari Discovery Candidate Plan v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/tests/golden/schemas/plan-v1.json
+++ b/amari-discovery/tests/golden/schemas/plan-v1.json
@@ -27,6 +27,9 @@
           "type": "string"
         },
         "probe_results": {
+          "items": {
+            "$ref": "#/$defs/probe_replay_hash"
+          },
           "maxItems": 256,
           "type": "array"
         },
@@ -38,6 +41,30 @@
         "catalog",
         "project_hash",
         "input_hash"
+      ],
+      "type": "object"
+    },
+    "normalization_trace": {
+      "additionalProperties": false,
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/$defs/plan_step"
+          },
+          "maxItems": 64,
+          "type": "array"
+        },
+        "before": {
+          "items": {
+            "$ref": "#/$defs/plan_step"
+          },
+          "maxItems": 64,
+          "type": "array"
+        }
+      },
+      "required": [
+        "before",
+        "after"
       ],
       "type": "object"
     },
@@ -187,6 +214,28 @@
     "probe_id": {
       "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
       "type": "string"
+    },
+    "probe_replay_hash": {
+      "additionalProperties": false,
+      "properties": {
+        "input_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "probe_id": {
+          "$ref": "#/$defs/probe_id"
+        },
+        "result_hash": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "probe_id",
+        "input_hash",
+        "result_hash"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://industrialalgebra.com/schemas/amari.discovery/plan/v1",
@@ -211,13 +260,16 @@
           "type": "boolean"
         },
         "trace": {
+          "items": {
+            "$ref": "#/$defs/normalization_trace"
+          },
           "maxItems": 4096,
           "type": "array"
         }
       },
       "required": [
-        "normalized",
-        "max_rewrites"
+        "max_rewrites",
+        "normalized"
       ],
       "type": "object"
     },

--- a/amari-discovery/tests/golden/schemas/probe-v1.json
+++ b/amari-discovery/tests/golden/schemas/probe-v1.json
@@ -1,0 +1,106 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/probe/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "backend": {
+      "const": "cpu"
+    },
+    "catalog_hash": {
+      "type": "string"
+    },
+    "duration_micros": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "input_hash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "output": true,
+    "probe_id": {
+      "pattern": "^amari-probe:[a-z0-9][a-z0-9_-]*:[a-z0-9][a-z0-9_-]*:v[1-9][0-9]*$",
+      "type": "string"
+    },
+    "project_hash": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "refuted_assumptions": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "resources": {
+      "additionalProperties": false,
+      "properties": {
+        "bytes": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "iterations": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nodes": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "operations": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "operations",
+        "nodes",
+        "iterations",
+        "bytes"
+      ],
+      "type": "object"
+    },
+    "seed": {
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "validated_assumptions": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "warnings": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    }
+  },
+  "required": [
+    "probe_id",
+    "backend",
+    "duration_micros",
+    "resources",
+    "catalog_hash",
+    "input_hash",
+    "validated_assumptions",
+    "refuted_assumptions",
+    "warnings",
+    "output"
+  ],
+  "title": "Amari Discovery Probe Result v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/tests/golden/schemas/request-v1.json
+++ b/amari-discovery/tests/golden/schemas/request-v1.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/request/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "arguments": {
+      "maxProperties": 32,
+      "type": "object"
+    },
+    "command": {
+      "enum": [
+        "capabilities",
+        "discover.search",
+        "discover.detail",
+        "discover.graph",
+        "discover.example",
+        "inspect",
+        "recommend",
+        "plan",
+        "probe.list",
+        "probe.describe",
+        "probe.run",
+        "schema"
+      ],
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "amari.discovery/v1"
+    }
+  },
+  "required": [
+    "schema_version",
+    "command",
+    "arguments"
+  ],
+  "title": "Amari Discovery Request v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/tests/golden/schemas/response-v1.json
+++ b/amari-discovery/tests/golden/schemas/response-v1.json
@@ -1,0 +1,134 @@
+{
+  "$defs": {
+    "provenance": {
+      "additionalProperties": false,
+      "properties": {
+        "catalog": {
+          "additionalProperties": false,
+          "properties": {
+            "hash": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "hash"
+          ],
+          "type": "object"
+        },
+        "compatibility": {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        },
+        "input_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "project_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "replay": {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "replayable": {
+              "type": "boolean"
+            },
+            "required_hashes": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array"
+            }
+          },
+          "required": [
+            "replayable",
+            "required_hashes",
+            "reasons"
+          ],
+          "type": "object"
+        },
+        "seed": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tool_version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool_version",
+        "catalog",
+        "compatibility",
+        "replay",
+        "project_hash",
+        "input_hash",
+        "seed"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://industrialalgebra.com/schemas/amari.discovery/response/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "data": true,
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    },
+    "schema_version": {
+      "const": "amari.discovery/v1"
+    },
+    "warnings": {
+      "items": {
+        "maxLength": 4096,
+        "type": "string"
+      },
+      "maxItems": 256,
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "provenance",
+    "warnings",
+    "data"
+  ],
+  "title": "Amari Discovery Response Envelope v1",
+  "type": "object",
+  "x-amari-protocol-version": "amari.discovery/v1"
+}

--- a/amari-discovery/tests/ndjson.rs
+++ b/amari-discovery/tests/ndjson.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared bounded NDJSON record framing contract.
+
+use std::io::{self, Write};
+
+use amari_discovery::{
+    CatalogIdentity, Compatibility, DiscoveryError, Envelope, NdjsonWriter, ReplayMetadata,
+    DEFAULT_MAX_NDJSON_RECORD_BYTES,
+};
+use serde_json::{json, Value};
+
+#[derive(Default)]
+struct ObservedWriter {
+    bytes: Vec<u8>,
+    flushes: usize,
+    fail_write: bool,
+    fail_flush: bool,
+}
+
+impl Write for ObservedWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.fail_write {
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "fixture write"));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flushes += 1;
+        if self.fail_flush {
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "fixture flush"));
+        }
+        Ok(())
+    }
+}
+
+fn envelope(data: Value) -> Envelope<Value> {
+    let mut envelope = Envelope::new(
+        data,
+        CatalogIdentity {
+            version: "fixture".to_owned(),
+            hash: "fixture-catalog".to_owned(),
+        },
+        Compatibility {
+            status: "compatible".to_owned(),
+            reasons: Vec::new(),
+        },
+        ReplayMetadata {
+            replayable: true,
+            required_hashes: vec!["catalog_hash".to_owned()],
+            reasons: Vec::new(),
+        },
+    );
+    envelope.provenance.input_hash = Some("fixture-input".to_owned());
+    envelope
+}
+
+#[test]
+fn every_write_emits_one_complete_object_line_and_flushes() {
+    let mut output = ObservedWriter::default();
+    {
+        let mut writer = NdjsonWriter::new(&mut output).unwrap();
+        writer.write(&json!({"sequence": 1})).unwrap();
+        writer.write(&json!({"sequence": 2})).unwrap();
+    }
+
+    assert_eq!(output.flushes, 2);
+    let lines = output
+        .bytes
+        .split(|byte| *byte == b'\n')
+        .collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[2].is_empty());
+    assert_eq!(
+        serde_json::from_slice::<Value>(lines[0]).unwrap(),
+        json!({"sequence": 1})
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(lines[1]).unwrap(),
+        json!({"sequence": 2})
+    );
+}
+
+#[test]
+fn embedded_newlines_are_escaped_without_splitting_records() {
+    let mut bytes = Vec::new();
+    NdjsonWriter::new(&mut bytes)
+        .unwrap()
+        .write(&json!({"message": "first\nsecond\r\nthird"}))
+        .unwrap();
+
+    assert_eq!(bytes.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert!(String::from_utf8(bytes.clone())
+        .unwrap()
+        .contains("first\\nsecond\\r\\nthird"));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&bytes[..bytes.len() - 1]).unwrap()["message"],
+        "first\nsecond\r\nthird"
+    );
+}
+
+#[test]
+fn record_limit_is_checked_before_any_bytes_are_written() {
+    let value = json!({"payload": "bounded"});
+    let encoded = serde_json::to_vec(&value).unwrap();
+    let mut exact = Vec::new();
+    NdjsonWriter::with_max_record_bytes(&mut exact, encoded.len())
+        .unwrap()
+        .write(&value)
+        .unwrap();
+    assert_eq!(exact.len(), encoded.len() + 1);
+
+    let mut rejected = Vec::new();
+    let error = NdjsonWriter::with_max_record_bytes(&mut rejected, encoded.len() - 1)
+        .unwrap()
+        .write(&value)
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        DiscoveryError::LimitExceeded(message) if message.contains("NDJSON record bytes")
+    ));
+    assert!(rejected.is_empty());
+    assert_eq!(DEFAULT_MAX_NDJSON_RECORD_BYTES, 1024 * 1024);
+}
+
+#[test]
+fn zero_limit_and_write_or_flush_failures_are_typed() {
+    assert!(matches!(
+        NdjsonWriter::with_max_record_bytes(Vec::new(), 0),
+        Err(DiscoveryError::InvalidInput(message)) if message.contains("greater than zero")
+    ));
+
+    let mut write_failure = ObservedWriter {
+        fail_write: true,
+        ..ObservedWriter::default()
+    };
+    let error = NdjsonWriter::new(&mut write_failure)
+        .unwrap()
+        .write(&json!({"ok": true}))
+        .unwrap_err();
+    assert!(matches!(error, DiscoveryError::Io(_)));
+
+    let mut flush_failure = ObservedWriter {
+        fail_flush: true,
+        ..ObservedWriter::default()
+    };
+    let error = NdjsonWriter::new(&mut flush_failure)
+        .unwrap()
+        .write(&json!({"ok": true}))
+        .unwrap_err();
+    assert!(matches!(error, DiscoveryError::Io(_)));
+    assert_eq!(flush_failure.flushes, 1);
+}
+
+#[test]
+fn typed_envelope_provenance_survives_ndjson_framing() {
+    let expected = envelope(json!({"result": "ok"}));
+    let mut bytes = Vec::new();
+    NdjsonWriter::new(&mut bytes)
+        .unwrap()
+        .write(&expected)
+        .unwrap();
+    let parsed: Envelope<Value> = serde_json::from_slice(&bytes[..bytes.len() - 1]).unwrap();
+
+    assert_eq!(parsed, expected);
+    assert_eq!(parsed.provenance.catalog.hash, "fixture-catalog");
+    assert_eq!(
+        parsed.provenance.input_hash.as_deref(),
+        Some("fixture-input")
+    );
+}

--- a/amari-discovery/tests/schema_contract.rs
+++ b/amari-discovery/tests/schema_contract.rs
@@ -131,6 +131,28 @@ fn plan_and_probe_schemas_reject_unbounded_or_ambiguous_core_shapes() {
         plan.document["properties"]["plan_hash"]["pattern"],
         "^[0-9a-f]{64}$"
     );
+    assert_eq!(
+        plan.document["properties"]["compatibility"]["$ref"],
+        "#/$defs/compatibility"
+    );
+    assert_eq!(
+        plan.document["$defs"]["compatibility"]["properties"]["probe_results"]["items"]["$ref"],
+        "#/$defs/probe_replay_hash"
+    );
+    assert_eq!(
+        plan.document["properties"]["normalization"]["properties"]["trace"]["items"]["$ref"],
+        "#/$defs/normalization_trace"
+    );
+    for side in ["before", "after"] {
+        assert_eq!(
+            plan.document["$defs"]["normalization_trace"]["properties"][side]["items"]["$ref"],
+            "#/$defs/plan_step"
+        );
+        assert_eq!(
+            plan.document["$defs"]["normalization_trace"]["properties"][side]["maxItems"],
+            64
+        );
+    }
 
     let probe = protocol_schema(SchemaKind::Probe).unwrap();
     assert_eq!(

--- a/amari-discovery/tests/schema_contract.rs
+++ b/amari-discovery/tests/schema_contract.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Golden contract for the five curated v1 machine schemas.
+
+use std::{collections::BTreeMap, fs, path::Path};
+
+use amari_discovery::{protocol_schema, SchemaKind, SCHEMA_V1};
+use serde_json::Value;
+
+fn expected() -> BTreeMap<SchemaKind, (&'static str, &'static [&'static str])> {
+    BTreeMap::from([
+        (
+            SchemaKind::Request,
+            (
+                "https://industrialalgebra.com/schemas/amari.discovery/request/v1",
+                &["schema_version", "command", "arguments"] as &[_],
+            ),
+        ),
+        (
+            SchemaKind::Response,
+            (
+                "https://industrialalgebra.com/schemas/amari.discovery/response/v1",
+                &["schema_version", "provenance", "warnings", "data"] as &[_],
+            ),
+        ),
+        (
+            SchemaKind::Goal,
+            (
+                "https://industrialalgebra.com/schemas/amari.discovery/goal/v1",
+                &["statement"] as &[_],
+            ),
+        ),
+        (
+            SchemaKind::Plan,
+            (
+                "https://industrialalgebra.com/schemas/amari.discovery/plan/v1",
+                &[
+                    "capability_id",
+                    "prerequisite_order",
+                    "steps",
+                    "compatibility",
+                    "normalization",
+                    "plan_hash",
+                ] as &[_],
+            ),
+        ),
+        (
+            SchemaKind::Probe,
+            (
+                "https://industrialalgebra.com/schemas/amari.discovery/probe/v1",
+                &[
+                    "probe_id",
+                    "backend",
+                    "duration_micros",
+                    "resources",
+                    "catalog_hash",
+                    "input_hash",
+                    "validated_assumptions",
+                    "refuted_assumptions",
+                    "warnings",
+                    "output",
+                ] as &[_],
+            ),
+        ),
+    ])
+}
+
+#[test]
+fn every_schema_has_stable_id_protocol_and_required_fields() {
+    assert_eq!(SchemaKind::ALL.len(), 5);
+    for (kind, (expected_id, expected_required)) in expected() {
+        let schema = protocol_schema(kind).unwrap();
+        assert_eq!(schema.kind, kind);
+        assert_eq!(schema.id, expected_id);
+        assert_eq!(schema.protocol_version, SCHEMA_V1);
+        assert_eq!(
+            schema.document["$schema"],
+            "https://json-schema.org/draft/2020-12/schema"
+        );
+        assert_eq!(schema.document["$id"], expected_id);
+        assert_eq!(schema.document["x-amari-protocol-version"], SCHEMA_V1);
+        let required = schema.document["required"].as_array().unwrap();
+        for field in expected_required {
+            assert!(
+                required.iter().any(|value| value == field),
+                "{kind:?} missing {field}"
+            );
+        }
+    }
+}
+
+#[test]
+fn request_and_response_lock_the_envelope_protocol_version() {
+    for kind in [SchemaKind::Request, SchemaKind::Response] {
+        let schema = protocol_schema(kind).unwrap();
+        assert_eq!(
+            schema.document["properties"]["schema_version"]["const"],
+            SCHEMA_V1
+        );
+        assert_eq!(schema.document["additionalProperties"], false);
+    }
+}
+
+#[test]
+fn curated_schema_bytes_match_checked_in_goldens() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for kind in SchemaKind::ALL {
+        let schema = protocol_schema(kind).unwrap();
+        let golden = fs::read(
+            root.join("tests/golden/schemas")
+                .join(format!("{}-v1.json", kind.as_str())),
+        )
+        .unwrap();
+        assert_eq!(
+            schema.canonical_json().unwrap(),
+            golden,
+            "{} schema drift",
+            kind.as_str()
+        );
+        let parsed: Value = serde_json::from_slice(&golden).unwrap();
+        assert_eq!(parsed, schema.document);
+    }
+}
+
+#[test]
+fn plan_and_probe_schemas_reject_unbounded_or_ambiguous_core_shapes() {
+    let plan = protocol_schema(SchemaKind::Plan).unwrap();
+    assert_eq!(plan.document["properties"]["steps"]["maxItems"], 64);
+    assert!(plan.document["$defs"]["plan_step"]["oneOf"].is_array());
+    assert_eq!(
+        plan.document["properties"]["plan_hash"]["pattern"],
+        "^[0-9a-f]{64}$"
+    );
+
+    let probe = protocol_schema(SchemaKind::Probe).unwrap();
+    assert_eq!(
+        probe.document["properties"]["input_hash"]["pattern"],
+        "^[0-9a-f]{64}$"
+    );
+    assert_eq!(
+        probe.document["properties"]["validated_assumptions"]["maxItems"],
+        256
+    );
+    assert_eq!(
+        probe.document["properties"]["refuted_assumptions"]["maxItems"],
+        256
+    );
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -41,6 +41,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "ts_source_inspection",
     ),
     "planner": (
+        "agent_contract",
         "cli_capabilities",
         "cli_discover",
         "cli_plan_replay",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -42,6 +42,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "cli_capabilities",
         "cli_discover",
         "cli_plan_replay",
+        "cli_probes",
         "cli_recommend_rust",
         "cli_recommend_ts",
         "plan_normalization",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -26,6 +26,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "catalog_signatures",
         "catalog_traits",
         "catalog_wasm",
+        "ndjson",
         "protocol",
         "schema_contract",
     ),

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -27,6 +27,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "catalog_traits",
         "catalog_wasm",
         "protocol",
+        "schema_contract",
     ),
     "inspection": (
         "cargo_inspection",


### PR DESCRIPTION
## Summary

Completes discovery Tasks 21C–22C: isolated probe CLI execution, curated protocol schemas, bounded NDJSON framing, and shared agent output contracts.

### Task 21C — probe CLI (`abdec4a`)
- adds `amari probe list`, `describe`, and explicit `run --input`
- routes execution exclusively through the private process supervisor
- keeps `--plan --dry-run` compatibility-only and non-executing
- provides structured errors and cooperative/process parity tests

### Task 22A — versioned schemas (`bb74094`)
- adds five curated v1 schemas: goal, request, response, plan, and probe
- checks byte-identical golden files and protocol/version requirements

### Task 22B — NDJSON (`5107fe4`)
- adds a shared bounded writer with exactly one flushed JSON record per line
- rejects record/byte overflow before partial writes

### Task 22C — agent contracts (`e9fb292`)
- adds schema CLI access
- unifies human, JSON, and NDJSON output contracts across one-shot commands
- preserves structured machine errors; interactive shell remains deferred

### Review fix (`f3b70a3`)
- constrains nested `probe_results` and normalization `trace` plan-schema arrays
- adds regression coverage for every item-bearing plan-schema array

## Safety

- no inspected project mutation or project-code execution
- probe requests cannot choose executables, arguments, CWD, environment, or shell
- public probe execution uses the validated process-isolation path
- output remains bounded and machine-parseable

## Verification

Independent review initially found one Important nested-array schema issue. It was fixed and focused re-review returned **APPROVE** with no remaining Critical or Important findings.

Fresh checks passed:
- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- Clippy with `-D warnings` for both feature matrices
- rustdoc with `-D warnings` for both feature matrices
- `cargo fmt --all --check`
- exhaustive CI sharding verification: 46 targets across 3 unique shards
- Python script compilation, schema/golden byte comparison, and `git diff --check`
