### PR TITLE
test: harden discovery probe framing and output

### DIFF
--- a/amari-discovery/Cargo.toml
+++ b/amari-discovery/Cargo.toml
@@ -65,4 +65,5 @@ ai = []
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+proptest = "1.4"
 tempfile = "3"

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -51,6 +51,7 @@ use crate::{
 
 /// Caller-selected ceilings for cooperative in-process probe execution.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProbeEngineLimits {
     /// Maximum canonical request JSON bytes.
     pub max_input_bytes: u64,
@@ -88,6 +89,7 @@ pub enum ProbeIsolation {
 
 /// Deterministic mathematical output and resource accounting from one probe.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProbeExecution {
     /// Stable executed probe ID.
     pub probe_id: ProbeId,

--- a/amari-discovery/src/probes/supervisor.rs
+++ b/amari-discovery/src/probes/supervisor.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const MAX_WORKER_STDERR_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct SupervisorIoLimits {
@@ -95,6 +96,13 @@ fn neutral_working_directory() -> PathBuf {
     temporary.canonicalize().unwrap_or(temporary)
 }
 
+fn production_io_limits() -> SupervisorIoLimits {
+    SupervisorIoLimits {
+        max_stdout_bytes: worker::MAX_ENCODED_FRAME_BYTES,
+        max_stderr_bytes: MAX_WORKER_STDERR_BYTES,
+    }
+}
+
 pub(super) fn execute_isolated(
     probe_id: &ProbeId,
     input: &serde_json::Value,
@@ -110,10 +118,7 @@ pub(super) fn execute_isolated(
             limits,
             provenance,
         },
-        SupervisorIoLimits {
-            max_stdout_bytes: 2 * 1024 * 1024,
-            max_stderr_bytes: 64 * 1024,
-        },
+        production_io_limits(),
         Duration::from_millis(defaults.probe_timeout_millis),
     )?;
     Ok(response.execution)
@@ -520,6 +525,23 @@ mod tests {
     }
 
     #[test]
+    fn production_stdout_limit_includes_the_frame_header() {
+        let limits = production_io_limits();
+        assert_eq!(limits.max_stdout_bytes, worker::MAX_ENCODED_FRAME_BYTES);
+        let launcher = TestWorkerLauncher::new(fixture_path(), "max-frame");
+        let captured = capture_bounded(
+            spawn_restricted(&launcher).unwrap(),
+            limits,
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        assert!(captured.status.success());
+        assert!(captured.stderr.is_empty());
+        assert_eq!(captured.stdout.len(), worker::MAX_ENCODED_FRAME_BYTES);
+    }
+
+    #[test]
     fn stdout_flood_exceeding_cap_terminates_the_worker() {
         let started = Instant::now();
         let launcher = TestWorkerLauncher::new(fixture_path(), "flood-stdout");
@@ -678,5 +700,45 @@ mod tests {
         assert!(
             matches!(error, crate::DiscoveryError::ProbeWorkerProtocol(message) if message.contains("provenance"))
         );
+    }
+
+    #[test]
+    fn successful_response_rejects_unknown_top_level_fields() {
+        let error = run_fixture("extra-response-field").unwrap_err();
+        assert!(matches!(
+            error,
+            crate::DiscoveryError::ProbeWorkerProtocol(message)
+                if message.contains("serialization")
+        ));
+    }
+
+    #[test]
+    fn successful_response_rejects_unknown_execution_fields() {
+        let error = run_fixture("extra-execution-field").unwrap_err();
+        assert!(matches!(
+            error,
+            crate::DiscoveryError::ProbeWorkerProtocol(message)
+                if message.contains("serialization")
+        ));
+    }
+
+    #[test]
+    fn repeated_crashes_and_protocol_failures_do_not_poison_recovery() {
+        for mode in ["crash", "nonzero", "malformed"]
+            .into_iter()
+            .cycle()
+            .take(9)
+        {
+            assert!(run_fixture(mode).is_err());
+            let recovered = run_fixture("valid").unwrap();
+            assert_eq!(
+                recovered.execution.output,
+                serde_json::json!({"fixture": true})
+            );
+            assert_eq!(
+                recovered.execution.isolation,
+                super::super::ProbeIsolation::Process
+            );
+        }
     }
 }

--- a/amari-discovery/src/probes/worker.rs
+++ b/amari-discovery/src/probes/worker.rs
@@ -11,7 +11,8 @@ use super::{ProbeEngine, ProbeEngineLimits, ProbeExecution};
 use crate::{DiscoveryError, DiscoveryResult, ProbeId, Provenance};
 
 const FRAME_HEADER_BYTES: usize = 4;
-const MAX_FRAME_BYTES: usize = 2 * 1024 * 1024;
+pub(super) const MAX_FRAME_BYTES: usize = 2 * 1024 * 1024;
+pub(super) const MAX_ENCODED_FRAME_BYTES: usize = FRAME_HEADER_BYTES + MAX_FRAME_BYTES;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -23,6 +24,7 @@ pub(super) struct WorkerRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct WorkerResponse {
     pub(super) provenance: Provenance,
     pub(super) execution: ProbeExecution,

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -12,8 +12,8 @@ use crate::{
         probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult},
     },
     CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
-    NdjsonWriter, PlanStep, ProbeIsolation, ProjectKind, ProjectSnapshot, ProtocolSchema,
-    Recommendation, SchemaCatalog,
+    NdjsonWriter, PlanStep, ProbeBackend, ProbeIsolation, ProjectKind, ProjectSnapshot,
+    ProtocolSchema, Recommendation, SchemaCatalog,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -216,17 +216,70 @@ pub(crate) fn write_probe_run_human(
     envelope: &Envelope<ProbeRunResult>,
 ) -> DiscoveryResult<()> {
     let run = &envelope.data;
-    writeln!(writer, "Probe: {}", run.result.probe_id)?;
+    let result = &run.result;
+    writeln!(writer, "Probe: {}", result.probe_id)?;
+    writeln!(writer, "Input schema: {}", run.input_schema)?;
+    writeln!(writer, "Output schema: {}", run.output_schema)?;
+    writeln!(writer, "Backend: {}", backend_name(result.backend))?;
     writeln!(writer, "Isolation: {}", isolation_name(run.isolation))?;
+    writeln!(writer, "Deterministic: {}", yes_no(run.deterministic))?;
     writeln!(writer, "Hard timeout: {}", yes_no(run.hard_timeout))?;
     writeln!(writer, "Crash isolation: {}", yes_no(run.crash_isolation))?;
-    writeln!(writer, "Duration (micros): {}", run.result.duration_micros)?;
+    writeln!(writer, "Timeout (millis): {}", run.timeout_millis)?;
+    writeln!(writer, "Duration (micros): {}", result.duration_micros)?;
+    writeln!(writer, "Resources:")?;
+    writeln!(writer, "  operations: {}", result.resources.operations)?;
+    writeln!(writer, "  nodes: {}", result.resources.nodes)?;
+    writeln!(writer, "  iterations: {}", result.resources.iterations)?;
+    writeln!(writer, "  bytes: {}", result.resources.bytes)?;
+    writeln!(writer, "Tool version: {}", envelope.provenance.tool_version)?;
     writeln!(
         writer,
-        "Result: {}",
-        serde_json::to_string(&run.result.output)?
+        "Catalog version: {}",
+        envelope.provenance.catalog.version
     )?;
+    writeln!(writer, "Catalog hash: {}", result.catalog_hash)?;
+    writeln!(
+        writer,
+        "Project hash: {}",
+        result.project_hash.as_deref().unwrap_or("none")
+    )?;
+    writeln!(writer, "Input hash: {}", result.input_hash)?;
+    match result.seed {
+        Some(seed) => writeln!(writer, "Seed: {seed}")?,
+        None => writeln!(writer, "Seed: none")?,
+    }
+    write_string_items(
+        writer,
+        "Validated assumptions",
+        &result.validated_assumptions,
+    )?;
+    write_string_items(writer, "Refuted assumptions", &result.refuted_assumptions)?;
+    write_string_items(writer, "Warnings", &result.warnings)?;
+    writeln!(writer, "Result: {}", serde_json::to_string(&result.output)?)?;
     Ok(())
+}
+
+fn write_string_items(
+    writer: &mut impl Write,
+    label: &str,
+    items: &[String],
+) -> DiscoveryResult<()> {
+    writeln!(writer, "{label}:")?;
+    if items.is_empty() {
+        writeln!(writer, "  none")?;
+    } else {
+        for item in items {
+            writeln!(writer, "  {item}")?;
+        }
+    }
+    Ok(())
+}
+
+const fn backend_name(backend: ProbeBackend) -> &'static str {
+    match backend {
+        ProbeBackend::Cpu => "cpu",
+    }
 }
 
 fn isolation_name(isolation: ProbeIsolation) -> &'static str {

--- a/amari-discovery/tests/fixtures/probe-test-worker.py
+++ b/amari-discovery/tests/fixtures/probe-test-worker.py
@@ -65,6 +65,22 @@ def main() -> int:
         response["provenance"]["input_hash"] = "wrong-input"
         write_frame(response)
         return 0
+    if mode == "extra-response-field":
+        response = success_response()
+        response["unbounded_authority"] = True
+        write_frame(response)
+        return 0
+    if mode == "extra-execution-field":
+        response = success_response()
+        response["execution"]["unbounded_authority"] = True
+        write_frame(response)
+        return 0
+    if mode == "max-frame":
+        frame_bytes = 2 * 1024 * 1024
+        sys.stdout.buffer.write(struct.pack(">I", frame_bytes))
+        sys.stdout.buffer.write(b"x" * frame_bytes)
+        sys.stdout.buffer.flush()
+        return 0
     if mode == "malformed":
         sys.stdout.buffer.write(struct.pack(">I", 8) + b"not-json")
         sys.stdout.buffer.flush()

--- a/amari-discovery/tests/golden/probe-output/probe-error-failed-human.txt
+++ b/amari-discovery/tests/golden/probe-output/probe-error-failed-human.txt
@@ -1,0 +1,1 @@
+probe_failed: probe worker exited with code 6

--- a/amari-discovery/tests/golden/probe-output/probe-error-failed.json
+++ b/amari-discovery/tests/golden/probe-output/probe-error-failed.json
@@ -1,0 +1,7 @@
+{
+  "details": {
+    "exit_code": 6
+  },
+  "kind": "probe_failed",
+  "message": "probe worker exited with code 6"
+}

--- a/amari-discovery/tests/golden/probe-output/probe-error-invalid-human.txt
+++ b/amari-discovery/tests/golden/probe-output/probe-error-invalid-human.txt
@@ -1,0 +1,1 @@
+invalid_input: invalid input: unknown probe `amari-probe:tropical:does-not-exist:v1`

--- a/amari-discovery/tests/golden/probe-output/probe-error-invalid.json
+++ b/amari-discovery/tests/golden/probe-output/probe-error-invalid.json
@@ -1,0 +1,7 @@
+{
+  "details": {
+    "exit_code": 2
+  },
+  "kind": "invalid_input",
+  "message": "invalid input: unknown probe `amari-probe:tropical:does-not-exist:v1`"
+}

--- a/amari-discovery/tests/golden/probe-output/probe-run-human.txt
+++ b/amari-discovery/tests/golden/probe-output/probe-run-human.txt
@@ -1,0 +1,28 @@
+Probe: amari-probe:tropical:viterbi:v1
+Input schema: amari.discovery/probe/tropical-viterbi/input/v1
+Output schema: amari.discovery/probe/tropical-viterbi/output/v1
+Backend: cpu
+Isolation: process
+Deterministic: yes
+Hard timeout: yes
+Crash isolation: yes
+Timeout (millis): 5000
+Duration (micros): <duration_micros>
+Resources:
+  operations: 14
+  nodes: 14
+  iterations: 3
+  bytes: 131
+Tool version: <tool_version>
+Catalog version: <catalog_version>
+Catalog hash: <catalog_hash>
+Project hash: none
+Input hash: 75453f57577a95c3134328e04aa4db014d7561cd3e67414bdaf01b875b56d723
+Seed: none
+Validated assumptions:
+  none
+Refuted assumptions:
+  none
+Warnings:
+  none
+Result: {"path":[0,0,0],"score":-7.0}

--- a/amari-discovery/tests/golden/probe-output/probe-run.json
+++ b/amari-discovery/tests/golden/probe-output/probe-run.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "crash_isolation": true,
+    "deterministic": true,
+    "hard_timeout": true,
+    "input_schema": "amari.discovery/probe/tropical-viterbi/input/v1",
+    "isolation": "process",
+    "output_schema": "amari.discovery/probe/tropical-viterbi/output/v1",
+    "result": {
+      "backend": "cpu",
+      "catalog_hash": "<catalog_hash>",
+      "duration_micros": 0,
+      "input_hash": "75453f57577a95c3134328e04aa4db014d7561cd3e67414bdaf01b875b56d723",
+      "output": {
+        "path": [
+          0,
+          0,
+          0
+        ],
+        "score": -7.0
+      },
+      "probe_id": "amari-probe:tropical:viterbi:v1",
+      "project_hash": null,
+      "refuted_assumptions": [],
+      "resources": {
+        "bytes": 131,
+        "iterations": 3,
+        "nodes": 14,
+        "operations": 14
+      },
+      "seed": null,
+      "validated_assumptions": [],
+      "warnings": []
+    },
+    "timeout_millis": 5000
+  },
+  "provenance": {
+    "catalog": {
+      "hash": "<catalog_hash>",
+      "version": "<catalog_version>"
+    },
+    "compatibility": {
+      "reasons": [],
+      "status": "compatible"
+    },
+    "input_hash": "75453f57577a95c3134328e04aa4db014d7561cd3e67414bdaf01b875b56d723",
+    "project_hash": null,
+    "replay": {
+      "reasons": [],
+      "replayable": true,
+      "required_hashes": [
+        "catalog_hash",
+        "input_hash"
+      ]
+    },
+    "seed": null,
+    "tool_version": "<tool_version>"
+  },
+  "schema_version": "amari.discovery/v1",
+  "warnings": []
+}

--- a/amari-discovery/tests/probe_framing.rs
+++ b/amari-discovery/tests/probe_framing.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Property-oriented hidden-worker framing and boundary hardening.
+
+#![cfg(feature = "standard-probes")]
+
+use amari_discovery::{Catalog, ProbeEngine, ProbeEngineLimits};
+use assert_cmd::Command;
+use predicates::prelude::*;
+use proptest::prelude::*;
+use serde_json::{json, Value};
+
+const MAX_FRAME_BYTES: u32 = 2 * 1024 * 1024;
+const VITERBI_PROBE: &str = "amari-probe:tropical:viterbi:v1";
+
+fn input() -> Value {
+    json!({
+        "transitions": [[-1.0, -2.0], [-2.0, -1.0]],
+        "emissions": [[-1.0, -3.0], [-3.0, -1.0]],
+        "observations": [0, 1, 0]
+    })
+}
+
+fn request_with_limits(limits: ProbeEngineLimits) -> Value {
+    let catalog = Catalog::embedded().unwrap();
+    json!({
+        "probe_id": VITERBI_PROBE,
+        "input": input(),
+        "limits": limits,
+        "provenance": {
+            "tool_version": env!("CARGO_PKG_VERSION"),
+            "catalog": {
+                "version": catalog.version(),
+                "hash": catalog.content_hash()
+            },
+            "compatibility": {"status": "compatible", "reasons": []},
+            "replay": {
+                "replayable": true,
+                "required_hashes": ["catalog_hash", "input_hash"],
+                "reasons": []
+            },
+            "project_hash": null,
+            "input_hash": "fixture-worker-input-hash",
+            "seed": null
+        }
+    })
+}
+
+fn frame_body(body: &[u8]) -> Vec<u8> {
+    let length = u32::try_from(body.len()).unwrap();
+    let mut frame = length.to_be_bytes().to_vec();
+    frame.extend_from_slice(body);
+    frame
+}
+
+fn frame(value: &Value) -> Vec<u8> {
+    frame_body(&serde_json::to_vec(value).unwrap())
+}
+
+fn run_worker(stdin: &[u8]) -> assert_cmd::assert::Assert {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command
+        .arg("__probe-worker")
+        .write_stdin(stdin.to_vec())
+        .assert()
+}
+
+fn decode_frame(bytes: &[u8]) -> Value {
+    let length = u32::from_be_bytes(bytes[..4].try_into().unwrap()) as usize;
+    assert_eq!(bytes.len(), length + 4);
+    serde_json::from_slice(&bytes[4..]).unwrap()
+}
+
+fn malformed_frames() -> impl Strategy<Value = Vec<u8>> {
+    prop_oneof![
+        proptest::collection::vec(any::<u8>(), 0..4),
+        proptest::collection::vec(any::<u8>(), 0..256).prop_map(|body| {
+            let declared = u32::try_from(body.len() + 1).unwrap();
+            let mut frame = declared.to_be_bytes().to_vec();
+            frame.extend_from_slice(&body);
+            frame
+        }),
+        proptest::collection::vec(any::<u8>(), 0..256).prop_map(|tail| {
+            let mut body = vec![0xff];
+            body.extend_from_slice(&tail);
+            frame_body(&body)
+        }),
+        proptest::collection::vec(any::<u8>(), 1..64).prop_map(|trailing| {
+            let mut frame = frame_body(b"{}");
+            frame.extend_from_slice(&trailing);
+            frame
+        }),
+        Just(0_u32.to_be_bytes().to_vec()),
+        Just((MAX_FRAME_BYTES + 1).to_be_bytes().to_vec()),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn arbitrary_malformed_frames_fail_without_stdout(frame in malformed_frames()) {
+        run_worker(&frame)
+            .failure()
+            .stdout(predicate::str::is_empty());
+    }
+}
+
+#[test]
+fn deeply_nested_and_oversized_json_are_rejected_with_typed_errors() {
+    let mut nested = Value::Null;
+    for _ in 0..160 {
+        nested = Value::Array(vec![nested]);
+    }
+    let mut deep_request = request_with_limits(ProbeEngineLimits::default());
+    deep_request["input"] = nested;
+    run_worker(&frame(&deep_request))
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("serialization"));
+
+    let mut oversized_input = request_with_limits(ProbeEngineLimits::default());
+    oversized_input["input"] = json!("x".repeat(1_048_576));
+    run_worker(&frame(&oversized_input))
+        .failure()
+        .code(7)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("input bytes"));
+}
+
+#[test]
+fn exact_operation_node_iteration_and_input_limits_pass_but_one_less_fails() {
+    let direct = ProbeEngine::new()
+        .unwrap()
+        .execute(&VITERBI_PROBE.parse().unwrap(), &input())
+        .unwrap();
+    let input_bytes = u64::try_from(serde_json::to_vec(&input()).unwrap().len()).unwrap();
+    assert!(direct.resources.operations > 0);
+    assert!(direct.resources.nodes > 0);
+    assert!(direct.resources.iterations > 0);
+
+    let exact = ProbeEngineLimits {
+        max_input_bytes: input_bytes,
+        max_operations: direct.resources.operations,
+        max_nodes: direct.resources.nodes,
+        max_iterations: direct.resources.iterations,
+        ..ProbeEngineLimits::default()
+    };
+    let output = run_worker(&frame(&request_with_limits(exact)))
+        .success()
+        .stderr(predicate::str::is_empty())
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        decode_frame(&output)["execution"]["resources"],
+        json!(direct.resources)
+    );
+
+    for tightened in 1_u8..16 {
+        let limits = ProbeEngineLimits {
+            max_input_bytes: input_bytes - u64::from(tightened & 0b0001 != 0),
+            max_operations: direct.resources.operations - u64::from(tightened & 0b0010 != 0),
+            max_nodes: direct.resources.nodes - u64::from(tightened & 0b0100 != 0),
+            max_iterations: direct.resources.iterations - u64::from(tightened & 0b1000 != 0),
+            ..exact
+        };
+        run_worker(&frame(&request_with_limits(limits)))
+            .failure()
+            .code(7)
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains("limit_exceeded"));
+    }
+}
+
+#[test]
+fn nested_limit_authority_and_unknown_probe_ids_are_rejected() {
+    let mut unknown_limit = request_with_limits(ProbeEngineLimits::default());
+    unknown_limit["limits"]["unbounded"] = json!(true);
+    run_worker(&frame(&unknown_limit))
+        .failure()
+        .code(9)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("serialization"));
+
+    let mut unknown_probe = request_with_limits(ProbeEngineLimits::default());
+    unknown_probe["probe_id"] = json!("amari-probe:tropical:unknown:v1");
+    run_worker(&frame(&unknown_probe))
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("unknown probe"));
+}
+
+#[test]
+fn repeated_malformed_requests_do_not_poison_a_later_valid_worker() {
+    for _ in 0..8 {
+        run_worker(&[0, 0, 0])
+            .failure()
+            .stdout(predicate::str::is_empty());
+    }
+
+    run_worker(&frame(&request_with_limits(ProbeEngineLimits::default())))
+        .success()
+        .stderr(predicate::str::is_empty());
+}

--- a/amari-discovery/tests/probe_output.rs
+++ b/amari-discovery/tests/probe_output.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Golden probe success/error output contracts across human and machine modes.
+
+#![cfg(feature = "standard-probes")]
+
+use std::{fs, process::Output};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
+const UNKNOWN: &str = "amari-probe:tropical:does-not-exist:v1";
+
+const RUN_JSON: &str = include_str!("golden/probe-output/probe-run.json");
+const RUN_HUMAN: &str = include_str!("golden/probe-output/probe-run-human.txt");
+const INVALID_JSON: &str = include_str!("golden/probe-output/probe-error-invalid.json");
+const INVALID_HUMAN: &str = include_str!("golden/probe-output/probe-error-invalid-human.txt");
+const FAILED_JSON: &str = include_str!("golden/probe-output/probe-error-failed.json");
+const FAILED_HUMAN: &str = include_str!("golden/probe-output/probe-error-failed-human.txt");
+
+fn viterbi_input() -> Value {
+    json!({
+        "transitions": [[-1.0, -2.0], [-2.0, -1.0]],
+        "emissions": [[-1.0, -3.0], [-3.0, -1.0]],
+        "observations": [0, 1, 0]
+    })
+}
+
+fn non_finite_result_input() -> Value {
+    json!({
+        "transitions": [[1.7e308]],
+        "emissions": [[1.7e308]],
+        "observations": [0, 0]
+    })
+}
+
+fn write_input(directory: &TempDir, name: &str, value: &Value) -> std::path::PathBuf {
+    let path = directory.path().join(name);
+    fs::write(&path, serde_json::to_vec(value).unwrap()).unwrap();
+    path
+}
+
+fn probe_run(path: &std::path::Path, mode: Option<&str>) -> Output {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command.args(["probe", "run", VITERBI, "--input"]).arg(path);
+    if let Some(mode) = mode {
+        command.arg(mode);
+    }
+    command.output().unwrap()
+}
+
+fn probe_describe_unknown(mode: Option<&str>) -> Output {
+    let mut command = Command::cargo_bin("amari").unwrap();
+    command.args(["probe", "describe", UNKNOWN]);
+    if let Some(mode) = mode {
+        command.arg(mode);
+    }
+    command.output().unwrap()
+}
+
+fn pretty_json(bytes: &[u8]) -> String {
+    let value: Value = serde_json::from_slice(bytes).unwrap();
+    format!("{}\n", serde_json::to_string_pretty(&value).unwrap())
+}
+
+fn normalize_success_json(bytes: &[u8]) -> (String, Value) {
+    let mut value: Value = serde_json::from_slice(bytes).unwrap();
+    value["provenance"]["tool_version"] = json!("<tool_version>");
+    value["provenance"]["catalog"]["version"] = json!("<catalog_version>");
+    value["provenance"]["catalog"]["hash"] = json!("<catalog_hash>");
+    value["data"]["result"]["catalog_hash"] = json!("<catalog_hash>");
+    value["data"]["result"]["duration_micros"] = json!(0);
+    (
+        format!("{}\n", serde_json::to_string_pretty(&value).unwrap()),
+        value,
+    )
+}
+
+fn normalize_human(bytes: &[u8]) -> String {
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    let mut normalized = String::new();
+    for line in text.lines() {
+        if line.starts_with("Duration (micros): ") {
+            normalized.push_str("Duration (micros): <duration_micros>\n");
+        } else if line.starts_with("Tool version: ") {
+            normalized.push_str("Tool version: <tool_version>\n");
+        } else if line.starts_with("Catalog version: ") {
+            normalized.push_str("Catalog version: <catalog_version>\n");
+        } else if line.starts_with("Catalog hash: ") {
+            normalized.push_str("Catalog hash: <catalog_hash>\n");
+        } else {
+            normalized.push_str(line);
+            normalized.push('\n');
+        }
+    }
+    normalized
+}
+
+#[test]
+fn successful_probe_human_json_and_ndjson_match_goldens_and_each_other() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = write_input(&temporary, "viterbi.json", &viterbi_input());
+
+    let human = probe_run(&input, None);
+    assert!(human.status.success());
+    assert!(human.stderr.is_empty());
+    assert_eq!(normalize_human(&human.stdout), RUN_HUMAN);
+
+    let json_output = probe_run(&input, Some("--json"));
+    let ndjson_output = probe_run(&input, Some("--ndjson"));
+    for output in [&json_output, &ndjson_output] {
+        assert!(output.status.success());
+        assert!(output.stderr.is_empty());
+        assert_eq!(
+            output.stdout.iter().filter(|byte| **byte == b'\n').count(),
+            1
+        );
+    }
+
+    let (json_normalized, json_value) = normalize_success_json(&json_output.stdout);
+    let (ndjson_normalized, ndjson_value) = normalize_success_json(&ndjson_output.stdout);
+    assert_eq!(json_normalized, RUN_JSON);
+    assert_eq!(ndjson_normalized, RUN_JSON);
+    assert_eq!(json_value, ndjson_value);
+
+    assert_eq!(json_value["schema_version"], "amari.discovery/v1");
+    assert_eq!(json_value["data"]["isolation"], "process");
+    assert_eq!(json_value["data"]["hard_timeout"], true);
+    assert_eq!(json_value["data"]["crash_isolation"], true);
+    assert!(json_value["provenance"]["catalog"]["hash"].is_string());
+    assert!(json_value["provenance"]["input_hash"].is_string());
+    assert!(json_value["data"]["result"]["validated_assumptions"].is_array());
+    assert!(json_value["data"]["result"]["refuted_assumptions"].is_array());
+}
+
+#[test]
+fn invalid_probe_error_has_golden_exit_stream_and_machine_contracts() {
+    let human = probe_describe_unknown(None);
+    assert_eq!(human.status.code(), Some(2));
+    assert!(human.stdout.is_empty());
+    assert_eq!(String::from_utf8(human.stderr).unwrap(), INVALID_HUMAN);
+
+    for mode in ["--json", "--ndjson"] {
+        let output = probe_describe_unknown(Some(mode));
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            output.stderr.iter().filter(|byte| **byte == b'\n').count(),
+            1
+        );
+        assert_eq!(pretty_json(&output.stderr), INVALID_JSON);
+    }
+}
+
+#[test]
+fn failed_probe_error_has_golden_exit_stream_and_machine_contracts() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = write_input(
+        &temporary,
+        "non-finite-result.json",
+        &non_finite_result_input(),
+    );
+
+    let human = probe_run(&input, None);
+    assert_eq!(human.status.code(), Some(6));
+    assert!(human.stdout.is_empty());
+    assert_eq!(String::from_utf8(human.stderr).unwrap(), FAILED_HUMAN);
+
+    for mode in ["--json", "--ndjson"] {
+        let output = probe_run(&input, Some(mode));
+        assert_eq!(output.status.code(), Some(6));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            output.stderr.iter().filter(|byte| **byte == b'\n').count(),
+            1
+        );
+        assert_eq!(pretty_json(&output.stderr), FAILED_JSON);
+    }
+}

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -66,6 +66,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_holographic",
         "probe_network",
         "probe_optimization",
+        "probe_output",
         "probe_rewrite_infer",
         "probe_rewrite_normalize",
         "probe_rewrite_predecessors",

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -62,6 +62,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
         "probe_core",
         "probe_dual",
         "probe_engine",
+        "probe_framing",
         "probe_holographic",
         "probe_network",
         "probe_optimization",


### PR DESCRIPTION
## Summary

Completes discovery hardening Tasks 26A–26B for the 0.24.0 plan.

### Task 26A — worker framing and boundary hardening (`df293e0`)

- adds property-oriented malformed-frame coverage for truncated headers/bodies, invalid JSON, trailing bytes, empty frames, and oversized frames
- covers deeply nested JSON and oversized typed inputs
- verifies exact resource ceilings pass and all 15 operation/node/iteration/input limit-tightening combinations fail safely
- rejects unknown nested limit authority and unknown probes
- makes `ProbeEngineLimits`, `ProbeExecution`, and worker responses reject unknown fields
- aligns the production stdout cap with the full 4-byte-header + 2 MiB body frame bound
- covers stdout/stderr flooding, strict response decoding, and repeated crash/protocol-failure recovery
- keeps process isolation truthful only after response and provenance validation

### Task 26B — probe and error output goldens (`83de91a`)

- adds normalized human/JSON/NDJSON success goldens
- adds invalid-input (exit 2) and isolated probe-failure (exit 6) error goldens
- locks stdout/stderr separation and one-record machine output
- locks provenance, process guarantees, schemas, backend, resources, timeout, input/catalog hashes, and result output
- locks validated/refuted assumption and warning fields
- expands human probe output to a transparent projection of machine output
- assigns both new integration targets exactly once in the discovery planner shard

## Review

Independent DeepSeek review: **APPROVE**, with no Critical or Important findings.

## Verification

Passed from a clean worktree at `83de91a47661c704a03f1949f0f47b2f6ccf4ee0`:

- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- `cargo clippy -p amari-discovery --all-targets --all-features -- -D warnings`
- `cargo clippy -p amari-discovery --all-targets --no-default-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery --all-features --no-deps`
- `cargo fmt --all -- --check`
- `python3 scripts/run-discovery-test-shard.py --verify` (56 targets, unique/exhaustive)
- `python3 scripts/verify-discovery-ci-sharding.py`
- `python3 scripts/verify-amari-binary-owner.py`
- `python3 scripts/verify-publish-order.py`
- `git diff --check origin/develop...HEAD`

The repository-wide hook retains the documented unrelated `amari-core/src/generic.rs` `clippy::needless-range-loop` warnings; both scoped discovery Clippy matrices above pass with warnings denied.
