### PR TITLE
test: harden discovery planner limits and replay

### DIFF
--- a/amari-discovery/src/commands/plan.rs
+++ b/amari-discovery/src/commands/plan.rs
@@ -6,12 +6,12 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use super::recommend::read_bounded_input;
-use crate::inspect::{inspect_supported_project, InspectionLimits};
-use crate::planner::catalog_plan_steps;
+use crate::inspect::{inspect_supported_project, snapshot_compatibility, InspectionLimits};
+use crate::planner::{catalog_plan_steps, validate_sha256_hash};
 use crate::{
-    CandidatePlan, CapabilityId, Catalog, DiscoveryError, DiscoveryOutcome, DiscoveryResult,
-    Envelope, PlanCompatibility, PlanNormalization, PlanNormalizer, ProjectKind, Recommendation,
-    SCHEMA_V1,
+    CandidatePlan, CapabilityId, Catalog, CatalogIdentity, DiscoveryError, DiscoveryOutcome,
+    DiscoveryResult, Envelope, PlanCompatibility, PlanNormalization, PlanNormalizer, ProjectKind,
+    Provenance, RecallConfig, Recommendation, ReplayMetadata, SCHEMA_V1,
 };
 
 const MAX_RECOMMENDATION_BYTES: u64 = 8 * 1_048_576;
@@ -58,13 +58,13 @@ pub fn replay_plan_envelope(
     let Envelope {
         schema_version,
         provenance,
-        warnings,
+        warnings: _,
         data,
     } = artifact;
     if schema_version != SCHEMA_V1 {
-        return Err(DiscoveryError::InvalidInput(format!(
-            "unsupported recommendation schema `{schema_version}`"
-        )));
+        return Err(DiscoveryError::InvalidInput(
+            "unsupported recommendation schema".to_owned(),
+        ));
     }
     if !provenance.replay.replayable {
         return Err(DiscoveryError::InvalidInput(
@@ -87,6 +87,14 @@ pub fn replay_plan_envelope(
         ));
     }
 
+    compare_untrusted(
+        "tool_version",
+        env!("CARGO_PKG_VERSION"),
+        &provenance.tool_version,
+    )?;
+    let expected_seed = RecallConfig::default().seed;
+    compare_seed(provenance.seed, expected_seed)?;
+
     let recommendation = match data {
         DiscoveryOutcome::Recommended(recommendation) => recommendation,
         DiscoveryOutcome::NoApplicableCapability { .. }
@@ -101,46 +109,62 @@ pub fn replay_plan_envelope(
     let candidate_id: CapabilityId = candidate_id.parse()?;
     let selected = select_candidate(&recommendation, &candidate_id)?;
 
-    compare_replay(
+    validate_sha256_hash("catalog_hash", &provenance.catalog.hash)?;
+    validate_sha256_hash("catalog_hash", &selected.compatibility.catalog.hash)?;
+    let provenance_project_hash = require_hash("project_hash", provenance.project_hash.as_deref())?;
+    let provenance_input_hash = require_hash("input_hash", provenance.input_hash.as_deref())?;
+    validate_sha256_hash("project_hash", &selected.compatibility.project_hash)?;
+    validate_sha256_hash("input_hash", &selected.compatibility.input_hash)?;
+    validate_sha256_hash("plan_hash", &selected.plan_hash)?;
+    for replay_hash in &selected.compatibility.probe_results {
+        validate_sha256_hash("probe_results", &replay_hash.input_hash)?;
+        validate_sha256_hash("probe_results", &replay_hash.result_hash)?;
+    }
+
+    compare_untrusted(
         "catalog_version",
         catalog.version(),
         &provenance.catalog.version,
     )?;
-    compare_replay(
+    compare_validated_hash(
         "catalog_hash",
         catalog.content_hash(),
         &provenance.catalog.hash,
     )?;
-    compare_replay(
+    compare_untrusted(
         "catalog_version",
         &provenance.catalog.version,
         &selected.compatibility.catalog.version,
     )?;
-    compare_replay(
+    compare_validated_hash(
         "catalog_hash",
         &provenance.catalog.hash,
         &selected.compatibility.catalog.hash,
     )?;
-    compare_optional_replay(
+    compare_validated_hash(
         "project_hash",
-        provenance.project_hash.as_deref(),
+        provenance_project_hash,
         &selected.compatibility.project_hash,
     )?;
-    compare_optional_replay(
+    compare_validated_hash(
         "input_hash",
-        provenance.input_hash.as_deref(),
+        provenance_input_hash,
         &selected.compatibility.input_hash,
     )?;
-    validate_sha256("plan_hash", &selected.plan_hash)?;
-    for replay_hash in &selected.compatibility.probe_results {
-        validate_sha256("probe_results", &replay_hash.result_hash)?;
-    }
 
     let snapshot = inspect_supported_project(project_root, limits)?;
     if matches!(snapshot.project_kind, ProjectKind::Unknown) {
         return Err(DiscoveryError::InvalidInput(
             "plan replay requires a Rust/Cargo or npm/TypeScript project".to_owned(),
         ));
+    }
+    let canonical_compatibility = snapshot_compatibility(&snapshot);
+    if provenance.compatibility != canonical_compatibility {
+        return Err(DiscoveryError::ReplayDrift {
+            field: "compatibility".to_owned(),
+            expected: "current project compatibility".to_owned(),
+            actual: "<mismatch>".to_owned(),
+        });
     }
     let actual = PlanCompatibility::from_replay_hashes(
         catalog,
@@ -181,9 +205,30 @@ pub fn replay_plan_envelope(
         });
     }
 
+    let mut warnings = snapshot.warnings.clone();
+    warnings.sort();
+    warnings.dedup();
     Ok(Envelope {
-        schema_version,
-        provenance,
+        schema_version: SCHEMA_V1.to_owned(),
+        provenance: Provenance {
+            tool_version: env!("CARGO_PKG_VERSION").to_owned(),
+            catalog: CatalogIdentity {
+                version: catalog.version().to_owned(),
+                hash: catalog.content_hash().to_owned(),
+            },
+            compatibility: canonical_compatibility,
+            replay: ReplayMetadata {
+                replayable: true,
+                required_hashes: REQUIRED_REPLAY_HASHES
+                    .iter()
+                    .map(|field| (*field).to_owned())
+                    .collect(),
+                reasons: Vec::new(),
+            },
+            project_hash: Some(snapshot.project_hash),
+            input_hash: Some(actual.input_hash),
+            seed: Some(expected_seed),
+        },
         warnings,
         data: expected,
     })
@@ -204,18 +249,16 @@ fn select_candidate(
         })
 }
 
-fn compare_optional_replay(
-    field: &str,
-    artifact: Option<&str>,
-    selected: &str,
-) -> DiscoveryResult<()> {
-    let artifact = artifact.ok_or_else(|| {
+fn require_hash<'a>(field: &str, value: Option<&'a str>) -> DiscoveryResult<&'a str> {
+    let value = value.ok_or_else(|| {
         DiscoveryError::InvalidInput(format!("recommendation provenance is missing `{field}`"))
     })?;
-    compare_replay(field, artifact, selected)
+    validate_sha256_hash(field, value)?;
+    Ok(value)
 }
 
-fn compare_replay(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {
+/// Compares values only after both have passed `validate_sha256_hash`.
+fn compare_validated_hash(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {
     if expected == actual {
         Ok(())
     } else {
@@ -227,18 +270,28 @@ fn compare_replay(field: &str, expected: &str, actual: &str) -> DiscoveryResult<
     }
 }
 
-fn validate_sha256(field: &str, value: &str) -> DiscoveryResult<()> {
-    if value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-    {
+fn compare_untrusted(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {
+    if expected == actual {
         Ok(())
     } else {
         Err(DiscoveryError::ReplayDrift {
             field: field.to_owned(),
-            expected: "64 lowercase hexadecimal SHA-256 characters".to_owned(),
-            actual: value.to_owned(),
+            expected: expected.to_owned(),
+            actual: "<mismatch>".to_owned(),
+        })
+    }
+}
+
+fn compare_seed(actual: Option<u64>, expected: u64) -> DiscoveryResult<()> {
+    if actual == Some(expected) {
+        Ok(())
+    } else {
+        Err(DiscoveryError::ReplayDrift {
+            field: "seed".to_owned(),
+            expected: expected.to_string(),
+            actual: actual
+                .map(|seed| seed.to_string())
+                .unwrap_or_else(|| "<missing>".to_owned()),
         })
     }
 }

--- a/amari-discovery/src/planner/graph.rs
+++ b/amari-discovery/src/planner/graph.rs
@@ -16,11 +16,42 @@ type MinPlusNumber = VerifiedTropicalNumber<f64, MinPlus>;
 
 /// Resource limits for capability-graph expansion.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GraphLimits {
     /// Maximum number of distinct capability nodes retained.
     pub max_nodes: usize,
     /// Maximum number of relationship edges from any seed.
     pub max_depth: usize,
+}
+
+impl GraphLimits {
+    /// Hard ceiling for retained capability nodes, independent of caller input.
+    pub const MAX_ALLOWED_NODES: usize = 64;
+    /// Hard ceiling for semantic relationship traversal depth.
+    pub const MAX_ALLOWED_DEPTH: usize = 16;
+
+    fn validate(self) -> DiscoveryResult<()> {
+        if self.max_nodes == 0 {
+            return Err(DiscoveryError::InvalidInput(
+                "capability graph max_nodes must be greater than zero".to_owned(),
+            ));
+        }
+        if self.max_nodes > Self::MAX_ALLOWED_NODES {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "capability graph max_nodes {} exceeds hard ceiling {}",
+                self.max_nodes,
+                Self::MAX_ALLOWED_NODES
+            )));
+        }
+        if self.max_depth > Self::MAX_ALLOWED_DEPTH {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "capability graph max_depth {} exceeds hard ceiling {}",
+                self.max_depth,
+                Self::MAX_ALLOWED_DEPTH
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Default for GraphLimits {
@@ -171,9 +202,11 @@ impl CapabilityGraphExpander {
     ///
     /// # Errors
     ///
-    /// Returns [`DiscoveryError::InvalidInput`] if any relationship cost is
-    /// negative, non-finite, or keyed by an empty relationship kind.
+    /// Returns [`DiscoveryError::InvalidInput`] for a zero node limit or an
+    /// invalid relationship cost. Returns [`DiscoveryError::LimitExceeded`]
+    /// when caller-provided graph limits exceed the fixed hard ceilings.
     pub fn new(limits: GraphLimits, costs: RelationCostPolicy) -> DiscoveryResult<Self> {
+        limits.validate()?;
         costs.validate()?;
         Ok(Self { limits, costs })
     }

--- a/amari-discovery/src/planner/mod.rs
+++ b/amari-discovery/src/planner/mod.rs
@@ -17,8 +17,8 @@ pub use graph::{
     GraphLimits, GraphPath, GraphStep, RelationCostPolicy,
 };
 pub use normalize::{NormalizationLimits, PlanNormalizer};
-pub(crate) use plan::catalog_plan_steps;
 pub use plan::PlanGenerator;
+pub(crate) use plan::{catalog_plan_steps, validate_sha256_hash};
 pub use rank::{
     BlockedCandidate, CandidateRanker, RankedCandidate, RankingComponents, RankingContext,
     RankingProvenance, RankingResult, RankingSignal, RankingSignalKind, RANKING_OBJECTIVE_ORDER,

--- a/amari-discovery/src/planner/normalize.rs
+++ b/amari-discovery/src/planner/normalize.rs
@@ -18,11 +18,42 @@ const MAX_ENCODED_PLAN_BYTES: usize = 1_048_576;
 
 /// Resource limits for deterministic plan normalization.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NormalizationLimits {
     /// Maximum input plan steps accepted by the normalizer.
     pub max_plan_steps: usize,
     /// Maximum successful `TermSystem::apply_once` rewrites retained in trace.
     pub max_rewrites: usize,
+}
+
+impl NormalizationLimits {
+    /// Hard ceiling for plan steps accepted by normalization.
+    pub const MAX_ALLOWED_PLAN_STEPS: usize = 64;
+    /// Hard ceiling for retained rewrite transitions.
+    pub const MAX_ALLOWED_REWRITES: usize = 4_096;
+
+    fn validate(self) -> DiscoveryResult<()> {
+        if self.max_plan_steps == 0 || self.max_rewrites == 0 {
+            return Err(DiscoveryError::InvalidInput(
+                "plan normalization limits must be greater than zero".to_owned(),
+            ));
+        }
+        if self.max_plan_steps > Self::MAX_ALLOWED_PLAN_STEPS {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "plan normalization max_plan_steps {} exceeds hard ceiling {}",
+                self.max_plan_steps,
+                Self::MAX_ALLOWED_PLAN_STEPS
+            )));
+        }
+        if self.max_rewrites > Self::MAX_ALLOWED_REWRITES {
+            return Err(DiscoveryError::LimitExceeded(format!(
+                "plan normalization max_rewrites {} exceeds hard ceiling {}",
+                self.max_rewrites,
+                Self::MAX_ALLOWED_REWRITES
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Default for NormalizationLimits {
@@ -45,13 +76,10 @@ impl PlanNormalizer {
     ///
     /// # Errors
     ///
-    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero.
+    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero and
+    /// [`DiscoveryError::LimitExceeded`] when a fixed hard ceiling is exceeded.
     pub fn new(limits: NormalizationLimits) -> DiscoveryResult<Self> {
-        if limits.max_plan_steps == 0 || limits.max_rewrites == 0 {
-            return Err(DiscoveryError::InvalidInput(
-                "plan normalization limits must be greater than zero".to_owned(),
-            ));
-        }
+        limits.validate()?;
         Ok(Self { limits })
     }
 

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -27,7 +27,9 @@ impl PlanGenerator {
     ///
     /// # Errors
     ///
-    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero.
+    /// Returns [`DiscoveryError::InvalidInput`] when either limit is zero and
+    /// [`DiscoveryError::LimitExceeded`] when a normalization hard ceiling is
+    /// exceeded.
     pub fn new(limits: NormalizationLimits) -> DiscoveryResult<Self> {
         Ok(Self {
             normalizer: PlanNormalizer::new(limits)?,

--- a/amari-discovery/src/planner/plan.rs
+++ b/amari-discovery/src/planner/plan.rs
@@ -78,8 +78,8 @@ impl PlanCompatibility {
     ///
     /// # Errors
     ///
-    /// Returns a serialization error if typed goal or probe evidence cannot be
-    /// encoded for deterministic hashing.
+    /// Returns typed replay drift for a malformed saved-probe input hash, or a
+    /// serialization error when evidence cannot be encoded deterministically.
     pub fn from_context(catalog: &Catalog, context: &PlanningContext) -> DiscoveryResult<Self> {
         compatibility(catalog, context)
     }
@@ -91,8 +91,8 @@ impl PlanCompatibility {
     ///
     /// # Errors
     ///
-    /// Returns a semantic goal error or a serialization error while hashing
-    /// canonical replay inputs.
+    /// Returns a semantic goal error, typed replay drift for malformed hashes,
+    /// or a serialization error while hashing canonical replay inputs.
     pub fn from_replay_hashes(
         catalog: &Catalog,
         project_hash: impl Into<String>,
@@ -100,7 +100,13 @@ impl PlanCompatibility {
         probe_results: Vec<ProbeReplayHash>,
     ) -> DiscoveryResult<Self> {
         goal.validate()?;
-        compatibility_from_hashes(catalog, project_hash.into(), goal, probe_results)
+        let project_hash = project_hash.into();
+        validate_sha256_hash("project_hash", &project_hash)?;
+        for probe in &probe_results {
+            validate_sha256_hash("probe_input_hash", &probe.input_hash)?;
+            validate_sha256_hash("probe_result_hash", &probe.result_hash)?;
+        }
+        compatibility_from_hashes(catalog, project_hash, goal, probe_results)
     }
 }
 
@@ -322,6 +328,7 @@ fn compatibility(
         .probe_results
         .iter()
         .map(|result| {
+            validate_sha256_hash("probe_input_hash", &result.input_hash)?;
             Ok(ProbeReplayHash {
                 probe_id: result.probe_id.clone(),
                 input_hash: result.input_hash.clone(),
@@ -371,6 +378,22 @@ struct CanonicalGoal<'a> {
     statement: &'a str,
     constraints: &'a [String],
     probe_results: &'a [ProbeReplayHash],
+}
+
+pub(crate) fn validate_sha256_hash(field: &str, value: &str) -> DiscoveryResult<()> {
+    if value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(DiscoveryError::ReplayDrift {
+            field: field.to_owned(),
+            expected: "64 lowercase hexadecimal SHA-256 characters".to_owned(),
+            actual: "<invalid_sha256>".to_owned(),
+        })
+    }
 }
 
 fn compare_replay(field: &str, expected: &str, actual: &str) -> DiscoveryResult<()> {

--- a/amari-discovery/src/protocol.rs
+++ b/amari-discovery/src/protocol.rs
@@ -567,7 +567,12 @@ pub struct Recommendation {
 /// Non-recommendation variants communicate expected domain conditions and do
 /// not imply a nonzero process exit code.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "status", content = "data", rename_all = "snake_case")]
+#[serde(
+    tag = "status",
+    content = "data",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 pub enum DiscoveryOutcome<T> {
     /// A capability or plan can be recommended.
     Recommended(T),

--- a/amari-discovery/src/protocol.rs
+++ b/amari-discovery/src/protocol.rs
@@ -145,6 +145,7 @@ impl fmt::Display for ProbeId {
 
 /// The catalog version and content hash used to produce a response.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CatalogIdentity {
     /// The Amari catalog version.
     pub version: String,
@@ -154,6 +155,7 @@ pub struct CatalogIdentity {
 
 /// Compatibility status and the evidence supporting it.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Compatibility {
     /// A stable compatibility status such as `compatible` or `unknown_version`.
     pub status: String,
@@ -163,6 +165,7 @@ pub struct Compatibility {
 
 /// Requirements for replaying a discovery response.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReplayMetadata {
     /// Whether the response contains sufficient provenance for replay.
     pub replayable: bool,
@@ -174,6 +177,7 @@ pub struct ReplayMetadata {
 
 /// Provenance shared by every discovery response.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Provenance {
     /// The `amari-discovery` package version.
     pub tool_version: String,
@@ -193,6 +197,7 @@ pub struct Provenance {
 
 /// A versioned discovery response envelope.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Envelope<T> {
     /// The machine protocol schema version.
     pub schema_version: String,
@@ -239,6 +244,7 @@ pub enum ProbeBackend {
 
 /// Resource usage observed during a bounded probe.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResourceObservations {
     /// Domain operations performed.
     pub operations: u64,
@@ -252,6 +258,7 @@ pub struct ResourceObservations {
 
 /// A typed result returned by a registered bounded probe.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProbeResult {
     /// The stable probe identifier.
     pub probe_id: ProbeId,
@@ -281,6 +288,7 @@ pub struct ProbeResult {
 
 /// A discrete piece of evidence used by discovery and planning.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Evidence {
     /// Stable evidence category.
     pub kind: String,
@@ -341,6 +349,7 @@ impl GoalSpec {
 
 /// Typed project, goal, and saved-probe inputs used to construct plans.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlanningContext {
     /// Sanitized read-only project snapshot.
     pub snapshot: ProjectSnapshot,
@@ -353,6 +362,7 @@ pub struct PlanningContext {
 
 /// Replay hash for one saved probe result consumed by planning.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProbeReplayHash {
     /// Registered probe identifier.
     pub probe_id: ProbeId,
@@ -364,6 +374,7 @@ pub struct ProbeReplayHash {
 
 /// Provenance that must match before a plan can be replayed.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlanCompatibility {
     /// Catalog version and content hash used to construct the plan.
     pub catalog: CatalogIdentity,
@@ -388,7 +399,7 @@ pub enum PlanTestTarget {
 
 /// One read-only integration instruction in a candidate plan.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum PlanStep {
     /// Add an exact Amari Cargo or npm package dependency.
     Dependency {
@@ -458,6 +469,7 @@ impl PlanStep {
 
 /// One deterministic rewrite applied during plan normalization.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NormalizationTrace {
     /// Plan steps immediately before the rewrite.
     pub before: Vec<PlanStep>,
@@ -467,6 +479,7 @@ pub struct NormalizationTrace {
 
 /// Completion and trace metadata for plan normalization.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PlanNormalization {
     /// Whether the plan reached a rewrite fixed point within its limits.
     pub normalized: bool,
@@ -479,6 +492,7 @@ pub struct PlanNormalization {
 
 /// A deterministic replayable plan for one ranked capability path.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CandidatePlan {
     /// Preferred catalog capability implemented by this plan.
     pub capability_id: CapabilityId,
@@ -496,6 +510,7 @@ pub struct CandidatePlan {
 
 /// Transparent normalized score components for one recommended capability.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RecommendationScoreComponents {
     /// Project and prerequisite applicability; higher is better.
     pub applicability: f64,
@@ -517,6 +532,7 @@ pub struct RecommendationScoreComponents {
 
 /// Score, evidence, and assumptions for one recommendation candidate.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RecommendationScore {
     /// Stable catalog capability ID.
     pub capability_id: CapabilityId,
@@ -535,6 +551,7 @@ pub struct RecommendationScore {
 
 /// A preferred replayable plan and its Pareto alternatives.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Recommendation {
     /// Goal used to generate the recommendation.
     pub goal: GoalSpec,

--- a/amari-discovery/tests/cli_plan_replay.rs
+++ b/amari-discovery/tests/cli_plan_replay.rs
@@ -165,7 +165,7 @@ fn write_probe_results(root: &Path) -> NamedTempFile {
         seed: Some(7),
         project_hash: Some(snapshot.project_hash),
         catalog_hash: catalog.content_hash().to_owned(),
-        input_hash: "saved-dual-input".to_owned(),
+        input_hash: "a".repeat(64),
         validated_assumptions: vec!["derivative_matches".to_owned()],
         refuted_assumptions: Vec::new(),
         warnings: Vec::new(),

--- a/amari-discovery/tests/cli_recommend_rust.rs
+++ b/amari-discovery/tests/cli_recommend_rust.rs
@@ -207,7 +207,7 @@ fn matching_saved_probe_improves_the_same_candidate_score() {
         seed: Some(7),
         project_hash: Some(snapshot.project_hash),
         catalog_hash: catalog.content_hash().to_owned(),
-        input_hash: "saved-dual-input".to_owned(),
+        input_hash: "b".repeat(64),
         validated_assumptions: vec!["derivative_matches".to_owned()],
         refuted_assumptions: Vec::new(),
         warnings: Vec::new(),

--- a/amari-discovery/tests/cli_recommend_ts.rs
+++ b/amari-discovery/tests/cli_recommend_ts.rs
@@ -219,7 +219,7 @@ fn matching_saved_probe_improves_typescript_candidate_verification() {
         seed: Some(11),
         project_hash: Some(snapshot.project_hash),
         catalog_hash: catalog.content_hash().to_owned(),
-        input_hash: "saved-geometric-product-input".to_owned(),
+        input_hash: "c".repeat(64),
         validated_assumptions: vec!["product_matches".to_owned()],
         refuted_assumptions: Vec::new(),
         warnings: Vec::new(),

--- a/amari-discovery/tests/planner_limits.rs
+++ b/amari-discovery/tests/planner_limits.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Adversarial planner resource-limit and domain-outcome contracts.
+
+use std::collections::BTreeSet;
+
+use amari_discovery::{
+    CapabilityGraphExpander, CapabilityId, Catalog, DiscoveryError, DiscoveryOutcome,
+    GraphConstraints, GraphExpansionState, GraphLimit, GraphLimits, NormalizationLimits,
+    PlanNormalizer, RelationCostPolicy,
+};
+use serde_json::{json, Value};
+
+fn id(value: &str) -> CapabilityId {
+    value.parse().unwrap()
+}
+
+#[test]
+fn graph_configuration_has_non_bypassable_hard_ceilings() {
+    assert!(CapabilityGraphExpander::new(
+        GraphLimits {
+            max_nodes: GraphLimits::MAX_ALLOWED_NODES,
+            max_depth: GraphLimits::MAX_ALLOWED_DEPTH,
+        },
+        RelationCostPolicy::default(),
+    )
+    .is_ok());
+
+    for limits in [
+        GraphLimits {
+            max_nodes: GraphLimits::MAX_ALLOWED_NODES + 1,
+            max_depth: GraphLimits::default().max_depth,
+        },
+        GraphLimits {
+            max_nodes: GraphLimits::default().max_nodes,
+            max_depth: GraphLimits::MAX_ALLOWED_DEPTH + 1,
+        },
+    ] {
+        assert!(matches!(
+            CapabilityGraphExpander::new(limits, RelationCostPolicy::default()),
+            Err(DiscoveryError::LimitExceeded(_))
+        ));
+    }
+
+    assert!(matches!(
+        CapabilityGraphExpander::new(
+            GraphLimits {
+                max_nodes: 0,
+                max_depth: 0,
+            },
+            RelationCostPolicy::default(),
+        ),
+        Err(DiscoveryError::InvalidInput(_))
+    ));
+}
+
+#[test]
+fn graph_limit_keeps_deterministic_partial_path_evidence() {
+    let seed = id("amari:amari-tropical:paths:shortest-path");
+    let expander = CapabilityGraphExpander::new(
+        GraphLimits {
+            max_nodes: 1,
+            max_depth: GraphLimits::default().max_depth,
+        },
+        RelationCostPolicy::default(),
+    )
+    .unwrap();
+    let catalog = Catalog::embedded().unwrap();
+
+    let first = expander
+        .expand(
+            &catalog,
+            std::slice::from_ref(&seed),
+            &GraphConstraints::default(),
+        )
+        .unwrap();
+    let second = expander
+        .expand(
+            &catalog,
+            std::slice::from_ref(&seed),
+            &GraphConstraints::default(),
+        )
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first.paths.len(), 1);
+    assert_eq!(first.paths[0].target, seed);
+    assert_eq!(first.paths[0].capabilities, vec![seed]);
+    assert!(matches!(
+        first.state,
+        GraphExpansionState::Partial { ref limits }
+            if limits == &[GraphLimit::NodeCount { max: 1, observed: 2 }]
+    ));
+}
+
+#[test]
+fn normalization_configuration_has_non_bypassable_hard_ceilings() {
+    assert!(PlanNormalizer::new(NormalizationLimits {
+        max_plan_steps: NormalizationLimits::MAX_ALLOWED_PLAN_STEPS,
+        max_rewrites: NormalizationLimits::MAX_ALLOWED_REWRITES,
+    })
+    .is_ok());
+
+    for limits in [
+        NormalizationLimits {
+            max_plan_steps: NormalizationLimits::MAX_ALLOWED_PLAN_STEPS + 1,
+            max_rewrites: 1,
+        },
+        NormalizationLimits {
+            max_plan_steps: 1,
+            max_rewrites: NormalizationLimits::MAX_ALLOWED_REWRITES + 1,
+        },
+    ] {
+        assert!(matches!(
+            PlanNormalizer::new(limits),
+            Err(DiscoveryError::LimitExceeded(_))
+        ));
+    }
+}
+
+#[test]
+fn planner_limit_dtos_reject_unknown_authority_fields() {
+    assert!(serde_json::from_value::<GraphLimits>(json!({
+        "max_nodes": 8,
+        "max_depth": 2,
+        "unbounded": true
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<NormalizationLimits>(json!({
+        "max_plan_steps": 8,
+        "max_rewrites": 32,
+        "max_trace_bytes": 999999999
+    }))
+    .is_err());
+}
+
+#[test]
+fn non_recommendation_domain_conditions_are_successful_typed_values() {
+    let outcomes = [
+        DiscoveryOutcome::<Value>::NoApplicableCapability {
+            evidence: Vec::new(),
+        },
+        DiscoveryOutcome::<Value>::InsufficientEvidence {
+            missing: vec!["project_inspection_partial".to_owned()],
+        },
+        DiscoveryOutcome::<Value>::Blocked {
+            reasons: vec!["platform_incompatible".to_owned()],
+        },
+    ];
+
+    for outcome in outcomes {
+        let bytes = serde_json::to_vec(&outcome).unwrap();
+        let decoded: DiscoveryOutcome<Value> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, outcome);
+        let value = serde_json::to_value(outcome).unwrap();
+        assert!(matches!(
+            value["status"].as_str(),
+            Some("no_applicable_capability" | "insufficient_evidence" | "blocked")
+        ));
+    }
+}
+
+#[test]
+fn domain_outcome_protocol_rejects_unknown_fields() {
+    let malformed = [
+        json!({
+            "status": "no_applicable_capability",
+            "data": {"evidence": [], "error": true}
+        }),
+        json!({
+            "status": "insufficient_evidence",
+            "data": {"missing": [], "execute": "cargo build"}
+        }),
+        json!({
+            "status": "blocked",
+            "data": {"reasons": [], "override": true}
+        }),
+    ];
+
+    for value in malformed {
+        assert!(serde_json::from_value::<DiscoveryOutcome<Value>>(value).is_err());
+    }
+}
+
+#[test]
+fn blocked_seed_is_preserved_as_typed_graph_evidence() {
+    let seed = id("amari:amari-tropical:paths:shortest-path");
+    let expansion = CapabilityGraphExpander::default()
+        .expand(
+            &Catalog::embedded().unwrap(),
+            std::slice::from_ref(&seed),
+            &GraphConstraints {
+                blocked_capabilities: BTreeSet::from([seed.clone()]),
+            },
+        )
+        .unwrap();
+
+    assert!(expansion.paths.is_empty());
+    assert_eq!(expansion.blocked_capabilities, vec![seed]);
+}

--- a/amari-discovery/tests/planner_replay.rs
+++ b/amari-discovery/tests/planner_replay.rs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Provenance, privacy, and cross-process planner replay hardening.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use amari_discovery::{Catalog, RecallConfig};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+use tempfile::{NamedTempFile, TempDir};
+use walkdir::WalkDir;
+
+const GOAL: &str = "differentiate a scalar polynomial with forward dual numbers";
+const CAPABILITY: &str = "amari:amari-dual:autodiff:forward-derivative";
+const SECRET: &str = "AKIA_REPLAY_PRIVATE_7f42d119";
+
+fn fixture_source() -> &'static Path {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/rust-project"
+    ))
+}
+
+fn materialize_fixture() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let version = Catalog::embedded().unwrap().version().to_owned();
+    copy_and_transform(fixture_source(), temp.path(), &version);
+    temp
+}
+
+fn copy_and_transform(source: &Path, target: &Path, version: &str) {
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let text = name.to_string_lossy();
+        let source_path = entry.path();
+        if source_path.is_dir() {
+            let target_path = target.join(&name);
+            fs::create_dir_all(&target_path).unwrap();
+            copy_and_transform(&source_path, &target_path, version);
+        } else if text.ends_with(".in") {
+            let target_path = target.join(text.trim_end_matches(".in"));
+            let contents = fs::read_to_string(source_path).unwrap();
+            fs::write(target_path, contents.replace("__AMARI_VERSION__", version)).unwrap();
+        } else if (text == "Cargo.toml" || text == "Cargo.lock")
+            && source.join(format!("{text}.in")).exists()
+        {
+            continue;
+        } else {
+            fs::copy(source_path, target.join(name)).unwrap();
+        }
+    }
+}
+
+fn tree_contents(root: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+    let mut files = WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|entry| entry.file_type().is_file())
+        .map(|entry| {
+            (
+                entry.path().strip_prefix(root).unwrap().to_owned(),
+                fs::read(entry.path()).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    files
+}
+
+fn recommend(root: &Path) -> Value {
+    let output = Command::cargo_bin("amari")
+        .unwrap()
+        .arg("recommend")
+        .arg(root)
+        .args(["--goal", GOAL, "--json"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap()
+}
+
+fn save(value: &Value) -> NamedTempFile {
+    let file = NamedTempFile::new().unwrap();
+    serde_json::to_writer(file.as_file(), value).unwrap();
+    file
+}
+
+fn plan_command(root: &Path, artifact: &Path) -> Command {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command
+        .arg("plan")
+        .arg(CAPABILITY)
+        .arg("--recommendation")
+        .arg(artifact)
+        .arg("--project")
+        .arg(root)
+        .arg("--json");
+    command
+}
+
+fn replay(root: &Path, recommendation: &Value) -> Vec<u8> {
+    let artifact = save(recommendation);
+    plan_command(root, artifact.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone()
+}
+
+fn selected_mut(recommendation: &mut Value) -> &mut Value {
+    &mut recommendation["data"]["data"]["preferred"]
+}
+
+#[test]
+fn recommendation_replays_in_a_fresh_process_with_canonical_provenance() {
+    let fixture = materialize_fixture();
+    let before = tree_contents(fixture.path());
+    let recommendation = recommend(fixture.path());
+    let catalog = Catalog::embedded().unwrap();
+
+    assert_eq!(
+        recommendation["provenance"]["seed"],
+        json!(RecallConfig::default().seed)
+    );
+    assert_eq!(
+        recommendation["provenance"]["catalog"]["version"],
+        catalog.version()
+    );
+    assert_eq!(
+        recommendation["provenance"]["catalog"]["hash"],
+        catalog.content_hash()
+    );
+    for pointer in [
+        "/provenance/catalog/hash",
+        "/provenance/project_hash",
+        "/provenance/input_hash",
+        "/data/data/preferred/plan_hash",
+    ] {
+        let hash = recommendation.pointer(pointer).unwrap().as_str().unwrap();
+        assert_eq!(hash.len(), 64, "{pointer}");
+        assert!(hash.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    let first = replay(fixture.path(), &recommendation);
+    let second = replay(fixture.path(), &recommendation);
+    let replayed: Value = serde_json::from_slice(&first).unwrap();
+    assert_eq!(first, second);
+    assert_eq!(
+        replayed["data"],
+        recommendation["data"]["data"]["preferred"]
+    );
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn coherent_stale_hashes_are_rejected_against_current_authority() {
+    let fixture = materialize_fixture();
+    let recommendation = recommend(fixture.path());
+
+    for (field, envelope_pointer, plan_pointer) in [
+        (
+            "catalog_hash",
+            "/provenance/catalog/hash",
+            "/data/data/preferred/compatibility/catalog/hash",
+        ),
+        (
+            "project_hash",
+            "/provenance/project_hash",
+            "/data/data/preferred/compatibility/project_hash",
+        ),
+        (
+            "input_hash",
+            "/provenance/input_hash",
+            "/data/data/preferred/compatibility/input_hash",
+        ),
+    ] {
+        let mut stale = recommendation.clone();
+        *stale.pointer_mut(envelope_pointer).unwrap() = json!("0".repeat(64));
+        *stale.pointer_mut(plan_pointer).unwrap() = json!("0".repeat(64));
+        let artifact = save(&stale);
+
+        plan_command(fixture.path(), artifact.path())
+            .assert()
+            .code(2)
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(field));
+    }
+}
+
+#[test]
+fn replay_rejects_seed_tool_and_compatibility_provenance_tampering() {
+    let fixture = materialize_fixture();
+    let recommendation = recommend(fixture.path());
+
+    let cases = [
+        ("seed", "/provenance/seed", json!(1)),
+        ("seed", "/provenance/seed", Value::Null),
+        (
+            "tool_version",
+            "/provenance/tool_version",
+            json!("99.99.99"),
+        ),
+        (
+            "compatibility",
+            "/provenance/compatibility/reasons",
+            json!([SECRET]),
+        ),
+    ];
+    for (field, pointer, replacement) in cases {
+        let mut tampered = recommendation.clone();
+        *tampered.pointer_mut(pointer).unwrap() = replacement;
+        let artifact = save(&tampered);
+        plan_command(fixture.path(), artifact.path())
+            .assert()
+            .code(2)
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains(field).and(predicate::str::contains(SECRET).not()));
+    }
+}
+
+#[test]
+fn untrusted_artifact_warnings_are_not_reflected_by_replay() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommend(fixture.path());
+    recommendation["warnings"] = json!([SECRET]);
+
+    let output = replay(fixture.path(), &recommendation);
+    let value: Value = serde_json::from_slice(&output).unwrap();
+
+    assert!(!String::from_utf8(output).unwrap().contains(SECRET));
+    assert!(!value["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|warning| warning == SECRET));
+}
+
+#[test]
+fn replay_protocol_rejects_unknown_nested_fields() {
+    let fixture = materialize_fixture();
+    let mut recommendation = recommend(fixture.path());
+    selected_mut(&mut recommendation)["compatibility"]["unbounded_authority"] = json!(SECRET);
+    let artifact = save(&recommendation);
+
+    plan_command(fixture.path(), artifact.path())
+        .assert()
+        .code(9)
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("serialization").and(predicate::str::contains(SECRET).not()),
+        );
+}
+
+#[test]
+fn recommendation_and_replay_do_not_leak_sensitive_project_evidence() {
+    let fixture = materialize_fixture();
+    fs::write(
+        fixture.path().join("src/private_evidence.rs"),
+        format!("// credential marker: {SECRET}\npub fn harmless() {{}}\n"),
+    )
+    .unwrap();
+    let before = tree_contents(fixture.path());
+
+    let recommendation = recommend(fixture.path());
+    let recommendation_bytes = serde_json::to_vec(&recommendation).unwrap();
+    let replay_bytes = replay(fixture.path(), &recommendation);
+
+    for bytes in [&recommendation_bytes, &replay_bytes] {
+        let output = String::from_utf8(bytes.clone()).unwrap();
+        assert!(!output.contains(SECRET));
+        assert!(!output.contains(fixture.path().to_str().unwrap()));
+    }
+    assert_eq!(tree_contents(fixture.path()), before);
+}
+
+#[test]
+fn replay_hash_constructor_rejects_malformed_project_and_probe_hashes() {
+    let catalog = Catalog::embedded().unwrap();
+    let goal = amari_discovery::GoalSpec {
+        statement: GOAL.to_owned(),
+        constraints: Vec::new(),
+    };
+    let malformed_probe = amari_discovery::ProbeReplayHash {
+        probe_id: "amari-probe:dual:polynomial-derivative:v1".parse().unwrap(),
+        input_hash: "not-a-hash".to_owned(),
+        result_hash: "0".repeat(64),
+    };
+
+    for (project_hash, probes) in [
+        ("not-a-hash".to_owned(), Vec::new()),
+        ("0".repeat(64), vec![malformed_probe]),
+    ] {
+        assert!(amari_discovery::PlanCompatibility::from_replay_hashes(
+            &catalog,
+            project_hash,
+            &goal,
+            probes,
+        )
+        .is_err());
+    }
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -54,6 +54,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "cli_recommend_ts",
         "plan_normalization",
         "planner_graph",
+        "planner_limits",
         "planner_ranking",
         "planner_recall",
         "probe_cgt",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -56,6 +56,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "planner_graph",
         "planner_limits",
         "planner_ranking",
+        "planner_replay",
         "planner_recall",
         "probe_cgt",
         "probe_core",


### PR DESCRIPTION
## Summary

Completes discovery hardening Tasks 25A–25B for the 0.24.0 plan.

### Task 25A — planner limits and domain outcomes (`5e2a042`)

- enforces non-bypassable graph ceilings (64 retained nodes, depth 16)
- enforces non-bypassable normalization ceilings (64 plan steps, 4,096 rewrites)
- rejects zero/oversized configurations with typed errors
- rejects unknown planner-limit and domain-outcome fields
- preserves deterministic partial graph paths and typed limit evidence
- locks `NoApplicableCapability`, `InsufficientEvidence`, and `Blocked` as successful typed values
- assigns `planner_limits` to the exhaustive planner CI shard

### Task 25B — provenance and replay hardening (`9e7262a`)

- binds replay to current tool version, deterministic recall seed, catalog identity, project hash, input hash, and probe hashes
- validates lowercase SHA-256 structure before comparing or reporting hash values
- rejects coherent stale/tampered provenance against current catalog/project authority
- re-derives compatibility, warnings, provenance, and normalized plan output instead of reflecting untrusted artifact fields
- prevents saved warning/compatibility/source evidence from leaking through replay output or errors
- rejects unknown fields throughout the versioned protocol DTO hierarchy
- validates saved probe input hashes for recommendation/replay compatibility
- adds fresh-process recommendation → plan replay, tamper, privacy, and deterministic-byte coverage
- assigns `planner_replay` to the exhaustive planner CI shard

## Review

Independent DeepSeek review: **APPROVE**, no Critical or Important defects. A focused re-review after the comparator naming/seed-null follow-up also returned **APPROVE**.

## Verification

Passed from a clean worktree at `9e7262a8286aa06c89d88a0544a1bfe3ef430f38`:

- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- `cargo fmt --all -- --check`
- `python3 scripts/run-discovery-test-shard.py --verify` (54 targets, unique/exhaustive)
- `python3 scripts/verify-discovery-ci-sharding.py`
- `python3 scripts/verify-amari-binary-owner.py`
- `python3 scripts/verify-publish-order.py`
- `git diff --check origin/develop...HEAD`

The repository-wide pre-commit hook still encounters the documented unrelated `amari-core/src/generic.rs` `clippy::needless-range-loop` warnings; both scoped discovery Clippy matrices above pass with warnings denied.
