### PR TITLE
test(discovery): harden project inspection boundaries

### DIFF
--- a/amari-discovery/src/inspect/cargo.rs
+++ b/amari-discovery/src/inspect/cargo.rs
@@ -164,6 +164,23 @@ fn safe_read_file(
 
 /// Normalize a workspace member path. Rejects glob patterns, absolute paths,
 /// parent/current components, non-UTF-8 components, or empty strings.
+fn invalid_member_hint(member: &str) -> String {
+    if member.is_empty() {
+        "<empty>".to_owned()
+    } else if member.contains('*') || member.contains('?') {
+        "<glob>".to_owned()
+    } else if Path::new(member).is_absolute() {
+        "<absolute>".to_owned()
+    } else if Path::new(member)
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
+        "<parent-or-current>".to_owned()
+    } else {
+        "<invalid>".to_owned()
+    }
+}
+
 fn normalize_member_path(member: &str) -> Option<String> {
     if member.is_empty() || member.contains('*') || member.contains('?') {
         return None;
@@ -342,7 +359,7 @@ pub fn inspect_cargo_project(
     )?;
 
     let mut root_pkg = parsed_root.package;
-    let ws_meta = parsed_root.ws_meta;
+    let mut ws_meta = parsed_root.ws_meta;
 
     // ---- Read Cargo.lock with limits ----
     let lock_path = root_canon.join("Cargo.lock");
@@ -419,7 +436,7 @@ pub fn inspect_cargo_project(
         for member in &meta.members {
             let Some(normalized) = normalize_member_path(member) else {
                 warnings.push(CargoInspectionWarning::IllegalMemberPath {
-                    member: member.clone(),
+                    member: invalid_member_hint(member),
                 });
                 continue;
             };
@@ -600,6 +617,17 @@ pub fn inspect_cargo_project(
                 }
             }
         }
+    }
+
+    // Keep only normalized, valid, deduplicated member paths in public evidence.
+    if let Some(meta) = &mut ws_meta {
+        meta.members = meta
+            .members
+            .iter()
+            .filter_map(|member| normalize_member_path(member))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
     }
 
     // Sort members for determinism

--- a/amari-discovery/src/inspect/cargo.rs
+++ b/amari-discovery/src/inspect/cargo.rs
@@ -37,6 +37,7 @@ pub use types::{
     WorkspaceMeta,
 };
 
+use std::collections::BTreeSet;
 use std::path::{Component, Path};
 use std::time::Instant;
 
@@ -161,24 +162,29 @@ fn safe_read_file(
 // Workspace member path validation
 // ============================================================================
 
-/// Validate a workspace member path. Rejects glob patterns, absolute paths,
-/// parent components, or empty strings.
-fn validate_member_path(member: &str) -> bool {
+/// Normalize a workspace member path. Rejects glob patterns, absolute paths,
+/// parent/current components, non-UTF-8 components, or empty strings.
+fn normalize_member_path(member: &str) -> Option<String> {
     if member.is_empty() || member.contains('*') || member.contains('?') {
-        return false;
+        return None;
     }
     let path = Path::new(member);
     if path.is_absolute() {
-        return false;
+        return None;
     }
+    let mut parts = Vec::new();
     for component in path.components() {
         match component {
-            Component::ParentDir => return false,
-            Component::Normal(_) => {}
-            _ => return false, // RootDir, Prefix, CurDir are all fishy in member paths
+            Component::Normal(value) => parts.push(value.to_str()?),
+            Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_)
+            | Component::CurDir => {
+                return None;
+            }
         }
     }
-    true
+    (!parts.is_empty()).then(|| parts.join("/"))
 }
 
 // ============================================================================
@@ -409,19 +415,17 @@ pub fn inspect_cargo_project(
     let mut member_state: Option<SnapshotState> = None;
 
     if let Some(ref meta) = ws_meta {
-        // Filter and validate member paths
-        let mut valid_members: Vec<&str> = Vec::new();
+        // Normalize, validate, and deduplicate member paths before any I/O.
+        let mut valid_members = BTreeSet::new();
         for member in &meta.members {
-            if !validate_member_path(member) {
+            let Some(normalized) = normalize_member_path(member) else {
                 warnings.push(CargoInspectionWarning::IllegalMemberPath {
                     member: member.clone(),
                 });
                 continue;
-            }
-            valid_members.push(member);
+            };
+            valid_members.insert(normalized);
         }
-        // Sort for deterministic order
-        valid_members.sort();
 
         for member_dir_name in valid_members {
             // Wall-clock check before each member
@@ -441,7 +445,7 @@ pub fn inspect_cargo_project(
                 break;
             }
 
-            let member_dir = root_canon.join(member_dir_name);
+            let member_dir = root_canon.join(&member_dir_name);
 
             // Check if member directory itself is a symlink
             if std::fs::symlink_metadata(&member_dir)
@@ -518,6 +522,12 @@ pub fn inspect_cargo_project(
                         &provenance,
                     ) {
                         Ok(parsed_member) => {
+                            if parsed_member.declares_workspace {
+                                warnings.push(CargoInspectionWarning::NestedWorkspaceRoot {
+                                    path: member_rel_manifest,
+                                });
+                                continue;
+                            }
                             let mut member_pkg = parsed_member.package;
                             lock::resolve_compatibility(
                                 &mut member_pkg.dependencies,

--- a/amari-discovery/src/inspect/cargo.rs
+++ b/amari-discovery/src/inspect/cargo.rs
@@ -256,15 +256,14 @@ pub fn inspect_cargo_project(
 
     // Validate root is a directory
     if !root.is_dir() {
-        return Err(DiscoveryError::InspectionFailure(format!(
-            "project root is not a directory: {}",
-            root.display()
-        )));
+        return Err(DiscoveryError::InspectionFailure(
+            "project root is not a directory".to_owned(),
+        ));
     }
 
-    // Canonicalize root for containment checks
-    let root_canon = root.canonicalize().map_err(|err| {
-        DiscoveryError::InspectionFailure(format!("cannot canonicalize project root: {}", err))
+    // Canonicalize root for containment checks without exposing its path.
+    let root_canon = root.canonicalize().map_err(|_| {
+        DiscoveryError::InspectionFailure("cannot canonicalize project root".to_owned())
     })?;
 
     let start = Instant::now();

--- a/amari-discovery/src/inspect/cargo/lock.rs
+++ b/amari-discovery/src/inspect/cargo/lock.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::protocol::Compatibility;
+use crate::{inspect::is_safe_version_requirement, protocol::Compatibility};
 
 use super::toml_helpers::{toml_line_col_from_source, toml_malformed_reason, toml_string};
 use super::types::{AmariDependencyEvidence, CargoInspectionWarning, LockedPackage};
@@ -73,9 +73,21 @@ pub(super) fn parse_lock(content: &[u8], lock_path: &str) -> ParsedLock {
                 Some(n) => n,
                 None => continue,
             };
-            let version = toml_string(table, "version").unwrap_or_else(|| "unknown".to_string());
-            let checksum = toml_string(table, "checksum");
-            let source = toml_string(table, "source");
+            let version = toml_string(table, "version")
+                .filter(|value| is_safe_version_requirement(value))
+                .unwrap_or_else(|| "unknown".to_owned());
+            let checksum = toml_string(table, "checksum").filter(|value| {
+                value.len() <= 128 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+            });
+            let source = toml_string(table, "source").map(|value| {
+                if value.starts_with("registry+") {
+                    "registry".to_owned()
+                } else if value.starts_with("git+") {
+                    "git".to_owned()
+                } else {
+                    "other".to_owned()
+                }
+            });
 
             packages.push(LockedPackage {
                 name,

--- a/amari-discovery/src/inspect/cargo/lock.rs
+++ b/amari-discovery/src/inspect/cargo/lock.rs
@@ -29,6 +29,14 @@ pub(super) struct ParsedLock {
 // Lock file parsing
 // ============================================================================
 
+fn is_safe_package_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
 /// Parse a `Cargo.lock` file content entirely offline using TOML.
 pub(super) fn parse_lock(content: &[u8], lock_path: &str) -> ParsedLock {
     let mut warnings = Vec::new();
@@ -69,8 +77,8 @@ pub(super) fn parse_lock(content: &[u8], lock_path: &str) -> ParsedLock {
                 Some(t) => t,
                 None => continue,
             };
-            let name = match toml_string(table, "name") {
-                Some(n) => n,
+            let name = match toml_string(table, "name").filter(|name| is_safe_package_name(name)) {
+                Some(name) => name,
                 None => continue,
             };
             let version = toml_string(table, "version")

--- a/amari-discovery/src/inspect/cargo/manifest.rs
+++ b/amari-discovery/src/inspect/cargo/manifest.rs
@@ -10,6 +10,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::error::{DiscoveryError, DiscoveryResult};
 
+use crate::inspect::is_safe_version_requirement;
+
 use super::toml_helpers::{
     parse_dep_value, toml_bool, toml_string, toml_strings_opt, toml_strings_sorted,
 };
@@ -211,7 +213,11 @@ pub(super) fn parse_dep_table(
         if is_workspace {
             let resolved =
                 resolve_workspace_dep(alias, &dep_table, workspace_bases, package_name, warnings);
-            declared_version = resolved.version;
+            declared_version = if is_safe_version_requirement(&resolved.version) {
+                resolved.version
+            } else {
+                "unknown".to_owned()
+            };
 
             let final_pkg = if resolved.package_name != *alias {
                 resolved.package_name.clone()
@@ -258,13 +264,22 @@ pub(super) fn parse_dep_table(
                 continue;
             }
 
-            if let Some(v) = toml_string(&dep_table, "version") {
-                declared_version = v;
-            } else if let Some(git) = toml_string(&dep_table, "git") {
+            if let Some(version) = toml_string(&dep_table, "version") {
+                declared_version = if is_safe_version_requirement(&version) {
+                    version
+                } else {
+                    warnings.push(CargoInspectionWarning::UnsupportedRequirement {
+                        package: package_name.to_string(),
+                        dep: alias.clone(),
+                        reason: "version requirement is not safe registry syntax".to_owned(),
+                    });
+                    "unknown".to_owned()
+                };
+            } else if toml_string(&dep_table, "git").is_some() {
                 warnings.push(CargoInspectionWarning::UnsupportedRequirement {
                     package: package_name.to_string(),
                     dep: alias.clone(),
-                    reason: format!("git dependency '{}' cannot be resolved offline", git),
+                    reason: "git dependency cannot be resolved offline".to_owned(),
                 });
                 declared_version = "unknown".to_string();
             } else if toml_string(&dep_table, "path").is_some() {

--- a/amari-discovery/src/inspect/cargo/manifest.rs
+++ b/amari-discovery/src/inspect/cargo/manifest.rs
@@ -631,6 +631,8 @@ pub(super) struct ParsedManifest {
     pub package: CargoPackage,
     /// Workspace metadata, only populated for the root manifest.
     pub ws_meta: Option<WorkspaceMeta>,
+    /// Whether this manifest declares a `[workspace]` table.
+    pub declares_workspace: bool,
 }
 
 /// Parse a single `Cargo.toml` manifest and extract the package info,
@@ -793,20 +795,18 @@ pub(super) fn parse_manifest_from_value(
     });
 
     // -- Workspace metadata (only from root manifest)
+    let workspace_table = manifest.get("workspace").and_then(|v| v.as_table());
     let ws_meta = if is_root {
-        manifest
-            .get("workspace")
-            .and_then(|v| v.as_table())
-            .map(|ws_table| {
-                let members = toml_strings_opt(ws_table, "members").unwrap_or_default();
-                let dep_bases = parse_workspace_deps(ws_table);
-                let pkg_fields = parse_workspace_package_fields(ws_table);
-                WorkspaceMeta {
-                    members,
-                    dependency_bases: dep_bases,
-                    package_fields: pkg_fields,
-                }
-            })
+        workspace_table.map(|ws_table| {
+            let members = toml_strings_opt(ws_table, "members").unwrap_or_default();
+            let dep_bases = parse_workspace_deps(ws_table);
+            let pkg_fields = parse_workspace_package_fields(ws_table);
+            WorkspaceMeta {
+                members,
+                dependency_bases: dep_bases,
+                package_fields: pkg_fields,
+            }
+        })
     } else {
         None
     };
@@ -827,6 +827,7 @@ pub(super) fn parse_manifest_from_value(
     Ok(ParsedManifest {
         package: pkg,
         ws_meta,
+        declares_workspace: workspace_table.is_some(),
     })
 }
 

--- a/amari-discovery/src/inspect/cargo/types.rs
+++ b/amari-discovery/src/inspect/cargo/types.rs
@@ -465,7 +465,7 @@ pub enum CargoInspectionWarning {
     /// A workspace member path uses illegal patterns (glob, abs, parent
     /// components, or is empty).
     IllegalMemberPath {
-        /// The raw member path from the manifest.
+        /// Fixed diagnostic category; never the raw manifest value.
         member: String,
     },
     /// A listed member declares another workspace root and is omitted.

--- a/amari-discovery/src/inspect/cargo/types.rs
+++ b/amari-discovery/src/inspect/cargo/types.rs
@@ -468,6 +468,11 @@ pub enum CargoInspectionWarning {
         /// The raw member path from the manifest.
         member: String,
     },
+    /// A listed member declares another workspace root and is omitted.
+    NestedWorkspaceRoot {
+        /// Normalized relative member manifest path.
+        path: String,
+    },
     /// An inherited workspace field (`workspace = true`) references a
     /// field that does not exist or is not `true` in `[workspace.package]`.
     WorkspaceFieldNotFound {

--- a/amari-discovery/src/inspect/limits.rs
+++ b/amari-discovery/src/inspect/limits.rs
@@ -23,7 +23,7 @@ use crate::capabilities::ResourceLimits;
 /// assert_eq!(limits.max_per_file_bytes, rl.max_per_file_bytes);
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct InspectionLimits {
     /// Maximum files considered by one project inspection
     /// (regular non-secret candidates, not only accepted files).

--- a/amari-discovery/src/inspect/mod.rs
+++ b/amari-discovery/src/inspect/mod.rs
@@ -92,6 +92,25 @@ pub(super) fn is_env_secret_name(name: &str) -> bool {
     name.starts_with(".env")
 }
 
+/// Returns whether a registry version or requirement is safe to expose as
+/// structured evidence. URL/path-like and control-bearing values are rejected.
+pub(super) fn is_safe_version_requirement(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_digit() || b"<>=~^*vV".contains(&byte))
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'.' | b'-' | b'+' | b'^' | b'~' | b'*' | b'<' | b'>' | b'=' | b'|' | b' '
+                )
+        })
+}
+
 // ---------------------------------------------------------------------------
 // No-follow read-only open — prevents symlink replacement races
 // ---------------------------------------------------------------------------
@@ -530,19 +549,14 @@ impl ProjectInspector for DefaultInspector {
     fn inspect(&self, root: &Path, limits: &InspectionLimits) -> DiscoveryResult<ProjectSnapshot> {
         // Validate root is a directory (before canonicalization)
         if !root.is_dir() {
-            return Err(DiscoveryError::InspectionFailure(format!(
-                "project root is not a directory: {}",
-                root.display()
-            )));
+            return Err(DiscoveryError::InspectionFailure(
+                "project root is not a directory".to_owned(),
+            ));
         }
 
-        // Canonicalize root once
-        let root_canon = root.canonicalize().map_err(|err| {
-            DiscoveryError::InspectionFailure(format!(
-                "cannot canonicalize project root {}: {}",
-                root.display(),
-                err
-            ))
+        // Canonicalize root once without exposing the caller's absolute path.
+        let root_canon = root.canonicalize().map_err(|_| {
+            DiscoveryError::InspectionFailure("cannot canonicalize project root".to_owned())
         })?;
 
         let start = Instant::now();

--- a/amari-discovery/src/inspect/npm.rs
+++ b/amari-discovery/src/inspect/npm.rs
@@ -35,7 +35,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{DiscoveryError, DiscoveryResult};
 use crate::inspect::snapshot::{InspectionLimit, SnapshotState};
-use crate::inspect::{bounded_read, BoundedOutcome, InspectionLimits};
+use crate::inspect::{bounded_read, is_safe_version_requirement, BoundedOutcome, InspectionLimits};
 use crate::protocol::Compatibility;
 
 #[cfg(not(unix))]
@@ -200,12 +200,17 @@ fn parse_package(bytes: &[u8], catalog_version: &str) -> DiscoveryResult<NpmPack
         else {
             continue;
         };
+        let declared_version = if is_safe_version_requirement(requirement) {
+            requirement.to_owned()
+        } else {
+            "unsupported".to_owned()
+        };
         dependencies.push(NpmDependencyEvidence {
             package_name: AMARI_WASM_PACKAGE.to_string(),
             kind,
-            declared_version: requirement.to_string(),
+            declared_version: declared_version.clone(),
             resolved_version: None,
-            compatibility: unresolved_compatibility(requirement, catalog_version),
+            compatibility: unresolved_compatibility(&declared_version, catalog_version),
             manifest_source: package_source.clone(),
             lock_source: None,
         });
@@ -267,7 +272,11 @@ fn parse_lock(bytes: &[u8]) -> Result<NpmLock, NpmInspectionWarning> {
         .and_then(|package| package.get("version"))
         .and_then(serde_json::Value::as_str)
     {
-        versions.insert(resolved.to_string());
+        versions.insert(if is_safe_version_requirement(resolved) {
+            resolved.to_owned()
+        } else {
+            "unknown".to_owned()
+        });
     }
     if let Some(resolved) = value
         .get("dependencies")
@@ -277,7 +286,11 @@ fn parse_lock(bytes: &[u8]) -> Result<NpmLock, NpmInspectionWarning> {
         .and_then(|package| package.get("version"))
         .and_then(serde_json::Value::as_str)
     {
-        versions.insert(resolved.to_string());
+        versions.insert(if is_safe_version_requirement(resolved) {
+            resolved.to_owned()
+        } else {
+            "unknown".to_owned()
+        });
     }
 
     let packages = versions

--- a/amari-discovery/src/inspect/rust/inspect.rs
+++ b/amari-discovery/src/inspect/rust/inspect.rs
@@ -220,14 +220,13 @@ pub fn inspect_rust_sources(
     limits: &InspectionLimits,
 ) -> DiscoveryResult<RustSourceInspection> {
     if !root.is_dir() {
-        return Err(DiscoveryError::InspectionFailure(format!(
-            "project root is not a directory: {}",
-            root.display()
-        )));
+        return Err(DiscoveryError::InspectionFailure(
+            "project root is not a directory".to_owned(),
+        ));
     }
 
-    let root_canon = root.canonicalize().map_err(|err| {
-        DiscoveryError::InspectionFailure(format!("cannot canonicalize project root: {}", err))
+    let root_canon = root.canonicalize().map_err(|_| {
+        DiscoveryError::InspectionFailure("cannot canonicalize project root".to_owned())
     })?;
 
     let aliases_by_pkg = build_package_aliases(cargo);

--- a/amari-discovery/tests/cargo_inspection.rs
+++ b/amari-discovery/tests/cargo_inspection.rs
@@ -2039,10 +2039,10 @@ members = ["*", "../escape", "/abs", ""]
             }
         })
         .collect();
-    assert!(member_texts.contains("*"));
-    assert!(member_texts.contains("../escape"));
-    assert!(member_texts.contains("/abs"));
-    assert!(member_texts.contains(""));
+    assert!(member_texts.contains("<glob>"));
+    assert!(member_texts.contains("<parent-or-current>"));
+    assert!(member_texts.contains("<absolute>"));
+    assert!(member_texts.contains("<empty>"));
 }
 
 // ===========================================================================

--- a/amari-discovery/tests/inspection_malformed.rs
+++ b/amari-discovery/tests/inspection_malformed.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs;
+
+use amari_discovery::{
+    inspect_cargo_project, inspect_npm_project, inspect_rust_sources, inspect_typescript_sources,
+    CargoInspectionWarning, Catalog, DiscoveryError, InspectionLimits, NpmInspectionWarning,
+    RustInspectionWarning, TypeScriptInspectionWarning,
+};
+use tempfile::TempDir;
+
+fn write(root: &TempDir, path: &str, bytes: &[u8]) {
+    let path = root.path().join(path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, bytes).unwrap();
+}
+
+#[test]
+fn nested_workspace_roots_are_rejected_without_recursive_descent() {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root,
+        "Cargo.toml",
+        br#"[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["member"]
+"#,
+    );
+    write(
+        &root,
+        "member/Cargo.toml",
+        br#"[package]
+name = "nested-root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["child"]
+"#,
+    );
+    write(
+        &root,
+        "member/child/Cargo.toml",
+        br#"[package]
+name = "must-not-be-inspected"
+version = "0.1.0"
+edition = "2021"
+"#,
+    );
+
+    let inspection = inspect_cargo_project(root.path(), &InspectionLimits::default()).unwrap();
+    assert!(inspection.workspace_members.is_empty());
+    assert!(inspection.warnings.iter().any(|warning| matches!(
+        warning,
+        CargoInspectionWarning::NestedWorkspaceRoot { path }
+            if path == "member/Cargo.toml"
+    )));
+    let encoded = serde_json::to_string(&inspection).unwrap();
+    assert!(!encoded.contains("must-not-be-inspected"));
+}
+
+#[test]
+fn normalized_duplicate_workspace_members_are_inspected_once() {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root,
+        "Cargo.toml",
+        br#"[package]
+name = "root"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["member", "member/"]
+"#,
+    );
+    write(
+        &root,
+        "member/Cargo.toml",
+        br#"[package]
+name = "member"
+version = "0.1.0"
+edition = "2021"
+"#,
+    );
+
+    let inspection = inspect_cargo_project(root.path(), &InspectionLimits::default()).unwrap();
+    assert_eq!(inspection.workspace_members.len(), 1);
+    assert_eq!(inspection.inspected_file_count, 2);
+}
+
+#[test]
+fn mixed_encoding_inputs_produce_typed_sanitized_outcomes() {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root,
+        "Cargo.toml",
+        br#"[package]
+name = "mixed"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["bad-member"]
+"#,
+    );
+    write(&root, "bad-member/Cargo.toml", b"[package]\nname='\xff'\n");
+    write(&root, "src/lib.rs", b"pub fn valid() {}\n\xff");
+    write(
+        &root,
+        "package.json",
+        br#"{"name":"mixed","version":"0.1.0"}"#,
+    );
+    write(&root, "package-lock.json", b"{\xff}");
+    write(&root, "src/index.ts", b"export const valid = 1;\n\xff");
+
+    let limits = InspectionLimits::default();
+    let cargo = inspect_cargo_project(root.path(), &limits).unwrap();
+    assert!(cargo.warnings.iter().any(|warning| matches!(
+        warning,
+        CargoInspectionWarning::MalformedManifest { path, .. }
+            if path == "bad-member/Cargo.toml"
+    )));
+    let rust = inspect_rust_sources(root.path(), &cargo, &limits).unwrap();
+    assert!(rust.warnings.iter().any(|warning| matches!(
+        warning,
+        RustInspectionWarning::InvalidUtf8Source { path } if path == "src/lib.rs"
+    )));
+    let npm = inspect_npm_project(root.path(), &limits).unwrap();
+    assert!(npm.warnings.iter().any(|warning| matches!(
+        warning,
+        NpmInspectionWarning::InvalidUtf8Lock { path, .. } if path == "package-lock.json"
+    )));
+    let typescript =
+        inspect_typescript_sources(root.path(), &npm, &Catalog::embedded().unwrap(), &limits)
+            .unwrap();
+    assert!(typescript.warnings.iter().any(|warning| matches!(
+        warning,
+        TypeScriptInspectionWarning::InvalidUtf8Source { path, .. }
+            if path == "src/index.ts"
+    )));
+
+    let encoded = serde_json::to_string(&(cargo, rust, npm, typescript)).unwrap();
+    assert!(!encoded.contains('�'));
+    assert!(!encoded.contains(root.path().to_str().unwrap()));
+}
+
+#[test]
+fn malicious_root_manifests_return_sanitized_errors() {
+    let cargo_root = tempfile::tempdir().unwrap();
+    write(
+        &cargo_root,
+        "Cargo.toml",
+        b"[package]\nname = \"SECRET-CARGO-SOURCE\n",
+    );
+    let cargo_error = inspect_cargo_project(cargo_root.path(), &InspectionLimits::default())
+        .unwrap_err()
+        .to_string();
+    assert!(!cargo_error.contains("SECRET-CARGO-SOURCE"));
+    assert!(!cargo_error.contains(cargo_root.path().to_str().unwrap()));
+
+    let npm_root = tempfile::tempdir().unwrap();
+    write(&npm_root, "package.json", br#"{"name":"SECRET-NPM-SOURCE""#);
+    let npm_error = inspect_npm_project(npm_root.path(), &InspectionLimits::default())
+        .unwrap_err()
+        .to_string();
+    assert!(!npm_error.contains("SECRET-NPM-SOURCE"));
+    assert!(!npm_error.contains(npm_root.path().to_str().unwrap()));
+}
+
+#[test]
+fn huge_source_token_streams_are_stopped_by_byte_guards_before_parsing() {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root,
+        "Cargo.toml",
+        br#"[package]
+name = "bounded"
+version = "0.1.0"
+edition = "2021"
+"#,
+    );
+    write(
+        &root,
+        "package.json",
+        br#"{"name":"bounded","version":"0.1.0"}"#,
+    );
+    write(&root, "src/lib.rs", &vec![b';'; 4097]);
+    write(&root, "src/index.ts", &vec![b';'; 4097]);
+    let limits = InspectionLimits {
+        max_per_file_bytes: 4096,
+        ..InspectionLimits::default()
+    };
+
+    let cargo = inspect_cargo_project(root.path(), &limits).unwrap();
+    let rust = inspect_rust_sources(root.path(), &cargo, &limits).unwrap();
+    assert!(rust.warnings.iter().any(|warning| matches!(
+        warning,
+        RustInspectionWarning::OversizedFile { path, size, limit }
+            if path == "src/lib.rs" && *size == 4097 && *limit == 4096
+    )));
+    assert!(rust.usages.is_empty());
+
+    let npm = inspect_npm_project(root.path(), &limits).unwrap();
+    let typescript =
+        inspect_typescript_sources(root.path(), &npm, &Catalog::embedded().unwrap(), &limits)
+            .unwrap();
+    assert!(typescript.warnings.iter().any(|warning| matches!(
+        warning,
+        TypeScriptInspectionWarning::OversizedFile { path, limit, observed }
+            if path == "src/index.ts" && *limit == 4096 && *observed == 4097
+    )));
+    assert!(typescript.imports.is_empty());
+}
+
+#[test]
+fn huge_required_manifests_fail_with_typed_limits_not_parser_failures() {
+    let root = tempfile::tempdir().unwrap();
+    write(&root, "Cargo.toml", &vec![b'x'; 1025]);
+    write(&root, "package.json", &vec![b'x'; 1025]);
+    let limits = InspectionLimits {
+        max_per_file_bytes: 1024,
+        ..InspectionLimits::default()
+    };
+
+    assert!(matches!(
+        inspect_cargo_project(root.path(), &limits).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+    assert!(matches!(
+        inspect_npm_project(root.path(), &limits).unwrap_err(),
+        DiscoveryError::LimitExceeded(_)
+    ));
+}

--- a/amari-discovery/tests/inspection_paths.rs
+++ b/amari-discovery/tests/inspection_paths.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs;
+
+use amari_discovery::{inspect_project, InspectionLimit, InspectionLimits, SnapshotState};
+use tempfile::TempDir;
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
+fn project(files: &[(&str, &[u8])]) -> TempDir {
+    let root = tempfile::tempdir().unwrap();
+    for (path, contents) in files {
+        let path = root.path().join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+    root
+}
+
+#[test]
+fn inspection_limits_reject_unknown_boundary_fields() {
+    let value = serde_json::json!({
+        "max_inspection_files": 10,
+        "max_inspection_bytes": 1024,
+        "max_traversal_depth": 4,
+        "max_per_file_bytes": 512,
+        "max_inspection_wall_millis": 1000,
+        "follow_symlinks": true
+    });
+    let error = serde_json::from_value::<InspectionLimits>(value).unwrap_err();
+    assert!(error.to_string().contains("unknown field"));
+}
+
+#[cfg(unix)]
+#[test]
+fn nested_symlink_cycles_and_parent_escapes_are_never_followed() {
+    let root = project(&[("Cargo.toml", b"[package]\nname='safe'\n")]);
+    let outside = tempfile::tempdir().unwrap();
+    fs::write(
+        outside.path().join("EXTERNAL_SECRET"),
+        b"outside-poison-24a",
+    )
+    .unwrap();
+    fs::create_dir_all(root.path().join("nested/a/b")).unwrap();
+    symlink(
+        root.path().join("nested/a"),
+        root.path().join("nested/a/b/back"),
+    )
+    .unwrap();
+    symlink(outside.path(), root.path().join("parent_escape")).unwrap();
+
+    let snapshot = inspect_project(root.path(), &InspectionLimits::default()).unwrap();
+    let encoded = serde_json::to_string(&snapshot).unwrap();
+    assert!(!encoded.contains("EXTERNAL_SECRET"));
+    assert!(!encoded.contains("outside-poison-24a"));
+    assert!(!encoded.contains(outside.path().to_str().unwrap()));
+    assert!(snapshot
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("nested/a/b/back")));
+    assert!(snapshot
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("parent_escape")));
+}
+
+#[cfg(unix)]
+#[test]
+fn ignored_directories_cannot_be_used_as_escape_tunnels() {
+    let root = project(&[("Cargo.toml", b"[package]\nname='safe'\n")]);
+    let outside = tempfile::tempdir().unwrap();
+    fs::write(outside.path().join("secret.rs"), b"ignored-escape-poison").unwrap();
+    for ignored in [".git", "target", "node_modules", ".worktrees", ".env-cache"] {
+        let directory = root.path().join(ignored);
+        fs::create_dir_all(&directory).unwrap();
+        symlink(outside.path(), directory.join("escape")).unwrap();
+    }
+
+    let snapshot = inspect_project(root.path(), &InspectionLimits::default()).unwrap();
+    let encoded = serde_json::to_string(&snapshot).unwrap();
+    assert!(!encoded.contains("secret.rs"));
+    assert!(!encoded.contains("ignored-escape-poison"));
+    assert!(!encoded.contains(outside.path().to_str().unwrap()));
+    assert_eq!(snapshot.files.len(), 1);
+}
+
+#[test]
+fn depth_ceiling_preserves_deterministic_root_evidence_as_partial() {
+    let root = project(&[
+        ("Cargo.toml", b"[package]\nname='bounded'\n"),
+        ("src/deeper/lib.rs", b"pub fn hidden() {}"),
+    ]);
+    let limits = InspectionLimits {
+        max_traversal_depth: 1,
+        ..InspectionLimits::default()
+    };
+
+    let first = inspect_project(root.path(), &limits).unwrap();
+    let second = inspect_project(root.path(), &limits).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(first.files.len(), 1);
+    assert_eq!(first.files[0].path, "Cargo.toml");
+    assert_eq!(
+        first.state,
+        SnapshotState::LimitExceeded {
+            limit: InspectionLimit::TraversalDepth { max: 1 }
+        }
+    );
+}
+
+#[test]
+fn considered_file_ceiling_retains_only_accepted_prefix_as_partial() {
+    let root = project(&[
+        ("Cargo.toml", b"manifest"),
+        ("a.rs", b"alpha"),
+        ("b.rs", b"beta"),
+    ]);
+    let limits = InspectionLimits {
+        max_inspection_files: 1,
+        ..InspectionLimits::default()
+    };
+
+    let snapshot = inspect_project(root.path(), &limits).unwrap();
+    assert_eq!(snapshot.file_count, 1);
+    assert_eq!(snapshot.files[0].path, "Cargo.toml");
+    assert_eq!(
+        snapshot.state,
+        SnapshotState::LimitExceeded {
+            limit: InspectionLimit::FileCount {
+                max: 1,
+                observed: 2,
+            }
+        }
+    );
+}
+
+#[test]
+fn aggregate_byte_ceiling_retains_exactly_fitting_evidence_as_partial() {
+    let root = project(&[("a.rs", b"12345"), ("b.rs", b"67890")]);
+    let limits = InspectionLimits {
+        max_inspection_bytes: 5,
+        max_per_file_bytes: 5,
+        ..InspectionLimits::default()
+    };
+
+    let snapshot = inspect_project(root.path(), &limits).unwrap();
+    assert_eq!(snapshot.total_bytes, 5);
+    assert_eq!(snapshot.files.len(), 1);
+    assert_eq!(snapshot.files[0].path, "a.rs");
+    assert_eq!(
+        snapshot.state,
+        SnapshotState::LimitExceeded {
+            limit: InspectionLimit::TotalBytes {
+                max: 5,
+                observed: 5,
+            }
+        }
+    );
+}

--- a/amari-discovery/tests/inspection_privacy.rs
+++ b/amari-discovery/tests/inspection_privacy.rs
@@ -35,6 +35,9 @@ edition = "2021"
 
 [dependencies]
 amari-core = {{ git = "https://user:{CARGO_SECRET}@example.invalid/private.git" }}
+
+[workspace]
+members = ["../{CARGO_SECRET}"]
 "#
         )
         .as_bytes(),
@@ -54,6 +57,10 @@ name = "amari-core"
 version = "0.23.0"
 source = "git+https://user:{CARGO_SECRET}@example.invalid/private.git"
 checksum = "abc123"
+
+[[package]]
+name = "https://user:{CARGO_SECRET}@example.invalid/name"
+version = "0.1.0"
 "#
         )
         .as_bytes(),

--- a/amari-discovery/tests/inspection_privacy.rs
+++ b/amari-discovery/tests/inspection_privacy.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{collections::BTreeMap, fs, path::Path};
+
+use amari_discovery::{
+    inspect_cargo_project, inspect_npm_project, inspect_project, inspect_project_envelope,
+    inspect_rust_sources, InspectionLimits,
+};
+use tempfile::TempDir;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const CARGO_SECRET: &str = "CARGO-TOKEN-24B2-DO-NOT-LEAK";
+const NPM_SECRET: &str = "NPM-TOKEN-24B2-DO-NOT-LEAK";
+const SOURCE_SECRET: &str = "SOURCE-TOKEN-24B2-DO-NOT-LEAK";
+const ENV_SECRET: &str = "ENV-TOKEN-24B2-DO-NOT-LEAK";
+
+fn write(root: &TempDir, path: &str, bytes: &[u8]) {
+    let path = root.path().join(path);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, bytes).unwrap();
+}
+
+fn mixed_project() -> TempDir {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root,
+        "Cargo.toml",
+        format!(
+            r#"[package]
+name = "privacy-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+amari-core = {{ git = "https://user:{CARGO_SECRET}@example.invalid/private.git" }}
+"#
+        )
+        .as_bytes(),
+    );
+    write(
+        &root,
+        "Cargo.lock",
+        format!(
+            r#"version = 3
+
+[[package]]
+name = "privacy-fixture"
+version = "0.1.0"
+
+[[package]]
+name = "amari-core"
+version = "0.23.0"
+source = "git+https://user:{CARGO_SECRET}@example.invalid/private.git"
+checksum = "abc123"
+"#
+        )
+        .as_bytes(),
+    );
+    write(
+        &root,
+        "package.json",
+        format!(
+            r#"{{"name":"privacy-fixture","version":"0.1.0","dependencies":{{"@justinelliottcobb/amari-wasm":"https://user:{NPM_SECRET}@example.invalid/pkg.tgz"}},"scripts":{{"secret":"{SOURCE_SECRET}"}}}}"#
+        )
+        .as_bytes(),
+    );
+    write(
+        &root,
+        "package-lock.json",
+        format!(
+            r#"{{"name":"privacy-fixture","version":"0.1.0","lockfileVersion":3,"packages":{{"node_modules/@justinelliottcobb/amari-wasm":{{"version":"{NPM_SECRET}"}}}}}}"#
+        )
+        .as_bytes(),
+    );
+    write(
+        &root,
+        "src/lib.rs",
+        format!("use amari_core::Multivector;\npub const PRIVATE: &str = \"{SOURCE_SECRET}\";\n")
+            .as_bytes(),
+    );
+    write(
+        &root,
+        "src/index.ts",
+        format!(
+            "import {{ GenericMultivector }} from '@justinelliottcobb/amari-wasm';\nconst private = '{SOURCE_SECRET}';\n"
+        )
+        .as_bytes(),
+    );
+    write(
+        &root,
+        ".env.production",
+        format!("API_KEY={ENV_SECRET}\n").as_bytes(),
+    );
+    root
+}
+
+fn assert_no_secrets(value: &str, root: &Path) {
+    for secret in [CARGO_SECRET, NPM_SECRET, SOURCE_SECRET, ENV_SECRET] {
+        assert!(!value.contains(secret), "leaked secret marker {secret}");
+    }
+    assert!(
+        !value.contains(root.to_str().unwrap()),
+        "leaked absolute root"
+    );
+}
+
+#[test]
+fn composed_snapshot_and_errors_redact_secret_shaped_content() {
+    let root = mixed_project();
+    let envelope = inspect_project_envelope(root.path(), &InspectionLimits::default()).unwrap();
+    let encoded = serde_json::to_string(&envelope).unwrap();
+    assert_no_secrets(&encoded, root.path());
+    assert!(encoded.contains("git dependency cannot be resolved offline"));
+    assert!(encoded.contains("unsupported"));
+}
+
+#[test]
+fn root_validation_errors_never_include_absolute_input_paths() {
+    let root = mixed_project();
+    let secret_named_file = root.path().join("ABSOLUTE-ROOT-SECRET-24B2");
+    fs::write(&secret_named_file, b"not a directory").unwrap();
+    let limits = InspectionLimits::default();
+
+    let generic = inspect_project(&secret_named_file, &limits)
+        .unwrap_err()
+        .to_string();
+    let cargo = inspect_cargo_project(&secret_named_file, &limits)
+        .unwrap_err()
+        .to_string();
+    let cargo_context = inspect_cargo_project(root.path(), &limits).unwrap();
+    let rust = inspect_rust_sources(&secret_named_file, &cargo_context, &limits)
+        .unwrap_err()
+        .to_string();
+    let npm = inspect_npm_project(&secret_named_file, &limits)
+        .unwrap_err()
+        .to_string();
+
+    for error in [generic, cargo, rust, npm] {
+        assert!(!error.contains("ABSOLUTE-ROOT-SECRET-24B2"), "{error}");
+        assert!(!error.contains(root.path().to_str().unwrap()), "{error}");
+        assert!(error.contains("not a directory"), "{error}");
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Eq, PartialEq)]
+struct FileIdentity {
+    bytes: Vec<u8>,
+    length: u64,
+    mode: u32,
+    modified: std::time::SystemTime,
+}
+
+#[cfg(unix)]
+fn identities(root: &Path, paths: &[&str]) -> BTreeMap<String, FileIdentity> {
+    paths
+        .iter()
+        .map(|relative| {
+            let path = root.join(relative);
+            let metadata = fs::metadata(&path).unwrap();
+            (
+                (*relative).to_owned(),
+                FileIdentity {
+                    bytes: fs::read(path).unwrap(),
+                    length: metadata.len(),
+                    mode: metadata.permissions().mode(),
+                    modified: metadata.modified().unwrap(),
+                },
+            )
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+#[test]
+fn composed_inspection_preserves_content_permissions_size_and_mtime() {
+    let root = mixed_project();
+    let paths = [
+        "Cargo.toml",
+        "Cargo.lock",
+        "package.json",
+        "package-lock.json",
+        "src/lib.rs",
+        "src/index.ts",
+        ".env.production",
+    ];
+    fs::set_permissions(
+        root.path().join("src/lib.rs"),
+        fs::Permissions::from_mode(0o640),
+    )
+    .unwrap();
+    let before = identities(root.path(), &paths);
+
+    inspect_project_envelope(root.path(), &InspectionLimits::default()).unwrap();
+
+    let after = identities(root.path(), &paths);
+    assert_eq!(after, before);
+}
+
+#[test]
+fn source_locations_are_hash_only_and_secret_files_are_absent() {
+    let root = mixed_project();
+    let envelope = inspect_project_envelope(root.path(), &InspectionLimits::default()).unwrap();
+    assert!(envelope
+        .data
+        .files
+        .iter()
+        .all(|source| source.content_hash.len() == 64));
+    assert!(envelope
+        .data
+        .files
+        .iter()
+        .all(|source| !source.path.starts_with(".env")));
+    let encoded = serde_json::to_string(&envelope.data.files).unwrap();
+    assert!(!encoded.contains("PRIVATE"));
+    assert!(!encoded.contains(SOURCE_SECRET));
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -35,6 +35,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "cargo_platform_inspection",
         "inspection_malformed",
         "inspection_paths",
+        "inspection_privacy",
         "inspection_safety",
         "npm_inspection",
         "npm_packages",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -33,6 +33,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
     "inspection": (
         "cargo_inspection",
         "cargo_platform_inspection",
+        "inspection_paths",
         "inspection_safety",
         "npm_inspection",
         "npm_packages",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -33,6 +33,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
     "inspection": (
         "cargo_inspection",
         "cargo_platform_inspection",
+        "inspection_malformed",
         "inspection_paths",
         "inspection_safety",
         "npm_inspection",


### PR DESCRIPTION
## Summary

Completes discovery Tasks 24A–24B2: traversal-boundary, malformed-input, privacy, and no-mutation hardening for project inspection.

### Task 24A — traversal boundaries (`4883715`)
- rejects unknown inspection-limit fields instead of silently accepting authority-like options
- locks nested symlink cycles, parent escapes, and ignored-directory escape tunnels
- verifies deterministic partial evidence at traversal-depth, considered-file, and aggregate-byte ceilings

### Task 24B1 — parser hardening (`e187544`)
- rejects nested workspace roots without recursive descent
- normalizes and deduplicates workspace member paths before I/O
- tests mixed encodings across Cargo, Rust, npm lock, and TypeScript inputs
- verifies malformed manifests remain sanitized and huge token streams hit byte guards before parsing
- preserves typed warnings and bounded outcomes

### Task 24B2 — privacy and no mutation (`69b5816`)
- removes absolute project roots and OS details from root-validation errors
- redacts git dependency URLs and unsafe Cargo/npm requirements
- classifies Cargo lock sources and validates lock versions/checksums
- verifies composed snapshots contain hashes rather than source or secret values
- proves inspection preserves content, permissions, size, and mtime across mixed projects

### Review fix (`edafed9`)
- rejects unsafe Cargo lock package names
- replaces raw illegal workspace-member strings with fixed diagnostic categories
- sanitizes and deduplicates public `WorkspaceMeta.members` evidence

## Safety

- no symlink following or project-root escape
- no project mutation, command execution, project-code evaluation, provider, or network access
- no source text, secret-shaped dependency URLs, absolute roots, or external targets in shared evidence/errors
- all parser and traversal inputs remain bounded by explicit file/byte/depth/time ceilings

## Review

Independent DeepSeek review initially identified two Important privacy gaps: unsafe Cargo lock package names and raw illegal-member warning values. Both were fixed. Focused re-review returned **APPROVE WITH NOTES** with no remaining Critical or Important findings.

## Verification

Fresh checks passed:
- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- Clippy with `-D warnings` for both feature matrices
- rustdoc with `-D warnings` for both feature matrices
- `cargo fmt --all --check`
- complete discovery inspection shard
- exhaustive CI sharding verification: 52 targets across 3 unique shards
- Python script compilation and `git diff --check`
