### PR TITLE
feat(discovery): add shell and AI validation contract

### DIFF
--- a/amari-discovery/src/ai.rs
+++ b/amari-discovery/src/ai.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Provider-neutral, in-process AI goal interpretation contract.
+//!
+//! This module defines validation boundaries only. It ships no provider,
+//! subprocess transport, network client, probe authority, or project mutation.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{CapabilityId, Catalog, DiscoveryError, DiscoveryResult, GoalSpec};
+
+/// Resource ceilings applied around one goal-interpreter invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AiContractLimits {
+    /// Maximum UTF-8 bytes accepted in one natural-language request.
+    pub max_request_bytes: usize,
+    /// Maximum catalog capability references accepted from an adapter.
+    pub max_capability_ids: usize,
+    /// Maximum missing-information questions accepted from an adapter.
+    pub max_missing_information: usize,
+    /// Maximum encoded bytes accepted in one adapter result.
+    pub max_output_bytes: usize,
+}
+
+impl Default for AiContractLimits {
+    fn default() -> Self {
+        Self {
+            max_request_bytes: 16 * 1024,
+            max_capability_ids: 64,
+            max_missing_information: 32,
+            max_output_bytes: 64 * 1024,
+        }
+    }
+}
+
+impl AiContractLimits {
+    fn validate(self) -> DiscoveryResult<()> {
+        if self.max_request_bytes == 0
+            || self.max_capability_ids == 0
+            || self.max_missing_information == 0
+            || self.max_output_bytes == 0
+        {
+            return Err(DiscoveryError::InvalidInput(
+                "AI contract limits must be positive".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Bounded natural-language input supplied to a [`GoalInterpreter`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalInterpretationRequest {
+    /// Natural-language statement to translate into a typed goal.
+    pub text: String,
+}
+
+/// Execution authority an untrusted adapter attempted to request.
+///
+/// Every variant is forbidden by [`ValidatedGoalInterpreter`]. The variants
+/// make attempted authority explicit instead of accepting opaque commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiExecutionRequest {
+    /// Attempt to execute a registered probe directly.
+    RunProbe,
+    /// Attempt to modify the inspected project.
+    ModifyProject,
+    /// Attempt to invoke a command or external process.
+    InvokeCommand,
+    /// Attempt to access a provider or other network endpoint.
+    AccessNetwork,
+}
+
+/// Typed output proposed by a provider-neutral goal interpreter.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GoalInterpretation {
+    /// Deterministic planner goal proposed by the adapter.
+    pub goal: GoalSpec,
+    /// Catalog capabilities referenced by the interpretation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capability_ids: Vec<CapabilityId>,
+    /// Missing information that a human shell may ask for explicitly.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_information: Vec<String>,
+    /// Forbidden authority requests disclosed by the adapter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub execution_requests: Vec<AiExecutionRequest>,
+}
+
+/// Provider-neutral in-process goal interpretation interface.
+///
+/// Implementations receive typed bounded input and return a proposed typed
+/// interpretation. Callers should invoke implementations only through
+/// [`ValidatedGoalInterpreter`].
+pub trait GoalInterpreter {
+    /// Interprets natural-language input into a proposed planner goal.
+    ///
+    /// # Errors
+    ///
+    /// Returns a structured error when interpretation cannot be completed.
+    fn interpret(&self, request: &GoalInterpretationRequest)
+        -> DiscoveryResult<GoalInterpretation>;
+}
+
+/// Catalog and authority validation around an in-process [`GoalInterpreter`].
+pub struct ValidatedGoalInterpreter<'a, I: ?Sized> {
+    catalog: &'a Catalog,
+    interpreter: &'a I,
+    limits: AiContractLimits,
+}
+
+impl<'a, I: GoalInterpreter + ?Sized> ValidatedGoalInterpreter<'a, I> {
+    /// Creates a validation wrapper with explicit positive resource ceilings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiscoveryError::InvalidInput`] when any ceiling is zero.
+    pub fn new(
+        catalog: &'a Catalog,
+        interpreter: &'a I,
+        limits: AiContractLimits,
+    ) -> DiscoveryResult<Self> {
+        limits.validate()?;
+        Ok(Self {
+            catalog,
+            interpreter,
+            limits,
+        })
+    }
+
+    /// Interprets a request and validates goal, catalog, size, and authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns a structured error for empty or oversized requests, invalid
+    /// goals, unknown or duplicate catalog references, oversized output, empty
+    /// missing-information entries, or any requested execution authority.
+    pub fn interpret(
+        &self,
+        request: &GoalInterpretationRequest,
+    ) -> DiscoveryResult<GoalInterpretation> {
+        let request_bytes = request.text.len();
+        if request.text.trim().is_empty() {
+            return Err(DiscoveryError::InvalidInput(
+                "AI goal interpretation request must not be empty".to_owned(),
+            ));
+        }
+        if request_bytes > self.limits.max_request_bytes {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "AI request bytes {request_bytes} exceed limit {}",
+                self.limits.max_request_bytes
+            )));
+        }
+
+        let interpretation = self.interpreter.interpret(request)?;
+        interpretation.goal.validate()?;
+        if interpretation.capability_ids.len() > self.limits.max_capability_ids {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "AI capability references {} exceed limit {}",
+                interpretation.capability_ids.len(),
+                self.limits.max_capability_ids
+            )));
+        }
+        if interpretation.missing_information.len() > self.limits.max_missing_information {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "AI missing-information entries {} exceed limit {}",
+                interpretation.missing_information.len(),
+                self.limits.max_missing_information
+            )));
+        }
+        if interpretation
+            .missing_information
+            .iter()
+            .any(|item| item.trim().is_empty())
+        {
+            return Err(DiscoveryError::InvalidInput(
+                "AI missing-information entries must not be empty".to_owned(),
+            ));
+        }
+        if !interpretation.execution_requests.is_empty() {
+            return Err(DiscoveryError::InvalidInput(
+                "AI adapter requested prohibited execution authority".to_owned(),
+            ));
+        }
+
+        let mut seen = BTreeSet::new();
+        for capability_id in &interpretation.capability_ids {
+            if !seen.insert(capability_id) {
+                return Err(DiscoveryError::InvalidInput(format!(
+                    "AI adapter returned duplicate capability `{capability_id}`"
+                )));
+            }
+            if !self
+                .catalog
+                .capabilities()
+                .iter()
+                .any(|capability| &capability.id == capability_id)
+            {
+                return Err(DiscoveryError::invalid_id(
+                    capability_id.to_string(),
+                    "AI adapter referenced a capability outside the embedded catalog",
+                ));
+            }
+        }
+
+        let output_bytes = serde_json::to_vec(&interpretation)?.len();
+        if output_bytes > self.limits.max_output_bytes {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "AI output bytes {output_bytes} exceed limit {}",
+                self.limits.max_output_bytes
+            )));
+        }
+        Ok(interpretation)
+    }
+}

--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -3,8 +3,9 @@
 //! Command-line parsing and dispatch for the `amari` binary.
 
 use std::{
+    ffi::OsString,
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -256,43 +257,120 @@ impl ProbeCommand {
 /// not executable in the current bootstrap implementation.
 pub fn run() -> DiscoveryResult<()> {
     let cli = Cli::parse();
-    let mode = if cli.ndjson {
+    let mode = output_mode(cli.json, cli.ndjson);
+    match cli.command {
+        Command::Shell { project } => {
+            if mode != render::OutputMode::Human {
+                return Err(DiscoveryError::NotImplemented(
+                    "shell machine output is deferred until its request/response contract is enabled"
+                        .to_owned(),
+                ));
+            }
+            let stdin = io::stdin();
+            let mut reader = stdin.lock();
+            let mut stdout = io::stdout().lock();
+            crate::shell::run_human(&mut reader, &mut stdout, |arguments, writer| {
+                run_shell_command(arguments, project.as_deref(), writer)
+            })
+        }
+        Command::ProbeWorker => crate::probes::worker::run_stdio(),
+        command => {
+            let mut stdout = io::stdout().lock();
+            dispatch_command(command, mode, &mut stdout)
+        }
+    }
+}
+
+fn output_mode(json: bool, ndjson: bool) -> render::OutputMode {
+    if ndjson {
         render::OutputMode::Ndjson
-    } else if cli.json {
+    } else if json {
         render::OutputMode::Json
     } else {
         render::OutputMode::Human
-    };
+    }
+}
+
+fn run_shell_command<W: Write>(
+    mut arguments: Vec<OsString>,
+    session_project: Option<&Path>,
+    writer: &mut W,
+) -> DiscoveryResult<()> {
+    apply_session_project(&mut arguments, session_project);
+    let cli = Cli::try_parse_from(std::iter::once(OsString::from("amari")).chain(arguments))
+        .map_err(|error| DiscoveryError::InvalidInput(error.to_string()))?;
+    if cli.json || cli.ndjson {
+        return Err(DiscoveryError::InvalidInput(
+            "shell output mode is selected when the shell starts, not per command".to_owned(),
+        ));
+    }
     match cli.command {
+        Command::Shell { .. } | Command::ProbeWorker => Err(DiscoveryError::InvalidInput(
+            "nested shell and worker commands are unavailable inside the shell".to_owned(),
+        )),
+        command => dispatch_command(command, render::OutputMode::Human, writer),
+    }
+}
+
+fn apply_session_project(arguments: &mut Vec<OsString>, session_project: Option<&Path>) {
+    let Some(project) = session_project else {
+        return;
+    };
+    match arguments.first().and_then(|argument| argument.to_str()) {
+        Some("inspect") if arguments.len() == 1 => arguments.push(project.as_os_str().to_owned()),
+        Some("recommend") => {
+            let has_explicit_path = arguments
+                .get(1)
+                .and_then(|argument| argument.to_str())
+                .is_some_and(|argument| !argument.starts_with('-'));
+            if !has_explicit_path {
+                arguments.insert(1, project.as_os_str().to_owned());
+            }
+        }
+        Some("plan") => {
+            let has_explicit_project = arguments.iter().any(|argument| {
+                argument == "--project"
+                    || argument
+                        .to_str()
+                        .is_some_and(|argument| argument.starts_with("--project="))
+            });
+            if !has_explicit_project {
+                arguments.push(OsString::from("--project"));
+                arguments.push(project.as_os_str().to_owned());
+            }
+        }
+        _ => {}
+    }
+}
+
+fn dispatch_command<W: Write>(
+    command: Command,
+    mode: render::OutputMode,
+    writer: &mut W,
+) -> DiscoveryResult<()> {
+    match command {
         Command::Capabilities => {
             let envelope = Capabilities::envelope()?;
-            let mut stdout = io::stdout().lock();
-            render::write_envelope(
-                &mut stdout,
-                &envelope,
-                mode,
-                render::write_capabilities_human,
-            )
+            render::write_envelope(writer, &envelope, mode, render::write_capabilities_human)
         }
         Command::Discover { command } => {
             let catalog = Catalog::embedded()?;
-            run_discover(&catalog, command, mode)
+            run_discover(&catalog, command, mode, writer)
         }
-        Command::Inspect { path } => run_inspect(path, mode),
+        Command::Inspect { path } => run_inspect(path, mode, writer),
         Command::Recommend {
             path,
             goal,
             goal_file,
             probe_results,
-        } => run_recommend(path, goal, goal_file, probe_results, mode),
+        } => run_recommend(path, goal, goal_file, probe_results, mode, writer),
         Command::Plan {
             candidate_id,
             recommendation,
             project,
-        } => run_plan(candidate_id, recommendation, project, mode),
-        Command::Probe { command } => run_probe(command, mode),
-        Command::Schema { kind } => run_schema(kind, mode),
-        Command::ProbeWorker => crate::probes::worker::run_stdio(),
+        } => run_plan(candidate_id, recommendation, project, mode, writer),
+        Command::Probe { command } => run_probe(command, mode, writer),
+        Command::Schema { kind } => run_schema(kind, mode, writer),
         command => Err(DiscoveryError::NotImplemented(format!(
             "{} is not implemented in this build",
             command.unavailable_name()
@@ -322,9 +400,12 @@ pub fn report_error(error: &DiscoveryError) {
     }
 }
 
-fn run_schema(kind: Option<SchemaKind>, mode: render::OutputMode) -> DiscoveryResult<()> {
+fn run_schema<W: Write>(
+    kind: Option<SchemaKind>,
+    mode: render::OutputMode,
+    writer: &mut W,
+) -> DiscoveryResult<()> {
     let catalog = Catalog::embedded()?;
-    let mut stdout = io::stdout().lock();
     match kind {
         Some(kind) => {
             let kind = match kind {
@@ -335,16 +416,11 @@ fn run_schema(kind: Option<SchemaKind>, mode: render::OutputMode) -> DiscoveryRe
                 SchemaKind::Probe => crate::SchemaKind::Probe,
             };
             let envelope = schema_envelope(&catalog, crate::protocol_schema(kind)?);
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_schema_human)
+            render::write_envelope(writer, &envelope, mode, render::write_schema_human)
         }
         None => {
             let envelope = schema_envelope(&catalog, crate::protocol_schema_catalog()?);
-            render::write_envelope(
-                &mut stdout,
-                &envelope,
-                mode,
-                render::write_schema_catalog_human,
-            )
+            render::write_envelope(writer, &envelope, mode, render::write_schema_catalog_human)
         }
     }
 }
@@ -368,19 +444,22 @@ fn schema_envelope<T>(catalog: &Catalog, data: T) -> Envelope<T> {
     )
 }
 
-fn run_probe(command: ProbeCommand, mode: render::OutputMode) -> DiscoveryResult<()> {
+fn run_probe<W: Write>(
+    command: ProbeCommand,
+    mode: render::OutputMode,
+    writer: &mut W,
+) -> DiscoveryResult<()> {
     let catalog = Catalog::embedded()?;
-    let mut stdout = io::stdout().lock();
     match command {
         ProbeCommand::List => {
             let envelope = commands::probe::list_envelope(&catalog)?;
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_probe_list_human)
+            render::write_envelope(writer, &envelope, mode, render::write_probe_list_human)
         }
         ProbeCommand::Describe { probe_id } => {
             let probe_id = probe_id.parse()?;
             let envelope = commands::probe::describe_envelope(&catalog, &probe_id)?;
             render::write_envelope(
-                &mut stdout,
+                writer,
                 &envelope,
                 mode,
                 render::write_probe_description_human,
@@ -403,18 +482,13 @@ fn run_probe(command: ProbeCommand, mode: render::OutputMode) -> DiscoveryResult
                 )),
                 (Some(path), None, false) => {
                     let envelope = commands::probe::run_input_envelope(&catalog, &probe_id, &path)?;
-                    render::write_envelope(
-                        &mut stdout,
-                        &envelope,
-                        mode,
-                        render::write_probe_run_human,
-                    )
+                    render::write_envelope(writer, &envelope, mode, render::write_probe_run_human)
                 }
                 (None, Some(path), true) => {
                     let envelope =
                         commands::probe::dry_run_plan_envelope(&catalog, &probe_id, &path)?;
                     render::write_envelope(
-                        &mut stdout,
+                        writer,
                         &envelope,
                         mode,
                         render::write_probe_dry_run_human,
@@ -429,23 +503,27 @@ fn run_probe(command: ProbeCommand, mode: render::OutputMode) -> DiscoveryResult
 }
 
 /// Runs bounded project inspection and renders the shared typed snapshot.
-fn run_inspect(path: Option<PathBuf>, mode: render::OutputMode) -> DiscoveryResult<()> {
+fn run_inspect<W: Write>(
+    path: Option<PathBuf>,
+    mode: render::OutputMode,
+    writer: &mut W,
+) -> DiscoveryResult<()> {
     let root = match path {
         Some(path) => path,
         None => std::env::current_dir()?,
     };
     let envelope = inspect_project_envelope(&root, &InspectionLimits::default())?;
-    let mut stdout = io::stdout().lock();
-    render::write_envelope(&mut stdout, &envelope, mode, render::write_inspection_human)
+    render::write_envelope(writer, &envelope, mode, render::write_inspection_human)
 }
 
 /// Runs deterministic recommendation for a supported project.
-fn run_recommend(
+fn run_recommend<W: Write>(
     path: Option<PathBuf>,
     goal: Option<String>,
     goal_file: Option<PathBuf>,
     probe_results: Option<PathBuf>,
     mode: render::OutputMode,
+    writer: &mut W,
 ) -> DiscoveryResult<()> {
     let goal = match (goal, goal_file) {
         (Some(statement), None) => GoalSpec {
@@ -475,21 +553,16 @@ fn run_recommend(
         saved_probes,
         &InspectionLimits::default(),
     )?;
-    let mut stdout = io::stdout().lock();
-    render::write_envelope(
-        &mut stdout,
-        &envelope,
-        mode,
-        render::write_recommendation_human,
-    )
+    render::write_envelope(writer, &envelope, mode, render::write_recommendation_human)
 }
 
 /// Replays one candidate from a saved recommendation artifact.
-fn run_plan(
+fn run_plan<W: Write>(
     candidate_id: String,
     recommendation: PathBuf,
     project: PathBuf,
     mode: render::OutputMode,
+    writer: &mut W,
 ) -> DiscoveryResult<()> {
     let artifact = commands::plan::read_recommendation(&recommendation)?;
     let catalog = Catalog::embedded()?;
@@ -500,33 +573,32 @@ fn run_plan(
         artifact,
         &InspectionLimits::default(),
     )?;
-    let mut stdout = io::stdout().lock();
-    render::write_envelope(&mut stdout, &envelope, mode, render::write_plan_human)
+    render::write_envelope(writer, &envelope, mode, render::write_plan_human)
 }
 
 /// Dispatches a discover subcommand against the embedded catalog and renders output.
-fn run_discover(
+fn run_discover<W: Write>(
     catalog: &Catalog,
     command: DiscoverCommand,
     mode: render::OutputMode,
+    writer: &mut W,
 ) -> DiscoveryResult<()> {
-    let mut stdout = io::stdout().lock();
     match command {
         DiscoverCommand::Search { query } => {
             let envelope = commands::discover::search_envelope(catalog, &query);
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_search_human)
+            render::write_envelope(writer, &envelope, mode, render::write_search_human)
         }
         DiscoverCommand::Detail { identifier } => {
             let envelope = commands::discover::detail_envelope(catalog, &identifier)?;
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_detail_human)
+            render::write_envelope(writer, &envelope, mode, render::write_detail_human)
         }
         DiscoverCommand::Graph { identifier } => {
             let envelope = commands::discover::graph_envelope(catalog, &identifier)?;
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_graph_human)
+            render::write_envelope(writer, &envelope, mode, render::write_graph_human)
         }
         DiscoverCommand::Example { identifier } => {
             let envelope = commands::discover::example_envelope(catalog, &identifier)?;
-            render::write_envelope(&mut stdout, &envelope, mode, render::write_example_human)
+            render::write_envelope(writer, &envelope, mode, render::write_example_human)
         }
     }
 }

--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -260,18 +260,41 @@ pub fn run() -> DiscoveryResult<()> {
     let mode = output_mode(cli.json, cli.ndjson);
     match cli.command {
         Command::Shell { project } => {
-            if mode != render::OutputMode::Human {
-                return Err(DiscoveryError::NotImplemented(
-                    "shell machine output is deferred until its request/response contract is enabled"
-                        .to_owned(),
-                ));
-            }
             let stdin = io::stdin();
             let mut reader = stdin.lock();
             let mut stdout = io::stdout().lock();
-            crate::shell::run_human(&mut reader, &mut stdout, |arguments, writer| {
-                run_shell_command(arguments, project.as_deref(), writer)
-            })
+            match mode {
+                render::OutputMode::Human => {
+                    crate::shell::run_human(&mut reader, &mut stdout, |arguments, writer| {
+                        run_shell_command(
+                            arguments,
+                            project.as_deref(),
+                            render::OutputMode::Human,
+                            writer,
+                        )
+                    })
+                }
+                render::OutputMode::Json => {
+                    crate::shell::run_json(&mut reader, &mut stdout, |arguments, writer| {
+                        run_shell_command(
+                            arguments,
+                            project.as_deref(),
+                            render::OutputMode::Json,
+                            writer,
+                        )
+                    })
+                }
+                render::OutputMode::Ndjson => {
+                    crate::shell::run_ndjson(&mut reader, &mut stdout, |arguments, writer| {
+                        run_shell_command(
+                            arguments,
+                            project.as_deref(),
+                            render::OutputMode::Ndjson,
+                            writer,
+                        )
+                    })
+                }
+            }
         }
         Command::ProbeWorker => crate::probes::worker::run_stdio(),
         command => {
@@ -294,6 +317,7 @@ fn output_mode(json: bool, ndjson: bool) -> render::OutputMode {
 fn run_shell_command<W: Write>(
     mut arguments: Vec<OsString>,
     session_project: Option<&Path>,
+    mode: render::OutputMode,
     writer: &mut W,
 ) -> DiscoveryResult<()> {
     apply_session_project(&mut arguments, session_project);
@@ -308,7 +332,7 @@ fn run_shell_command<W: Write>(
         Command::Shell { .. } | Command::ProbeWorker => Err(DiscoveryError::InvalidInput(
             "nested shell and worker commands are unavailable inside the shell".to_owned(),
         )),
-        command => dispatch_command(command, render::OutputMode::Human, writer),
+        command => dispatch_command(command, mode, writer),
     }
 }
 

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -27,6 +27,7 @@ mod probes;
 pub mod protocol;
 mod render;
 pub mod schema;
+mod shell;
 
 pub use capabilities::{
     AiAdapterStatus, Capabilities, CatalogStatus, FeatureGate, PlatformInfo, ResourceLimits,

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -10,11 +10,13 @@
 //!
 //! - `standard-probes` (default): compiles registered deterministic probe
 //!   adapters, beginning with bounded tropical Viterbi decoding.
-//! - `ai`: reserves the provider-neutral AI adapter contract. It does not
-//!   enable network access or an external provider transport.
+//! - `ai`: compiles the provider-neutral AI validation contract. It does not
+//!   enable network access, an external provider transport, or execution authority.
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "ai")]
+pub mod ai;
 pub mod capabilities;
 pub mod catalog;
 pub mod cli;
@@ -29,6 +31,11 @@ mod render;
 pub mod schema;
 mod shell;
 
+#[cfg(feature = "ai")]
+pub use ai::{
+    AiContractLimits, AiExecutionRequest, GoalInterpretation, GoalInterpretationRequest,
+    GoalInterpreter, ValidatedGoalInterpreter,
+};
 pub use capabilities::{
     AiAdapterStatus, Capabilities, CatalogStatus, FeatureGate, PlatformInfo, ResourceLimits,
     RuntimeCapabilityState,

--- a/amari-discovery/src/shell.rs
+++ b/amari-discovery/src/shell.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Human shell input handling over the shared CLI command dispatcher.
+
+use std::{
+    ffi::OsString,
+    io::{BufRead, Read, Write},
+};
+
+use crate::{DiscoveryError, DiscoveryResult};
+
+const MAX_SHELL_INPUT_BYTES: u64 = 64 * 1024;
+
+pub(crate) fn run_human<R, W, F>(
+    reader: &mut R,
+    writer: &mut W,
+    mut dispatch: F,
+) -> DiscoveryResult<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(Vec<OsString>, &mut W) -> DiscoveryResult<()>,
+{
+    writeln!(
+        writer,
+        "Amari discovery shell. Type `help` for commands or `exit` to leave."
+    )?;
+    loop {
+        write!(writer, "amari> ")?;
+        writer.flush()?;
+
+        let mut bytes = Vec::new();
+        let count = Read::by_ref(reader)
+            .take(MAX_SHELL_INPUT_BYTES + 1)
+            .read_until(b'\n', &mut bytes)?;
+        if count == 0 {
+            break;
+        }
+        if count as u64 > MAX_SHELL_INPUT_BYTES {
+            return Err(DiscoveryError::LimitExceeded(
+                "shell input exceeds 65536 bytes".to_owned(),
+            ));
+        }
+        let line = std::str::from_utf8(&bytes).map_err(|_| {
+            DiscoveryError::InvalidInput("shell input must be valid UTF-8".to_owned())
+        })?;
+        let arguments = tokenize(line.trim_end_matches(['\r', '\n']))?;
+        if arguments.is_empty() {
+            continue;
+        }
+        match arguments[0].as_str() {
+            "exit" | "quit" if arguments.len() == 1 => break,
+            "help" if arguments.len() == 1 => write_help(writer)?,
+            _ => dispatch(arguments.into_iter().map(OsString::from).collect(), writer)?,
+        }
+    }
+    Ok(())
+}
+
+fn write_help(writer: &mut impl Write) -> DiscoveryResult<()> {
+    writeln!(writer, "Shell commands:")?;
+    writeln!(writer, "  capabilities")?;
+    writeln!(writer, "  discover search|detail|graph|example ...")?;
+    writeln!(writer, "  inspect [PATH]")?;
+    writeln!(writer, "  recommend [PATH] --goal TEXT|--goal-file FILE")?;
+    writeln!(
+        writer,
+        "  plan CANDIDATE --recommendation FILE [--project PATH]"
+    )?;
+    writeln!(writer, "  probe list|describe|run ...")?;
+    writeln!(writer, "  schema [request|response|goal|plan|probe]")?;
+    writeln!(writer, "  help")?;
+    writeln!(writer, "  exit")?;
+    Ok(())
+}
+
+fn tokenize(line: &str) -> DiscoveryResult<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut active = false;
+
+    for character in line.chars() {
+        if escaped {
+            token.push(character);
+            escaped = false;
+            active = true;
+            continue;
+        }
+        match (quote, character) {
+            (_, '\\') => {
+                escaped = true;
+                active = true;
+            }
+            (Some(expected), current) if current == expected => {
+                quote = None;
+                active = true;
+            }
+            (None, '\'' | '"') => {
+                quote = Some(character);
+                active = true;
+            }
+            (None, current) if current.is_whitespace() => {
+                if active {
+                    tokens.push(std::mem::take(&mut token));
+                    active = false;
+                }
+            }
+            (_, current) => {
+                token.push(current);
+                active = true;
+            }
+        }
+    }
+    if escaped {
+        return Err(DiscoveryError::InvalidInput(
+            "shell input ends with an incomplete escape".to_owned(),
+        ));
+    }
+    if quote.is_some() {
+        return Err(DiscoveryError::InvalidInput(
+            "shell input contains an unterminated quote".to_owned(),
+        ));
+    }
+    if active {
+        tokens.push(token);
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tokenize;
+
+    #[test]
+    fn tokenizer_preserves_quoted_and_escaped_arguments() {
+        assert_eq!(
+            tokenize("recommend --goal \"geometric product\" path\\ with\\ spaces").unwrap(),
+            [
+                "recommend",
+                "--goal",
+                "geometric product",
+                "path with spaces"
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizer_rejects_incomplete_input() {
+        assert!(tokenize("recommend --goal 'missing").is_err());
+        assert!(tokenize("inspect missing\\").is_err());
+    }
+}

--- a/amari-discovery/src/shell.rs
+++ b/amari-discovery/src/shell.rs
@@ -340,7 +340,7 @@ fn tokenize(line: &str) -> DiscoveryResult<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::tokenize;
+    use super::{ensure_bounded_input, tokenize, MAX_SHELL_INPUT_BYTES};
 
     #[test]
     fn tokenizer_preserves_quoted_and_escaped_arguments() {
@@ -359,5 +359,13 @@ mod tests {
     fn tokenizer_rejects_incomplete_input() {
         assert!(tokenize("recommend --goal 'missing").is_err());
         assert!(tokenize("inspect missing\\").is_err());
+    }
+
+    #[test]
+    fn shell_input_limit_accepts_exact_boundary_and_rejects_one_more_byte() {
+        let exact = vec![b'x'; MAX_SHELL_INPUT_BYTES as usize];
+        assert!(ensure_bounded_input(&exact).is_ok());
+        let oversized = vec![b'x'; MAX_SHELL_INPUT_BYTES as usize + 1];
+        assert!(ensure_bounded_input(&oversized).is_err());
     }
 }

--- a/amari-discovery/src/shell.rs
+++ b/amari-discovery/src/shell.rs
@@ -7,7 +7,10 @@ use std::{
     io::{BufRead, Read, Write},
 };
 
-use crate::{DiscoveryError, DiscoveryResult};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::{DiscoveryError, DiscoveryResult, SCHEMA_V1};
 
 const MAX_SHELL_INPUT_BYTES: u64 = 64 * 1024;
 
@@ -30,16 +33,8 @@ where
         writer.flush()?;
 
         let mut bytes = Vec::new();
-        let count = Read::by_ref(reader)
-            .take(MAX_SHELL_INPUT_BYTES + 1)
-            .read_until(b'\n', &mut bytes)?;
-        if count == 0 {
+        if read_bounded_line(reader, &mut bytes)? == 0 {
             break;
-        }
-        if count as u64 > MAX_SHELL_INPUT_BYTES {
-            return Err(DiscoveryError::LimitExceeded(
-                "shell input exceeds 65536 bytes".to_owned(),
-            ));
         }
         let line = std::str::from_utf8(&bytes).map_err(|_| {
             DiscoveryError::InvalidInput("shell input must be valid UTF-8".to_owned())
@@ -55,6 +50,220 @@ where
         }
     }
     Ok(())
+}
+
+pub(crate) fn run_json<R, W, F>(
+    reader: &mut R,
+    writer: &mut W,
+    mut dispatch: F,
+) -> DiscoveryResult<()>
+where
+    R: Read,
+    W: Write,
+    F: FnMut(Vec<OsString>, &mut W) -> DiscoveryResult<()>,
+{
+    let mut bytes = Vec::new();
+    Read::by_ref(reader)
+        .take(MAX_SHELL_INPUT_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    ensure_bounded_input(&bytes)?;
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Err(DiscoveryError::InvalidInput(
+            "shell JSON mode requires exactly one request".to_owned(),
+        ));
+    }
+    dispatch(parse_machine_request(&bytes)?, writer)
+}
+
+pub(crate) fn run_ndjson<R, W, F>(
+    reader: &mut R,
+    writer: &mut W,
+    mut dispatch: F,
+) -> DiscoveryResult<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(Vec<OsString>, &mut W) -> DiscoveryResult<()>,
+{
+    loop {
+        let mut bytes = Vec::new();
+        if read_bounded_line(reader, &mut bytes)? == 0 {
+            return Ok(());
+        }
+        if bytes.iter().all(u8::is_ascii_whitespace) {
+            return Err(DiscoveryError::InvalidInput(
+                "shell NDJSON requests must not be blank".to_owned(),
+            ));
+        }
+        dispatch(parse_machine_request(&bytes)?, writer)?;
+    }
+}
+
+fn read_bounded_line(reader: &mut impl BufRead, bytes: &mut Vec<u8>) -> DiscoveryResult<usize> {
+    let count = Read::by_ref(reader)
+        .take(MAX_SHELL_INPUT_BYTES + 1)
+        .read_until(b'\n', bytes)?;
+    ensure_bounded_input(bytes)?;
+    Ok(count)
+}
+
+fn ensure_bounded_input(bytes: &[u8]) -> DiscoveryResult<()> {
+    if bytes.len() as u64 > MAX_SHELL_INPUT_BYTES {
+        return Err(DiscoveryError::LimitExceeded(
+            "shell input exceeds 65536 bytes".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MachineRequest {
+    schema_version: String,
+    command: String,
+    arguments: Map<String, Value>,
+}
+
+fn parse_machine_request(bytes: &[u8]) -> DiscoveryResult<Vec<OsString>> {
+    let request: MachineRequest = serde_json::from_slice(bytes)
+        .map_err(|error| DiscoveryError::InvalidInput(format!("invalid shell request: {error}")))?;
+    if request.schema_version != SCHEMA_V1 {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "unsupported shell request schema `{}`",
+            request.schema_version
+        )));
+    }
+    if request.arguments.len() > 32 {
+        return Err(DiscoveryError::LimitExceeded(format!(
+            "shell request arguments {} exceed limit 32",
+            request.arguments.len()
+        )));
+    }
+    machine_arguments(&request.command, request.arguments)
+}
+
+fn machine_arguments(
+    command: &str,
+    mut arguments: Map<String, Value>,
+) -> DiscoveryResult<Vec<OsString>> {
+    let mut result: Vec<OsString> = command.split('.').map(OsString::from).collect();
+    match command {
+        "capabilities" | "probe.list" => {}
+        "discover.search" => push_required(&mut result, &mut arguments, "query", None)?,
+        "discover.detail" | "discover.graph" | "discover.example" => {
+            push_required(&mut result, &mut arguments, "identifier", None)?;
+        }
+        "inspect" => push_optional(&mut result, &mut arguments, "path", None)?,
+        "recommend" => {
+            push_optional(&mut result, &mut arguments, "path", None)?;
+            push_optional(&mut result, &mut arguments, "goal", Some("--goal"))?;
+            push_optional(
+                &mut result,
+                &mut arguments,
+                "goal_file",
+                Some("--goal-file"),
+            )?;
+            push_optional(
+                &mut result,
+                &mut arguments,
+                "probe_results",
+                Some("--probe-results"),
+            )?;
+        }
+        "plan" => {
+            push_required(&mut result, &mut arguments, "candidate_id", None)?;
+            push_required(
+                &mut result,
+                &mut arguments,
+                "recommendation",
+                Some("--recommendation"),
+            )?;
+            push_optional(&mut result, &mut arguments, "project", Some("--project"))?;
+        }
+        "probe.describe" => {
+            push_required(&mut result, &mut arguments, "probe_id", None)?;
+        }
+        "probe.run" => {
+            push_required(&mut result, &mut arguments, "probe_id", None)?;
+            push_optional(&mut result, &mut arguments, "input", Some("--input"))?;
+            push_optional(&mut result, &mut arguments, "plan", Some("--plan"))?;
+            if take_optional_bool(&mut arguments, "dry_run")?.unwrap_or(false) {
+                result.push(OsString::from("--dry-run"));
+            }
+        }
+        "schema" => push_optional(&mut result, &mut arguments, "kind", None)?,
+        _ => {
+            return Err(DiscoveryError::InvalidInput(format!(
+                "unknown shell command `{command}`"
+            )));
+        }
+    }
+    if let Some(name) = arguments.keys().next() {
+        return Err(DiscoveryError::InvalidInput(format!(
+            "unknown argument `{name}` for shell command `{command}`"
+        )));
+    }
+    Ok(result)
+}
+
+fn push_required(
+    result: &mut Vec<OsString>,
+    arguments: &mut Map<String, Value>,
+    name: &str,
+    flag: Option<&str>,
+) -> DiscoveryResult<()> {
+    let value = take_string(arguments, name)?.ok_or_else(|| {
+        DiscoveryError::InvalidInput(format!("shell request requires argument `{name}`"))
+    })?;
+    if let Some(flag) = flag {
+        result.push(OsString::from(flag));
+    }
+    result.push(OsString::from(value));
+    Ok(())
+}
+
+fn push_optional(
+    result: &mut Vec<OsString>,
+    arguments: &mut Map<String, Value>,
+    name: &str,
+    flag: Option<&str>,
+) -> DiscoveryResult<()> {
+    if let Some(value) = take_string(arguments, name)? {
+        if let Some(flag) = flag {
+            result.push(OsString::from(flag));
+        }
+        result.push(OsString::from(value));
+    }
+    Ok(())
+}
+
+fn take_string(arguments: &mut Map<String, Value>, name: &str) -> DiscoveryResult<Option<String>> {
+    arguments
+        .remove(name)
+        .map(|value| {
+            value.as_str().map(str::to_owned).ok_or_else(|| {
+                DiscoveryError::InvalidInput(format!(
+                    "shell request argument `{name}` must be a string"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn take_optional_bool(
+    arguments: &mut Map<String, Value>,
+    name: &str,
+) -> DiscoveryResult<Option<bool>> {
+    arguments
+        .remove(name)
+        .map(|value| {
+            value.as_bool().ok_or_else(|| {
+                DiscoveryError::InvalidInput(format!(
+                    "shell request argument `{name}` must be a boolean"
+                ))
+            })
+        })
+        .transpose()
 }
 
 fn write_help(writer: &mut impl Write) -> DiscoveryResult<()> {

--- a/amari-discovery/tests/agent_contract.rs
+++ b/amari-discovery/tests/agent_contract.rs
@@ -160,7 +160,7 @@ fn machine_errors_are_single_structured_stderr_records_with_stable_codes() {
 }
 
 #[test]
-fn json_and_ndjson_are_mutually_exclusive_and_shell_remains_deferred() {
+fn json_and_ndjson_are_mutually_exclusive() {
     Command::cargo_bin("amari")
         .unwrap()
         .args(["capabilities", "--json", "--ndjson"])
@@ -168,20 +168,4 @@ fn json_and_ndjson_are_mutually_exclusive_and_shell_remains_deferred() {
         .failure()
         .code(2)
         .stdout(predicate::str::is_empty());
-
-    for mode in ["--json", "--ndjson"] {
-        let output = Command::cargo_bin("amari")
-            .unwrap()
-            .args(["shell", mode])
-            .assert()
-            .failure()
-            .code(69)
-            .stdout(predicate::str::is_empty())
-            .get_output()
-            .stderr
-            .clone();
-        let error: Value = serde_json::from_slice(&output).unwrap();
-        assert_eq!(error["kind"], "not_implemented");
-        assert_eq!(error["details"]["exit_code"], 69);
-    }
 }

--- a/amari-discovery/tests/ai_contract.rs
+++ b/amari-discovery/tests/ai_contract.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![cfg(feature = "ai")]
+
+use amari_discovery::{
+    AiContractLimits, AiExecutionRequest, Catalog, DiscoveryError, GoalInterpretation,
+    GoalInterpretationRequest, GoalInterpreter, GoalSpec, ValidatedGoalInterpreter,
+};
+
+#[derive(Clone)]
+struct FixedInterpreter {
+    result: GoalInterpretation,
+}
+
+impl GoalInterpreter for FixedInterpreter {
+    fn interpret(
+        &self,
+        _request: &GoalInterpretationRequest,
+    ) -> amari_discovery::DiscoveryResult<GoalInterpretation> {
+        Ok(self.result.clone())
+    }
+}
+
+fn known_interpretation() -> GoalInterpretation {
+    GoalInterpretation {
+        goal: GoalSpec {
+            statement: "decode a bounded state sequence".to_owned(),
+            constraints: vec!["deterministic CPU execution".to_owned()],
+        },
+        capability_ids: vec!["amari:amari-tropical:sequence:viterbi".parse().unwrap()],
+        missing_information: vec!["state count".to_owned()],
+        execution_requests: Vec::new(),
+    }
+}
+
+fn request() -> GoalInterpretationRequest {
+    GoalInterpretationRequest {
+        text: "I need to decode the most likely state sequence".to_owned(),
+    }
+}
+
+#[test]
+fn deterministic_in_process_adapter_returns_catalog_validated_goal() {
+    let catalog = Catalog::embedded().unwrap();
+    let adapter = FixedInterpreter {
+        result: known_interpretation(),
+    };
+    let validator =
+        ValidatedGoalInterpreter::new(&catalog, &adapter, AiContractLimits::default()).unwrap();
+
+    let first = validator.interpret(&request()).unwrap();
+    let second = validator.interpret(&request()).unwrap();
+    assert_eq!(first, known_interpretation());
+    assert_eq!(
+        serde_json::to_vec(&first).unwrap(),
+        serde_json::to_vec(&second).unwrap()
+    );
+}
+
+#[test]
+fn uncatalogued_capability_ids_are_rejected() {
+    let catalog = Catalog::embedded().unwrap();
+    let mut result = known_interpretation();
+    result.capability_ids = vec!["amari:missing:domain:operation".parse().unwrap()];
+    let adapter = FixedInterpreter { result };
+    let validator =
+        ValidatedGoalInterpreter::new(&catalog, &adapter, AiContractLimits::default()).unwrap();
+
+    let error = validator.interpret(&request()).unwrap_err();
+    assert!(matches!(error, DiscoveryError::InvalidId { .. }));
+}
+
+#[test]
+fn any_execution_authority_requested_by_an_adapter_is_rejected() {
+    let catalog = Catalog::embedded().unwrap();
+    for execution_request in [
+        AiExecutionRequest::RunProbe,
+        AiExecutionRequest::ModifyProject,
+        AiExecutionRequest::InvokeCommand,
+        AiExecutionRequest::AccessNetwork,
+    ] {
+        let mut result = known_interpretation();
+        result.execution_requests = vec![execution_request];
+        let adapter = FixedInterpreter { result };
+        let validator =
+            ValidatedGoalInterpreter::new(&catalog, &adapter, AiContractLimits::default()).unwrap();
+
+        let error = validator.interpret(&request()).unwrap_err();
+        assert!(matches!(error, DiscoveryError::InvalidInput(_)));
+        assert!(error.to_string().contains("execution authority"));
+    }
+}
+
+#[test]
+fn request_goal_references_questions_and_encoded_output_are_bounded() {
+    let catalog = Catalog::embedded().unwrap();
+    let limits = AiContractLimits {
+        max_request_bytes: 8,
+        max_capability_ids: 1,
+        max_missing_information: 1,
+        max_output_bytes: 512,
+    };
+    let adapter = FixedInterpreter {
+        result: known_interpretation(),
+    };
+    let validator = ValidatedGoalInterpreter::new(&catalog, &adapter, limits).unwrap();
+    assert!(matches!(
+        validator.interpret(&request()).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+
+    let mut too_many_capabilities = known_interpretation();
+    too_many_capabilities
+        .capability_ids
+        .push("amari:amari-tropical:paths:shortest-path".parse().unwrap());
+    let adapter = FixedInterpreter {
+        result: too_many_capabilities,
+    };
+    let validator = ValidatedGoalInterpreter::new(
+        &catalog,
+        &adapter,
+        AiContractLimits {
+            max_request_bytes: 1024,
+            ..limits
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        validator.interpret(&request()).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+
+    let mut too_many_questions = known_interpretation();
+    too_many_questions
+        .missing_information
+        .push("observation count".to_owned());
+    let adapter = FixedInterpreter {
+        result: too_many_questions,
+    };
+    let validator = ValidatedGoalInterpreter::new(
+        &catalog,
+        &adapter,
+        AiContractLimits {
+            max_request_bytes: 1024,
+            ..limits
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        validator.interpret(&request()).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+
+    let mut invalid_goal = known_interpretation();
+    invalid_goal.goal.constraints = vec!["constraint".to_owned(); GoalSpec::MAX_CONSTRAINTS + 1];
+    let adapter = FixedInterpreter {
+        result: invalid_goal,
+    };
+    let validator = ValidatedGoalInterpreter::new(
+        &catalog,
+        &adapter,
+        AiContractLimits {
+            max_request_bytes: 1024,
+            max_output_bytes: 1024 * 1024,
+            ..limits
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        validator.interpret(&request()).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+
+    let mut oversized = known_interpretation();
+    oversized.goal.statement = "x".repeat(1024);
+    let adapter = FixedInterpreter { result: oversized };
+    let validator = ValidatedGoalInterpreter::new(
+        &catalog,
+        &adapter,
+        AiContractLimits {
+            max_request_bytes: 1024,
+            ..limits
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        validator.interpret(&request()).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+}
+
+#[test]
+fn zero_contract_limits_are_rejected_before_adapter_use() {
+    let catalog = Catalog::embedded().unwrap();
+    let adapter = FixedInterpreter {
+        result: known_interpretation(),
+    };
+    let error = ValidatedGoalInterpreter::new(
+        &catalog,
+        &adapter,
+        AiContractLimits {
+            max_request_bytes: 0,
+            ..AiContractLimits::default()
+        },
+    )
+    .err()
+    .unwrap();
+    assert!(matches!(error, DiscoveryError::InvalidInput(_)));
+}

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -217,14 +217,17 @@ fn help_exposes_the_approved_command_families() {
 }
 
 #[test]
-fn unavailable_commands_use_a_typed_non_internal_failure() {
+fn shell_rejects_unknown_machine_commands_with_a_typed_non_internal_failure() {
     Command::cargo_bin("amari")
         .unwrap()
         .args(["shell", "--json"])
+        .write_stdin(
+            r#"{"schema_version":"amari.discovery/v1","command":"unknown","arguments":{}}"#,
+        )
         .assert()
-        .code(69)
+        .code(2)
         .stdout(predicate::str::is_empty())
-        .stderr(predicate::str::contains("not_implemented"))
+        .stderr(predicate::str::contains("invalid_input"))
         .stderr(predicate::str::contains("internal failure").not());
 }
 

--- a/amari-discovery/tests/shell.rs
+++ b/amari-discovery/tests/shell.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    fs,
+    io::{Read, Write},
+    process::{Command as ProcessCommand, Stdio},
+};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn rust_project() -> TempDir {
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir(project.path().join("src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        r#"[package]
+name = "shell-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+amari-core = "0.23.0"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "use amari_core::Multivector;\npub fn scalar() -> Multivector<3,0,0> { Multivector::scalar(1.0) }\n",
+    )
+    .unwrap();
+    project
+}
+
+fn npm_project() -> TempDir {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"shell-npm","version":"0.1.0","dependencies":{"@justinelliottcobb/amari-wasm":"0.23.0"}}"#,
+    )
+    .unwrap();
+    project
+}
+
+fn saved_recommendation(project: &TempDir) -> (TempDir, String, std::path::PathBuf) {
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "recommend",
+            project.path().to_str().unwrap(),
+            "--goal",
+            "compute a geometric product",
+            "--json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let recommendation: Value = serde_json::from_slice(&output).unwrap();
+    let candidate = recommendation["data"]["data"]["preferred"]["capability_id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("recommendation.json");
+    fs::write(&path, output).unwrap();
+    (directory, candidate, path)
+}
+
+#[test]
+fn session_project_defaults_inspect_recommend_and_plan_while_explicit_paths_override() {
+    let rust = rust_project();
+    let npm = npm_project();
+    let (_artifact, candidate, recommendation) = saved_recommendation(&rust);
+    let input = format!(
+        "inspect\ninspect {}\nrecommend --goal \"compute a geometric product\"\nplan {} --recommendation {}\nexit\n",
+        npm.path().display(),
+        candidate,
+        recommendation.display(),
+    );
+
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--project", rust.path().to_str().unwrap()])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Rust/Cargo project"))
+        .stdout(predicate::str::contains("npm/TypeScript project"))
+        .stdout(predicate::str::contains("Recommendation for:"))
+        .stdout(predicate::str::contains("Plan for:"));
+}
+
+#[test]
+fn shell_delegates_help_capabilities_discovery_and_probe_authority() {
+    Command::cargo_bin("amari")
+        .unwrap()
+        .arg("shell")
+        .write_stdin(
+            "help\ncapabilities\ndiscover search tropical\ndiscover detail amari:amari-tropical:sequence:viterbi\nprobe list\nexit\n",
+        )
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("Shell commands:"))
+        .stdout(predicate::str::contains("Amari Discovery"))
+        .stdout(predicate::str::contains("Registered probes:"))
+        .stdout(predicate::str::contains("amari.discovery/v1"));
+}
+
+#[test]
+fn nonexistent_session_project_returns_the_inspection_error_and_stable_exit_code() {
+    let missing = tempfile::tempdir().unwrap().path().join("missing");
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--project", missing.to_str().unwrap()])
+        .write_stdin("inspect\n")
+        .assert()
+        .code(4)
+        .stderr(predicate::str::contains("inspection_failure"));
+}
+
+#[test]
+fn session_project_is_revalidated_after_the_shell_starts() {
+    let project = rust_project();
+    let binary = Command::cargo_bin("amari")
+        .unwrap()
+        .get_program()
+        .to_owned();
+    let mut child = ProcessCommand::new(binary)
+        .args(["shell", "--project", project.path().to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+    stdin.write_all(b"capabilities\n").unwrap();
+    stdin.flush().unwrap();
+
+    let mut observed = Vec::new();
+    while !observed.ends_with(b"amari> ") {
+        let mut byte = [0_u8; 1];
+        assert_eq!(stdout.read(&mut byte).unwrap(), 1);
+        observed.push(byte[0]);
+    }
+    drop(project);
+    stdin.write_all(b"inspect\n").unwrap();
+    drop(stdin);
+
+    let status = child.wait().unwrap();
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert_eq!(status.code(), Some(4));
+    assert!(stderr.contains("inspection_failure"), "{stderr}");
+}

--- a/amari-discovery/tests/shell_agent_contract.rs
+++ b/amari-discovery/tests/shell_agent_contract.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn request(command: &str, arguments: Value) -> Value {
+    json!({
+        "schema_version": "amari.discovery/v1",
+        "command": command,
+        "arguments": arguments,
+    })
+}
+
+fn one_shot(arguments: &[&str]) -> Value {
+    let bytes = Command::cargo_bin("amari")
+        .unwrap()
+        .args(arguments)
+        .arg("--json")
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn rust_project() -> TempDir {
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir(project.path().join("src")).unwrap();
+    fs::write(
+        project.path().join("Cargo.toml"),
+        r#"[package]
+name = "shell-agent-rust"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+amari-core = "0.23.0"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "use amari_core::Multivector;\npub fn scalar() -> Multivector<3,0,0> { Multivector::scalar(1.0) }\n",
+    )
+    .unwrap();
+    project
+}
+
+fn npm_project() -> TempDir {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"name":"shell-agent-npm","version":"0.1.0","dependencies":{"@justinelliottcobb/amari-wasm":"0.23.0"}}"#,
+    )
+    .unwrap();
+    project
+}
+
+#[test]
+fn json_mode_pairs_one_typed_request_with_the_one_shot_response() {
+    let input = serde_json::to_vec(&request("capabilities", json!({}))).unwrap();
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--json"])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output).unwrap(),
+        one_shot(&["capabilities"])
+    );
+}
+
+#[test]
+fn ndjson_mode_emits_exactly_one_shared_envelope_per_request_line() {
+    let requests = [
+        request("capabilities", json!({})),
+        request("discover.search", json!({"query": "tropical"})),
+        request("probe.list", json!({})),
+    ];
+    let mut input = requests
+        .iter()
+        .map(|value| serde_json::to_string(value).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    input.push('\n');
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--ndjson"])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+
+    let records: Vec<Value> = output
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice(line).unwrap())
+        .collect();
+    assert_eq!(records.len(), requests.len());
+    assert_eq!(records[0], one_shot(&["capabilities"]));
+    assert_eq!(records[1], one_shot(&["discover", "search", "tropical"]));
+    assert_eq!(records[2], one_shot(&["probe", "list"]));
+}
+
+#[test]
+fn shell_modes_share_session_project_semantics_and_allow_explicit_override() {
+    let rust = rust_project();
+    let npm = npm_project();
+    let lines = [
+        request("inspect", json!({})),
+        request("inspect", json!({"path": npm.path().to_str().unwrap()})),
+    ];
+    let input = lines
+        .iter()
+        .map(|line| serde_json::to_string(line).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "shell",
+            "--project",
+            rust.path().to_str().unwrap(),
+            "--ndjson",
+        ])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    let records: Vec<Value> = output
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice(line).unwrap())
+        .collect();
+    assert_eq!(records[0]["data"]["project_kind"], "rust_cargo");
+    assert_eq!(records[1]["data"]["project_kind"], "npm_type_script");
+
+    let json = Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "shell",
+            "--project",
+            rust.path().to_str().unwrap(),
+            "--json",
+        ])
+        .write_stdin(serde_json::to_vec(&request("inspect", json!({}))).unwrap())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: Value = serde_json::from_slice(&json).unwrap();
+    assert_eq!(json, records[0]);
+
+    let human = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--project", rust.path().to_str().unwrap()])
+        .write_stdin("inspect\nexit\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let human = String::from_utf8(human).unwrap();
+    assert!(human.contains("Rust/Cargo project"));
+    assert!(human.contains(json["data"]["project_hash"].as_str().unwrap()));
+}
+
+#[test]
+fn machine_errors_stay_on_stderr_with_stable_exit_semantics() {
+    let input = request("inspect", json!({"unknown": true}));
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--ndjson"])
+        .write_stdin(serde_json::to_string(&input).unwrap() + "\n")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .stderr
+        .clone();
+    assert_eq!(output.iter().filter(|byte| **byte == b'\n').count(), 1);
+    let error: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(error["kind"], "invalid_input");
+    assert_eq!(error["details"]["exit_code"], 2);
+
+    let missing = tempfile::tempdir().unwrap().path().join("missing");
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--project", missing.to_str().unwrap(), "--json"])
+        .write_stdin(serde_json::to_vec(&request("inspect", json!({}))).unwrap())
+        .assert()
+        .code(4)
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .stderr
+        .clone();
+    let error: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(error["kind"], "inspection_failure");
+    assert_eq!(error["details"]["exit_code"], 4);
+}
+
+#[test]
+fn json_mode_rejects_unpaired_trailing_requests_and_machine_modes_have_no_prompt() {
+    let encoded = serde_json::to_string(&request("capabilities", json!({}))).unwrap();
+    Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--json"])
+        .write_stdin(format!("{encoded}\n{encoded}\n"))
+        .assert()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("invalid_input"));
+
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["shell", "--ndjson"])
+        .write_stdin(serde_json::to_string(&request("capabilities", json!({}))).unwrap() + "\n")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(!String::from_utf8(output).unwrap().contains("amari>"));
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -101,6 +101,8 @@ def run(shard: str) -> int:
     command = ["cargo", "test", "--package", "amari-discovery"]
     if shard == "catalog":
         command.extend(("--lib", "--bins"))
+    if shard == "planner":
+        command.extend(("--features", "ai"))
     for test in tests:
         command.extend(("--test", test))
     print(f"Running discovery {shard} shard ({len(tests)} integration targets)...", flush=True)

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -65,6 +65,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_surreal",
         "probe_tropical",
         "probe_worker_protocol",
+        "shell",
     ),
 }
 

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -42,6 +42,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
     ),
     "planner": (
         "agent_contract",
+        "ai_contract",
         "cli_capabilities",
         "cli_discover",
         "cli_plan_replay",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -67,6 +67,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_tropical",
         "probe_worker_protocol",
         "shell",
+        "shell_agent_contract",
     ),
 }
 

--- a/scripts/verify-discovery-ci-sharding.py
+++ b/scripts/verify-discovery-ci-sharding.py
@@ -67,6 +67,14 @@ def main() -> int:
     if not RUNNER.is_file():
         errors.append("scripts/run-discovery-test-shard.py must exist")
     else:
+        runner = RUNNER.read_text(encoding="utf-8")
+        require(runner, 'if shard == "planner":', RUNNER, errors)
+        require(
+            runner,
+            'command.extend(("--features", "ai"))',
+            RUNNER,
+            errors,
+        )
         result = subprocess.run(
             [sys.executable, str(RUNNER), "--verify"],
             cwd=ROOT,


### PR DESCRIPTION
## Summary

Completes discovery Tasks 23A–23C: a human shell over shared handlers, a provider-neutral AI validation contract, and JSON/NDJSON shell parity.

### Task 23A — human shell (`306f627`)
- adds `amari shell [--project PATH]` with bounded, non-executing input parsing
- delegates capabilities, discovery, inspection, recommendation, planning, schema, and probe commands to the existing typed handlers
- applies session project defaults to inspect/recommend/plan while explicit command paths override them
- revalidates project context on every command and preserves typed errors/exit codes

### Task 23B — AI contract (`425ddc8`)
- adds feature-gated `GoalInterpreter` and `ValidatedGoalInterpreter`
- validates request/output ceilings, `GoalSpec`, catalog capability IDs, duplicate references, and missing-information entries
- rejects all probe, command, mutation, and network authority requests
- ships no concrete provider, subprocess transport, or network client
- keeps capabilities truthful: contract may be compiled while provider/executable remain false

### Task 23C — shell agent contracts (`3dd0293`)
- accepts exactly one typed request in JSON mode
- accepts one bounded typed request per line and emits one shared envelope per line in NDJSON mode
- preserves human/JSON/NDJSON semantic parity, session context, clean stdout/stderr separation, and stable error codes
- uses the Task 22 renderers and one-shot domain handlers without separate shell domain logic

### Review fix (`9bd20f2`)
- enables `ai` in the planner CI shard so `ai_contract` executes instead of compiling to zero tests
- locks that feature invariant in the sharding verifier
- adds exact 65,536-byte acceptance and 65,537-byte rejection coverage

## Safety

- no target-project mutation
- no arbitrary commands, shells, project code, providers, or network access
- machine input is strictly typed, bounded, and rejects unknown fields/arguments
- registered probes continue through the existing fixed process supervisor

## Review

Independent DeepSeek review initially found the planner shard was skipping feature-gated AI tests. After correction, focused re-review returned **APPROVE WITH NOTES** with no Critical or Important findings.

## Verification

Fresh checks passed:
- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- Clippy with `-D warnings` for both feature matrices
- rustdoc with `-D warnings` for both feature matrices
- `cargo fmt --all --check`
- planner shard with `--features ai`
- exhaustive CI sharding verification: 49 targets across 3 unique shards
- Python script compilation and `git diff --check`
