### PR TITLE
docs: complete discovery release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - Unreleased
+
+### Added
+
+#### New crate: `amari-discovery`
+
+- Sole workspace owner of the installed `amari` command, replacing the root-package placeholder binary
+- Generated Rust API index, authoritative WASM declaration surface, curated semantic capabilities, relationships, examples, and declarative probe descriptors
+- Progressive `discover search`, `detail`, `graph`, and `example` catalog commands
+- Deterministic, bounded, read-only Rust/Cargo and npm TypeScript project inspection with typed partial outcomes and privacy-preserving evidence
+- Frozen holographic candidate recall, bounded capability-graph expansion, Pareto ranking, and normalized replayable plans
+- Registered bounded probes across geometric algebra, tropical algebra, dual numbers, networks, optimization, holographic memory, CGT, exact rational surreal/surcomplex arithmetic, and rewriting
+- Restricted process-isolated public probe execution with strict framed worker protocol, fixed launch authority, bounded concurrent output drains, deadlines, kill/reap handling, and validated provenance
+- Shared human, versioned JSON, and NDJSON contracts; interactive and machine shell modes; curated protocol schemas; stable structured errors and exit codes
+- Optional provider-neutral `ai` validation contract without a concrete provider, subprocess transport, network client, or execution authority
+
+### Changed
+
+- `BindingAlgebra` now provides canonical additive `superpose` and coefficient `scale` operations; FHRR overrides preserve its complete coefficient representation
+- Discovery planning uses additive holographic superposition rather than attention/cleanup bundling
+
+### Security
+
+- Inspection does not execute Cargo, rustc, npm, Node.js, build scripts, lifecycle scripts, project code, arbitrary shell commands, providers, or network requests
+- Traversal, parsing, planning, replay, probes, worker framing, output, and evidence are bounded and hardened against path escapes, untrusted artifact reflection, source/secret leakage, and authority smuggling
+
+### Documentation
+
+- Added `docs/guide/amari-discovery.md` and expanded `amari-discovery/README.md` with human, agent, contributor, protocol, privacy, AI, probe, and release workflows
+
+> Release status: 0.24.0 remains unreleased. The separately approved
+> `amari-rewrite` expansion, aggregate version bump, catalog regeneration,
+> registry-resolution checks, package/publish dry-runs, and post-publication
+> installation gates must complete before release acceptance.
+
+---
+
 ## [0.23.0] - Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ A unified mathematical computing library featuring geometric algebra, differenti
 - **Arbitrary-signature WASM** — `WasmGenericMultivector(p, q, r)` lets users select any Clifford algebra signature at runtime. Operations for DIM ≤ 6 dispatch through a compile-time match table (84 signatures); larger dimensions fall back to a cached Cayley-table path. 8 fast-path aliases (`WasmMultivector300`, `210`, `310`, `200`, `030`, `410`, `500`, `110`) provide pre-built convenience for the most common physics/engineering signatures.
 - **`amari-rewrite`** is a new crate providing foundational ARS/TRS term-rewriting with `Rewritable` traits, path replacement, substitution/matching, bounded inverse rewriting, anti-unification, and rule inference scaffolding. Experimental `neural`, `smt`, and `amari-network` feature gates offer rewrite-search guidance hooks.
 
+## v0.24.0 Development Preview: Amari Discovery
+
+The unreleased `amari-discovery` crate is the sole owner of the installed
+`amari` command. It provides deterministic catalog exploration, bounded
+read-only Rust/Cargo and npm TypeScript inspection, holographic candidate
+recall, Pareto ranking, replayable integration plans, registered mathematical
+probes, and shared human/JSON/NDJSON contracts.
+
+From a source checkout, install and inspect the available surface with:
+
+```bash
+cargo install --path amari-discovery
+amari capabilities
+amari discover search tropical
+amari inspect .
+```
+
+Discovery never edits inspected projects or runs their compilers, build
+scripts, lifecycle scripts, arbitrary commands, providers, or network access.
+See the [Amari Discovery Guide](docs/guide/amari-discovery.md) for the human and
+agent loops, privacy boundary, probe isolation, catalog maintenance, and
+release-status caveats. This preview is not a 0.24.0 publication claim; the
+workspace remains at 0.23.0 until aggregate release acceptance.
+
 ## v0.22.0 Highlights
 
 - **`amari-cgt`** is now a first-class short combinatorial game theory crate with arena-backed games, canonicalization, outcome/comparison helpers, nimbers, bounded/exact layer generation, and growth-reporting utilities.
@@ -999,6 +1023,7 @@ The library is optimized for high-performance applications:
 - **[API Reference](examples/DOCUMENTATION.md)**: Detailed API documentation
 - **[Migration Guide](docs/archive/MIGRATION_v0.12.0.md)**: Migrating from v0.11.x to v0.12.0+
 - **[Changelog](CHANGELOG.md)**: Version history and changes
+- **[Amari Discovery Guide](docs/guide/amari-discovery.md)**: Human and agent discovery, planning, probes, safety, and contributor workflows
 - **[docs.rs](https://docs.rs/amari)**: Complete API reference
 
 ## Contributing

--- a/amari-discovery/README.md
+++ b/amari-discovery/README.md
@@ -1,14 +1,156 @@
 # amari-discovery
 
-`amari-discovery` is the agent-first discovery and planning runtime for the
-Amari mathematical ecosystem. It installs the `amari` command.
+`amari-discovery` is the deterministic, offline-first discovery and planning
+runtime for the Amari mathematical ecosystem. It is the sole workspace owner
+of the installed `amari` command.
 
-The command is designed to inspect Rust and JavaScript/TypeScript projects,
-find relevant Amari capabilities, produce replayable integration plans, and
-run registered bounded probes. It does not edit inspected projects or execute
-arbitrary project code, shell commands, or network providers.
+The command inspects Rust/Cargo and npm TypeScript projects, finds catalogued
+Amari capabilities, produces replayable integration plans, and runs registered
+bounded probes. It does not edit inspected projects or execute project code,
+build scripts, lifecycle scripts, arbitrary commands, providers, or network
+requests.
 
-This crate is under active development for Amari 0.24.0 while the feature
-branch remains at workspace version 0.23.0. Deterministic catalog discovery is
-implemented; project inspection, recommendations, planning, and bounded probe
-execution remain in development.
+> **Release status:** the implementation is being prepared for Amari 0.24.0
+> while the workspace remains at 0.23.0. Install from the workspace path for
+> feature-branch validation; do not treat this preview as a published 0.24.0
+> release.
+
+Every `bash` block below is runnable with the stated checkout or project
+context. Contributor-only catalog commands use `text` blocks because they have
+additional toolchain prerequisites.
+
+## Install from a checkout
+
+```bash
+cargo install --path amari-discovery
+amari capabilities
+```
+
+Exactly one binary, `amari`, is installed. The root `amari` library package
+does not own a second command.
+
+## Human quick start
+
+Run these commands from a Rust/Cargo or npm TypeScript project:
+
+```bash
+amari capabilities
+amari discover search tropical
+amari inspect .
+amari recommend . --goal "differentiate a scalar polynomial with forward dual numbers"
+amari probe list
+```
+
+Use `amari shell --project .` for an interactive session over the same typed
+handlers. Run `amari <command> --help` for command-specific options.
+
+## Agent loop
+
+Machine consumers should start by negotiating capabilities and retain the full
+versioned envelopes used for replay:
+
+```bash
+project=$(pwd)
+artifacts=$(mktemp -d)
+
+amari capabilities --json > "$artifacts/capabilities.json"
+amari inspect "$project" --json > "$artifacts/inspection.json"
+amari recommend "$project" \
+  --goal "differentiate a scalar polynomial with forward dual numbers" \
+  --json > "$artifacts/recommendation.json"
+
+candidate=$(jq -r '.data.data.preferred.capability_id' "$artifacts/recommendation.json")
+amari plan "$candidate" \
+  --recommendation "$artifacts/recommendation.json" \
+  --project "$project" \
+  --json > "$artifacts/plan.json"
+
+probe_id=$(jq -r '.data.steps[] | select(.kind == "probe") | .probe_id' "$artifacts/plan.json" | head -n1)
+amari probe run "$probe_id" --plan "$artifacts/plan.json" --dry-run --json
+
+printf '%s\n' '{"coefficients":[1.0,2.0,3.0],"at":2.0}' > "$artifacts/probe-input.json"
+amari probe run amari-probe:dual:polynomial-derivative:v1 \
+  --input "$artifacts/probe-input.json" \
+  --json > "$artifacts/probe-result.json"
+```
+
+`plan` re-inspects the current project and validates the saved recommendation's
+tool version, recall seed, catalog identity, project/input hashes, and saved
+probe hashes. A dry run validates compatibility only; actual probe execution
+requires an explicit typed input JSON file.
+
+## Output and errors
+
+- Human output is the default.
+- `--json` emits one `amari.discovery/v1` response envelope.
+- `--ndjson` emits the same envelope as one newline-delimited record.
+- `amari shell --json` accepts exactly one typed request.
+- `amari shell --ndjson` accepts one bounded typed request per line and emits
+  one response per line.
+- Success is written to stdout. Structured errors are written to stderr.
+- Stable error kinds and exit codes are reported by `amari capabilities --json`.
+
+The curated request, response, goal, plan, and probe schemas are available
+through `amari schema` and in [`schemas/`](schemas/).
+
+## Inspection and privacy boundary
+
+Inspection is read-only and bounded by file count, file size, aggregate bytes,
+depth, and wall-clock limits. It follows neither external symlinks nor ignored
+directory tunnels. Public evidence contains hashes and typed categories rather
+than source text, secrets, absolute project roots, external targets, command
+arguments, or raw parser/worker diagnostics.
+
+Supported project evidence is intentionally narrow:
+
+- Cargo manifests, lockfiles, Cargo platform configuration, and Rust source
+  structure without running Cargo, rustc, build scripts, or project code.
+- Root `package.json`, npm `package-lock.json` schema versions 2 and 3,
+  TypeScript/JavaScript source structure, and generated Amari WASM `.d.ts`
+  declarations without running npm, Node.js, lifecycle scripts, or project
+  code. Yarn and pnpm locks are not interpreted in 0.24.0.
+
+Usable bounded partial inspections are successful typed outcomes. Likewise,
+`no_applicable_capability`, `insufficient_evidence`, and `blocked` are domain
+outcomes rather than process failures.
+
+## Probes and AI boundary
+
+Only catalogued probe IDs with compiled adapters can run. Probe requests carry
+only a probe ID, typed input, limits, and provenance. Public probe execution is
+isolated in a restricted worker launched from the current `amari` executable;
+callers cannot select a shell, executable, arguments, environment, working
+directory, project handle, provider, or network transport.
+
+The optional `ai` feature exposes a provider-neutral in-process
+`GoalInterpreter` contract. Its validated wrapper bounds input/output, rejects
+execution authority, and requires returned capability IDs to exist in the
+embedded catalog. No concrete provider, subprocess transport, network client,
+or additional execution authority ships with this crate.
+
+## Catalog maintenance
+
+Runtime discovery uses checked-in generated structure plus curated semantic
+and probe metadata. `amari-discovery` is intentionally excluded from its own
+structural catalog to prevent self-index drift.
+
+From the workspace root, contributors regenerate the Rust catalog with:
+
+```text
+cargo run -p amari-discovery --example generate_catalog -- .
+```
+
+Regenerate the authoritative WASM surface with:
+
+```text
+./scripts/generate-discovery-wasm-surface.sh
+```
+
+Both generators use fixed output paths and atomic replacement. Review and
+commit catalog changes; CI rejects drift, dangling semantic references, probe
+manifest mismatches, or an unexpected discovery self-index.
+
+## More documentation
+
+See the [Amari Discovery Guide](../docs/guide/amari-discovery.md) for complete
+human, agent, contributor, safety, protocol, and release-readiness workflows.

--- a/amari-discovery/benchmarks.md
+++ b/amari-discovery/benchmarks.md
@@ -1,0 +1,65 @@
+# amari-discovery Budgets and Measurements
+
+This file distinguishes portable functional budgets from machine-specific
+release-binary reporting. Integration tests enforce agent-output and coarse
+latency ceilings. Binary size is measured and reported, not asserted in tests,
+because target triples, linkers, debug symbols, and toolchain revisions affect
+it materially.
+
+## Enforced functional budgets
+
+`tests/budgets.rs` runs the real `amari` test binary and enforces:
+
+| Surface | Ceiling | Approximate token ceiling | Rationale |
+| --- | ---: | ---: | --- |
+| `capabilities --json` | 8,192 bytes | 2,048 | Complete negotiation remains small enough for an agent preflight |
+| `discover search tropical --json` | 4,096 bytes | 1,024 | Compact search does not expand into detail/graph payloads |
+| deterministic recommendation | 32,768 bytes | 8,192 | Full preferred/alternative evidence remains bounded |
+| minimal Rust inspection | 30 seconds | n/a | Coarse portable deadline, not a microbenchmark |
+
+Token counts use a reporting approximation of four UTF-8 bytes per token; they
+are not tokenizer-specific guarantees. Machine output must also remain one
+compact newline-terminated record. Recommendation runs with identical project,
+goal, catalog, and seed must be byte-identical.
+
+A representative 2026-07-23 development-profile sample on x86_64 Linux
+observed 5,083-byte capabilities output, 1,117-byte tropical search output,
+4,673-byte deterministic recommendation output, and 2.57-second inspection of
+the repository's bounded Rust fixture. These observations are context only;
+the table above is the portable contract.
+
+## Release binary measurement
+
+Run from any directory in the repository:
+
+```text
+./scripts/measure-discovery-binary.sh
+```
+
+The script builds only `amari-discovery`'s `amari` binary in release mode,
+measures `target/release/amari`, calculates its SHA-256, and replaces the
+managed report below. It does not fail based on binary size and never measures
+a test-profile executable.
+
+<!-- discovery-binary-measurement:start -->
+
+- Measured UTC: `2026-07-23`
+- Build: `cargo build --release -p amari-discovery --bin amari`
+- Toolchain: `rustc 1.98.0-nightly (91fe22da8 2026-06-21)`
+- Host target: `x86_64-unknown-linux-gnu`
+- Profile: `release`
+- Binary: `target/release/amari`
+- Size: `23982928` bytes (`22.87` MiB)
+- SHA-256: `98969eb8c2651618fb3dd0a06a7c0b53135fe3bc37546537cb94a1c62d48bb3b`
+
+<!-- discovery-binary-measurement:end -->
+
+## Interpretation
+
+The executable embeds `catalog/generated.json` and
+`catalog/generated-wasm.json` so runtime discovery remains offline and cannot
+drift from reviewed authority. The uncompressed Rust catalog is currently the
+largest package input. Any future binary-size reduction must preserve catalog
+identity, deterministic offline behavior, schema/probe contracts, and safety
+tests; moving authority to an implicit network fetch is not an acceptable
+optimization.

--- a/amari-discovery/tests/budgets.rs
+++ b/amari-discovery/tests/budgets.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Portable functional budgets for discovery's agent-facing command surface.
+
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+const MAX_CAPABILITIES_JSON_BYTES: usize = 8 * 1024;
+const MAX_SEARCH_JSON_BYTES: usize = 4 * 1024;
+const MAX_RECOMMENDATION_JSON_BYTES: usize = 32 * 1024;
+const MAX_SMALL_INSPECTION_DURATION: Duration = Duration::from_secs(30);
+
+fn command_output(arguments: &[&str]) -> Vec<u8> {
+    let output = Command::cargo_bin("amari")
+        .expect("amari test binary")
+        .args(arguments)
+        .output()
+        .expect("run amari command");
+    assert!(
+        output.status.success(),
+        "command {arguments:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn small_project() -> TempDir {
+    let temporary = tempfile::tempdir().expect("temporary project");
+    fs::create_dir(temporary.path().join("src")).expect("create source directory");
+    let manifest = format!(
+        r#"[package]
+name = "discovery-budget-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+amari-core = "{}"
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    fs::write(temporary.path().join("Cargo.toml"), manifest).expect("write manifest");
+    fs::write(
+        temporary.path().join("src/lib.rs"),
+        "use amari_core::Multivector;\npub fn scalar() -> Multivector<3, 0, 0> { Multivector::scalar(1.0) }\n",
+    )
+    .expect("write source");
+    temporary
+}
+
+fn assert_single_compact_record(bytes: &[u8]) {
+    assert_eq!(
+        bytes.iter().filter(|byte| **byte == b'\n').count(),
+        1,
+        "machine output must remain one compact record"
+    );
+    assert_eq!(bytes.last(), Some(&b'\n'));
+}
+
+fn approximate_tokens(bytes: usize) -> usize {
+    bytes.div_ceil(4)
+}
+
+#[test]
+fn capabilities_json_stays_within_agent_context_budget() {
+    let bytes = command_output(&["capabilities", "--json"]);
+    assert_single_compact_record(&bytes);
+    assert!(
+        bytes.len() <= MAX_CAPABILITIES_JSON_BYTES,
+        "capabilities output grew to {} bytes (~{} tokens), above {} bytes",
+        bytes.len(),
+        approximate_tokens(bytes.len()),
+        MAX_CAPABILITIES_JSON_BYTES
+    );
+}
+
+#[test]
+fn compact_search_stays_within_agent_context_budget() {
+    let bytes = command_output(&["discover", "search", "tropical", "--json"]);
+    assert_single_compact_record(&bytes);
+    assert!(
+        bytes.len() <= MAX_SEARCH_JSON_BYTES,
+        "compact search output grew to {} bytes (~{} tokens), above {} bytes",
+        bytes.len(),
+        approximate_tokens(bytes.len()),
+        MAX_SEARCH_JSON_BYTES
+    );
+}
+
+#[test]
+fn small_fixture_inspection_has_a_coarse_portable_deadline() {
+    let project = small_project();
+    let started = Instant::now();
+    let bytes = command_output(&[
+        "inspect",
+        project.path().to_str().expect("UTF-8 project path"),
+        "--json",
+    ]);
+    let elapsed = started.elapsed();
+
+    assert_single_compact_record(&bytes);
+    assert!(
+        elapsed <= MAX_SMALL_INSPECTION_DURATION,
+        "small fixture inspection took {elapsed:?}, above the coarse {MAX_SMALL_INSPECTION_DURATION:?} budget"
+    );
+}
+
+#[test]
+fn recommendation_is_byte_deterministic_and_bounded() {
+    let project = small_project();
+    let project_path = project.path().to_str().expect("UTF-8 project path");
+    let arguments = [
+        "recommend",
+        project_path,
+        "--goal",
+        "compute a geometric product",
+        "--json",
+    ];
+    let first = command_output(&arguments);
+    let second = command_output(&arguments);
+
+    assert_single_compact_record(&first);
+    assert_eq!(first, second, "fixed-input recommendation output drifted");
+    assert!(
+        first.len() <= MAX_RECOMMENDATION_JSON_BYTES,
+        "recommendation output grew to {} bytes (~{} tokens), above {} bytes",
+        first.len(),
+        approximate_tokens(first.len()),
+        MAX_RECOMMENDATION_JSON_BYTES
+    );
+}

--- a/amari-holographic/src/algebra/mod.rs
+++ b/amari-holographic/src/algebra/mod.rs
@@ -21,8 +21,8 @@
 //! - **Inverse** (`⁻¹`): Enable unbinding to retrieve associated values
 //! - **Similarity**: Measure closeness between representations
 //!
-//! The [`BindingAlgebra`] trait abstracts these operations, allowing
-//! [`TropicalDual<A>`] to be generic over the underlying algebra.
+//! The [`BindingAlgebra`] trait abstracts these operations, allowing memory
+//! and retrieval algorithms to be generic over the underlying algebra.
 //!
 //! # Capacity Scaling
 //!

--- a/amari-holographic/src/memory/mod.rs
+++ b/amari-holographic/src/memory/mod.rs
@@ -1,7 +1,7 @@
 //! Holographic memory using generalized binding algebras.
 //!
 //! This module provides Vector Symbolic Architecture (VSA) operations
-//! using the [`BindingAlgebra`] trait, enabling:
+//! using the [`crate::algebra::BindingAlgebra`] trait, enabling:
 //!
 //! - Compositional key-value storage in superposition
 //! - Content-addressable retrieval with automatic cleanup

--- a/amari-holographic/src/optical/tropical.rs
+++ b/amari-holographic/src/optical/tropical.rs
@@ -250,7 +250,7 @@ impl TropicalOpticalAlgebra {
     /// Given a current state and a set of attractor fields, computes
     /// one iteration of tropical dynamics:
     ///
-    /// new_state = tropical_add(attractors[0], tropical_add(attractors[1], ...))
+    /// `new_state = tropical_add(attractors[0], tropical_add(attractors[1], ...))`
     ///
     /// This drives the state toward the "nearest" attractor at each pixel.
     pub fn attractor_step(

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,11 @@ This directory contains comprehensive documentation for the Amari mathematical c
 - **[Main README](../README.md)** - Project overview and quick start
 - **[Changelog](../CHANGELOG.md)** - Version history and changes
 - **[Version Management](../VERSION_MANAGEMENT.md)** - Version synchronization procedures
+- **[Amari Discovery Guide](guide/amari-discovery.md)** - Human and agent discovery, planning, probes, protocol, privacy, and contributor workflows
+
+### 📘 Guides
+
+- **[Amari Discovery](guide/amari-discovery.md)** - Complete `amari` command workflow and safety model for the 0.24.0 discovery runtime
 
 ### 📦 Releases
 
@@ -119,6 +124,7 @@ Historical and outdated documentation (kept for reference):
 
 Individual crates have their own documentation:
 
+- **[amari-discovery README](../amari-discovery/README.md)** - Agent-first discovery and planning runtime
 - **[amari-network README](../amari-network/README.md)** - Geometric network analysis
 - **[amari-network Mathematical Foundations](../amari-network/MATHEMATICAL_FOUNDATIONS.md)** - Mathematical background
 - **[amari-optimization README](../amari-optimization/README.md)** - Optimization algorithms

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ This directory contains comprehensive documentation for the Amari mathematical c
 Current release process documentation:
 
 - **[v0.9.8 Release Process](releases/RELEASE_PROCESS_v0.9.8.md)** - Current release procedures and lessons learned
+- **[v0.24.0 Aggregate Release Gates](releases/v0.24.0-aggregate-release-gates.md)** - Feature-branch evidence, hold conditions, publication order, verified packaging, and post-publication acceptance
 - **[v0.21.0 Tropical / Dual Release Prep](releases/v0.21.0-tropical-dual-release-prep.md)** - Release notes, PR summary, publish-order notes, and hold conditions for the `0.21.0` cycle
 
 ### 🗺️ Roadmaps

--- a/docs/guide/amari-discovery.md
+++ b/docs/guide/amari-discovery.md
@@ -1,0 +1,321 @@
+# Amari Discovery Guide
+
+`amari-discovery` installs the `amari` command for humans and software agents
+that need to understand and integrate the Amari ecosystem. It combines a
+checked-in capability catalog, bounded project inspection, deterministic
+candidate retrieval and ranking, replayable plans, and registered mathematical
+probes.
+
+This guide describes the 0.24.0 feature surface while the workspace is still at
+0.23.0. Passing feature-branch checks is not a 0.24.0 release claim; aggregate
+versioning, catalog regeneration, package verification, publication, and
+post-publication installation remain separate release gates. Every `bash`
+block in this guide is runnable in the stated checkout or inspected-project
+context. Contributor commands with additional WASM/toolchain prerequisites use
+`text` blocks instead.
+
+## Why `amari-discovery` owns `amari`
+
+The root `amari` crate is the Rust library umbrella. A second placeholder
+binary there would make `cargo install` ownership ambiguous and could drift
+from the discovery protocol. The workspace therefore has one binary owner:
+`amari-discovery` declares `[[bin]] name = "amari"`, while the root package is
+library-only. CI verifies this invariant.
+
+## Installation during 0.24.0 development
+
+From an Amari checkout:
+
+```bash
+cargo install --path amari-discovery
+amari --version
+amari capabilities
+```
+
+The path install must create exactly one file named `amari` in the install
+root's `bin` directory. Registry installation is not accepted until the
+0.24.0 dependency chain has been published and indexed.
+
+## Human workflow
+
+### 1. Negotiate the installed surface
+
+```bash
+amari capabilities
+```
+
+Capabilities report the binary name, protocol version, output modes, catalog
+identity, inspectors, feature-gated probe availability, schemas, AI contract
+state, and stable exit codes. Consumers should not infer availability from a
+catalog entry alone: a descriptor can be known while its implementation is not
+compiled into the current binary.
+
+### 2. Explore the catalog
+
+```bash
+amari discover search tropical
+amari discover detail amari:amari-tropical:sequence:viterbi
+amari discover graph amari:amari-tropical:sequence:viterbi
+amari discover example amari:amari-dual:autodiff:forward-derivative
+```
+
+`search` returns compact ranked summaries. `detail`, `graph`, and `example`
+progressively expose richer catalog evidence without inspecting a project.
+
+### 3. Inspect without executing the project
+
+```bash
+amari inspect .
+```
+
+Inspection recognizes Rust/Cargo projects, npm TypeScript projects, and mixed
+roots. It reads a bounded deterministic subset of regular files and returns
+complete or typed partial evidence. It does not invoke Cargo, rustc, npm,
+Node.js, lifecycle scripts, build scripts, project binaries, or the network.
+
+### 4. Recommend and plan
+
+```bash
+amari recommend . --goal "differentiate a scalar polynomial with forward dual numbers"
+```
+
+Recommendations include a preferred Pareto candidate, alternatives, the full
+minimization score/evidence breakdown, prerequisites, compatibility, planned
+steps, and relevant probes. `no_applicable_capability`,
+`insufficient_evidence`, and `blocked` are successful domain outcomes.
+
+A replayable plan requires the saved machine recommendation, candidate ID, and
+current project. See the agent workflow below.
+
+### 5. Inspect registered probes
+
+```bash
+amari probe list
+amari probe describe amari-probe:dual:polynomial-derivative:v1
+probe_input=$(mktemp)
+printf '%s\n' '{"coefficients":[1.0,2.0,3.0],"at":2.0}' > "$probe_input"
+amari probe run amari-probe:dual:polynomial-derivative:v1 --input "$probe_input"
+```
+
+Only registered, compiled adapters run. The public CLI routes execution through
+a restricted process worker and reports process isolation only after validating
+the worker frame, result, and provenance.
+
+## Agent workflow: capabilities → inspect → recommend → plan → probe
+
+The following workflow requires `jq` and should be run from the project being
+analyzed:
+
+```bash
+project=$(pwd)
+artifacts=$(mktemp -d)
+
+amari capabilities --json > "$artifacts/capabilities.json"
+jq -e '.schema_version == "amari.discovery/v1" and .data.binary == "amari"' "$artifacts/capabilities.json"
+
+amari inspect "$project" --json > "$artifacts/inspection.json"
+jq -e '.provenance.project_hash and (.provenance.replay.required_hashes | length > 0)' "$artifacts/inspection.json"
+
+amari recommend "$project" \
+  --goal "differentiate a scalar polynomial with forward dual numbers" \
+  --json > "$artifacts/recommendation.json"
+jq -e '.data.status == "recommended"' "$artifacts/recommendation.json"
+
+candidate=$(jq -r '.data.data.preferred.capability_id' "$artifacts/recommendation.json")
+amari plan "$candidate" \
+  --recommendation "$artifacts/recommendation.json" \
+  --project "$project" \
+  --json > "$artifacts/plan.json"
+jq -e '.data.plan_hash and (.data.steps | length > 0)' "$artifacts/plan.json"
+
+probe_id=$(jq -r '.data.steps[] | select(.kind == "probe") | .probe_id' "$artifacts/plan.json" | head -n1)
+amari probe run "$probe_id" --plan "$artifacts/plan.json" --dry-run --json > "$artifacts/probe-dry-run.json"
+jq -e '.data.executable == true and .data.compatible == true' "$artifacts/probe-dry-run.json"
+
+printf '%s\n' '{"coefficients":[1.0,2.0,3.0],"at":2.0}' > "$artifacts/probe-input.json"
+amari probe run amari-probe:dual:polynomial-derivative:v1 \
+  --input "$artifacts/probe-input.json" \
+  --json > "$artifacts/probe-result.json"
+jq -e '.data.isolation == "process" and .data.result.output.derivative == 6.0' "$artifacts/probe-result.json"
+```
+
+The saved recommendation is not trusted merely because its internal hashes are
+self-consistent. `plan` re-inspects the project and re-derives the current tool
+version, deterministic recall seed, catalog identity, project/input hashes,
+probe hashes, compatibility, warnings, provenance, normalized steps, and plan
+hash. Malformed SHA-256 values, stale authority, or changed projects fail with
+a typed replay error.
+
+A probe `--plan --dry-run` is compatibility-only and never executes the probe.
+Actual execution requires an explicit typed JSON file via `--input`; plans
+cannot smuggle a project path, executable, command arguments, shell configuration, provider, or
+network authority into a worker request.
+
+## JSON, NDJSON, and shell contracts
+
+All modes project the same typed response envelopes:
+
+- default: human-readable output;
+- `--json`: exactly one JSON envelope and trailing newline;
+- `--ndjson`: exactly one JSON envelope as one NDJSON record;
+- `amari shell --json`: exactly one bounded request from stdin and one response;
+- `amari shell --ndjson`: one bounded request and response per non-empty line.
+
+A machine shell request has this shape:
+
+```json
+{"schema_version":"amari.discovery/v1","command":"discover.search","arguments":{"query":"tropical"}}
+```
+
+For a streaming session:
+
+```bash
+printf '%s\n' \
+  '{"schema_version":"amari.discovery/v1","command":"capabilities","arguments":{}}' \
+  '{"schema_version":"amari.discovery/v1","command":"discover.search","arguments":{"query":"tropical"}}' \
+  '{"schema_version":"amari.discovery/v1","command":"probe.list","arguments":{}}' \
+  | amari shell --ndjson
+```
+
+Emit curated schemas with `amari schema request --json`, replacing `request`
+with `response`, `goal`, `plan`, or `probe`. Checked-in schemas live in
+`amari-discovery/schemas/` and use JSON Schema 2020-12.
+
+### Stable errors and streams
+
+Successful output goes to stdout. Human and structured errors go to stderr;
+machine errors are single JSON/NDJSON records with `details.exit_code`. The
+running binary advertises the authoritative map. The current v1 classes are:
+
+| Error kind | Exit code |
+| --- | ---: |
+| `invalid_id`, `invalid_input` | 2 |
+| `catalog_corruption` | 3 |
+| `inspection_failure` | 4 |
+| `probe_unavailable` | 5 |
+| `probe_failed` | 6 |
+| `limit_exceeded` | 7 |
+| `io` | 8 |
+| `serialization` | 9 |
+| `not_implemented` | 69 |
+| `internal` | 70 |
+
+Scripts should negotiate this map instead of hard-coding future additions.
+Domain non-recommendations are successful values and do not use error exits.
+
+## Read-only and privacy model
+
+Inspection and replay never modify the target project. Traversal is bounded by
+considered regular files, per-file bytes, aggregate bytes, depth, and elapsed
+wall time. It does not follow symlinks outside the canonical root, symlink
+cycles, ignored-directory tunnels, or recursively declared nested workspaces.
+
+Public evidence intentionally excludes:
+
+- complete source text and secret-shaped content;
+- absolute project roots and external symlink targets;
+- raw malformed workspace paths, lockfile source URLs, or unsafe package names;
+- Cargo runner/linker directories and command arguments;
+- raw parser diagnostics and worker stderr;
+- untrusted saved warnings or compatibility reasons.
+
+Source locations are content-addressed. Malformed evidence is represented by
+fixed categories, and usable bounded partial snapshots remain typed successful
+outcomes.
+
+## Rust and TypeScript inspection scope
+
+### Rust/Cargo
+
+The inspector reads Cargo manifests and lockfiles, workspace membership, target
+and feature declarations, `.cargo/config.toml` platform evidence, Rust import
+and API usage structure, attributes, cfgs, tests, examples, benches, and bounded
+vocabulary. It does not run dependency resolution or compile the project.
+
+### npm TypeScript
+
+The npm inspector supports only root `package.json` and root
+`package-lock.json` schema versions 2 and 3 in 0.24.0. It reads bounded
+TypeScript/JavaScript structure and the installed Amari WASM package's generated
+`.d.ts` declarations. Missing or malformed optional lockfiles are typed and
+nonfatal. Yarn and pnpm locks are excluded, and no package scripts execute.
+
+Rust and TypeScript evidence map into shared semantic capability IDs. WASM API
+authority comes from generated `.d.ts`, not hand-maintained TypeScript claims.
+
+## Probe isolation and limits
+
+Probe descriptors define schemas, feature requirements, cost, determinism,
+side effects, network policy, timeout, input/output bytes, and work ceilings.
+Callers may tighten but never loosen descriptor limits. In-process library
+execution truthfully reports `cooperative`; the CLI reports `process` only
+following successful supervisor validation.
+
+The worker protocol is exactly one non-empty, bounded, four-byte big-endian
+length-prefixed JSON request and response frame. The supervisor launches only
+its current executable with the sole hidden `__probe-worker` argument, clears
+the inherited environment, uses a neutral working directory, drains stdout and
+stderr concurrently under independent caps, and kills and reaps on deadline or
+cap violation. Raw diagnostics never become public errors.
+
+## Optional AI contract
+
+Feature `ai` exposes the provider-neutral `GoalInterpreter` trait and
+`ValidatedGoalInterpreter`. Validation bounds input and output, rejects empty
+or duplicate fields, verifies capability IDs against the embedded catalog, and
+rejects any requested execution authority.
+
+It does **not** ship a provider, subprocess protocol, shell bridge, network
+client, credential path, or probe bypass. Applications embedding the trait
+remain responsible for obtaining an interpretation; Amari only validates its
+bounded typed result.
+
+## Contributor catalog workflow
+
+The runtime catalog is hybrid:
+
+1. `catalog/generated.json` records deterministic Rust workspace structure;
+2. `catalog/generated-wasm.json` records the authoritative generated `.d.ts`
+   surface;
+3. `catalog/semantic/*.toml` supplies curated concepts and relations;
+4. `catalog/probes.toml` declares bounded probe authority.
+
+`amari-discovery` is excluded from generated structural records so the tool does
+not self-index and drift whenever its own implementation changes.
+
+Regenerate Rust structure from the workspace root:
+
+```text
+cargo run -p amari-discovery --example generate_catalog -- .
+```
+
+Regenerate the WASM surface with the pinned contributor path:
+
+```text
+./scripts/generate-discovery-wasm-surface.sh
+```
+
+Generators accept no caller-selected output path, write only fixed catalog
+files atomically, and perform no runtime network access. After regeneration,
+run:
+
+```text
+cargo test -p amari-discovery --test catalog_generation --all-features
+cargo test -p amari-discovery --test catalog_integrity --all-features
+cargo test -p amari-discovery --test catalog_wasm --all-features
+```
+
+CI also checks schema goldens, catalog identity, semantic references, probe
+registry parity, the sole binary owner, exhaustive discovery-test sharding,
+and dependency-safe publication order.
+
+## Release boundary
+
+Feature-branch completion proves source and path-install behavior only. It does
+not prove a registry package can resolve unpublished 0.24.0 dependencies.
+Aggregate release acceptance occurs after discovery, additive holographic
+superposition, and the separately approved rewrite expansion are merged. The
+release branch must then move every workspace package and internal constraint
+to 0.24.0, regenerate both catalogs, run full package/publish dry-runs in
+actual dependency order, inspect and install the verified archive, publish,
+and repeat installation from the registry.

--- a/docs/releases/v0.24.0-aggregate-release-gates.md
+++ b/docs/releases/v0.24.0-aggregate-release-gates.md
@@ -1,0 +1,273 @@
+# Amari 0.24.0 Aggregate Release Gates
+
+This document separates feature-branch evidence from aggregate release
+acceptance. A merged implementation, successful path install, or unverified
+`.crate` archive is **not** a 0.24.0 release. Release acceptance requires the
+separately approved rewrite expansion, synchronized 0.24.0 package metadata,
+regenerated catalogs, registry-resolvable dependencies, verified archives,
+publication, tags, and post-publication installation.
+
+## Current hold state
+
+As of 2026-07-23:
+
+- `BindingAlgebra::superpose` and `scale` are merged through PR #189.
+- Discovery implementation and hardening through Task 26 are merged through
+  PR #214.
+- Public discovery documentation is implemented on the Task 27–30 feature
+  branch.
+- The workspace and embedded catalog still identify version 0.23.0.
+- The separately approved `amari-rewrite` expansion has not completed.
+- Required 0.24.0 internal dependencies have not been published and indexed.
+
+Therefore 0.24.0 is **not release-ready or shipped**.
+
+## Task 28 publication-order audit
+
+The feature-branch audit derived dependencies from `cargo metadata`, rather
+than maintaining a second manual list. `amari-discovery` directly depends on:
+
+- `amari-core`
+- `amari-tropical`
+- `amari-dual` (optional)
+- `amari-network`
+- `amari-optimization`
+- `amari-holographic`
+- `amari-cgt` (optional)
+- `amari-surreal` (optional)
+- `amari-surcomplex` (optional)
+- `amari-rewrite`
+
+All ten precede `amari-discovery` in `.github/workflows/publish.yml`, and
+`amari-discovery` precedes the root `amari` package. The workflow's shell step
+continues to stop when `cargo publish --allow-dirty` fails. These checks passed:
+
+```text
+./scripts/verify-workflow-crates.sh
+python3 scripts/verify-amari-binary-owner.py
+python3 scripts/verify-publish-order.py
+```
+
+No Task 28 workflow or verifier change was required.
+
+## Feature-branch package evidence
+
+Evidence was captured from commit `2026ee82a8011fc77a0c535319b3c6f3aca22fce`
+with the workspace at 0.23.0.
+
+### Path install
+
+The following path-source contract passed:
+
+```text
+cargo install --path amari-discovery --root target/task29-install
+test "$(find target/task29-install/bin -maxdepth 1 -type f -printf '%f\n')" = "amari"
+target/task29-install/bin/amari capabilities --json \
+  | jq -e '.data.binary == "amari"'
+target/task29-install/bin/amari discover search tropical --json \
+  | jq -e '.data.results | length > 0'
+```
+
+Observed evidence:
+
+- exactly one installed command: `amari`;
+- protocol: `amari.discovery/v1`;
+- output modes: human, JSON, and NDJSON;
+- catalog identity:
+  `0.23.0/dfec41500c93e65ee2852918d478bf15cb79c5e419daf5b8b293b63b7caf09ff`;
+- tropical search returned two results.
+
+This proves the workspace path source builds and installs. It does not prove
+that a registry-normalized 0.24.0 package resolves.
+
+### Unverified archive inspection
+
+The feature branch intentionally ran:
+
+```text
+cargo package -p amari-discovery --allow-dirty --no-verify
+tar -tf target/package/amari-discovery-0.23.0.crate
+```
+
+Observed archive:
+
+| Property | Value |
+| --- | --- |
+| Archive | `target/package/amari-discovery-0.23.0.crate` |
+| SHA-256 | `e6ad870f6a47cd3050a0b0aed716c0b9e8c63d73e66193e964ba58c8aaed02f5` |
+| Files | 178 |
+| Uncompressed | 19.6 MiB |
+| Compressed | 1,205,656 bytes |
+| Largest file | `catalog/generated.json`, 17,528,971 bytes |
+
+The archive contains the runtime catalogs, semantic/probe metadata, schemas,
+source, README, examples, and integration-test evidence. It excludes build
+output, worktrees, and `tests/fixtures/probe-test-worker.py`. The generated
+catalog dominates uncompressed size but compresses sufficiently; it is runtime
+authority and cannot simply be omitted to reduce package size.
+
+Cargo normalized every direct Amari dependency to registry version `0.23.0`
+and removed dependency paths. That archive was **not verified**. The
+`--no-verify` flag bypasses Cargo's extracted registry-style build and must not
+be reported as registry package verification. In particular, published
+`amari-holographic@0.23.0` does not contain `BindingAlgebra::superpose`, which
+the current discovery planner requires.
+
+## Preconditions for the aggregate 0.24.0 branch
+
+Do not start aggregate acceptance until all of the following are merged into
+the release branch:
+
+1. the canonical superposition implementation from PR #189;
+2. all approved `amari-discovery` work;
+3. the separately decided `amari-rewrite` expansion;
+4. any release-blocking review fixes.
+
+PR #176 is documentation/handoff history only; PR #189 is the sole canonical
+superposition code implementation.
+
+## Version and stale-constraint gate
+
+On the aggregate release branch:
+
+```bash
+./scripts/version-sync.sh set 0.24.0
+./scripts/version-sync.sh verify 0.24.0
+cargo metadata --no-deps --format-version 1 > /tmp/amari-0.24-metadata.json
+```
+
+Audit the metadata, every workspace `Cargo.toml`, npm package metadata, test
+fixtures, examples, and generated catalog identity. No active internal
+requirement may remain at 0.23.0. Historical changelog prose may retain old
+version numbers; live constraints may not.
+
+The version change must happen only after discovery, superposition, and rewrite
+expansion are all present. A version bump by itself is not a release.
+
+## Catalog regeneration gate
+
+Regenerate both authorities after the 0.24.0 version sync and final API merge:
+
+```bash
+./scripts/generate-discovery-wasm-surface.sh
+cargo run -p amari-discovery --example generate_catalog -- .
+cargo test -p amari-discovery --test catalog_generation --all-features
+cargo test -p amari-discovery --test catalog_integrity --all-features
+cargo test -p amari-discovery --test catalog_wasm --all-features
+```
+
+Review and commit the expected 0.24.0 catalog changes. Then run both generators
+a second time and require:
+
+```bash
+git diff --exit-code -- \
+  amari-discovery/catalog/generated.json \
+  amari-discovery/catalog/generated-wasm.json
+```
+
+The embedded catalog must report 0.24.0, exclude `amari-discovery` structural
+self-indexing, contain current rewrite/superposition surfaces, and have no
+semantic, relationship, WASM mapping, or probe drift.
+
+## Source verification gate
+
+From a clean aggregate branch, run the repository's complete sequential
+verification matrix. At minimum:
+
+```bash
+cargo fmt --all -- --check
+git diff --check
+cargo test -p amari-discovery --all-features
+cargo test -p amari-discovery --no-default-features
+cargo check -p amari-discovery --no-default-features
+cargo test -p amari-holographic
+cargo test --workspace --quiet
+cargo clippy -p amari-discovery -p amari-holographic \
+  --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc \
+  -p amari-discovery -p amari-holographic --all-features --no-deps
+./scripts/version-sync.sh verify 0.24.0
+./scripts/verify-workflow-crates.sh
+python3 scripts/verify-amari-binary-owner.py
+python3 scripts/verify-publish-order.py
+python3 scripts/verify-discovery-ci-sharding.py
+```
+
+Resolve unrelated workspace lint debt before the release PR rather than
+silently weakening release checks.
+
+## Registry-ordered package and publish gates
+
+Cargo rewrites workspace path dependencies to registry dependencies when it
+packages a crate. Consequently, a downstream 0.24.0 package cannot be fully
+verified until every direct 0.24.0 dependency is published and indexed.
+
+Use the exact order validated by `scripts/verify-publish-order.py`. For each
+crate in `.github/workflows/publish.yml`:
+
+1. wait until all direct internal dependencies at 0.24.0 are available from the
+   registry;
+2. run `cargo package -p <crate>` without `--no-verify`;
+3. inspect `target/package/<crate>-0.24.0.crate`;
+4. run `cargo publish -p <crate> --dry-run`;
+5. only after review, publish the crate and wait for crates.io indexing before
+   moving to the next dependent crate.
+
+A failed package, dry-run, publish, or index check stops the sequence. Do not
+skip failures or package downstream crates against unpublished dependencies.
+The workflow order places `amari-discovery` after all ten direct dependencies
+and before `amari`.
+
+When the discovery dependencies are indexed, its mandatory gates are:
+
+```bash
+cargo package -p amari-discovery
+cargo publish -p amari-discovery --dry-run
+```
+
+Neither command may use `--no-verify` for aggregate release acceptance.
+
+## Verified archive installation gate
+
+After the verified discovery package succeeds, install from the extracted
+archive rather than from the workspace:
+
+```bash
+archive=target/package/amari-discovery-0.24.0.crate
+extract_root=$(mktemp -d)
+install_root=$(mktemp -d)
+tar -xf "$archive" -C "$extract_root"
+cargo install \
+  --path "$extract_root/amari-discovery-0.24.0" \
+  --root "$install_root"
+test "$(find "$install_root/bin" -maxdepth 1 -type f -printf '%f\n')" = "amari"
+"$install_root/bin/amari" capabilities --json \
+  | jq -e '.data.binary == "amari" and .provenance.catalog.version == "0.24.0"'
+"$install_root/bin/amari" discover search tropical --json \
+  | jq -e '.data.results | length > 0'
+```
+
+Record the archive SHA-256, compressed/uncompressed sizes, file list, catalog
+identity, installed binary size, and smoke-test output in the final release
+checklist.
+
+## Post-publication gate
+
+After crates.io reports `amari-discovery@0.24.0`, repeat from the registry:
+
+```bash
+install_root=$(mktemp -d)
+cargo install amari-discovery --version 0.24.0 --root "$install_root"
+test "$(find "$install_root/bin" -maxdepth 1 -type f -printf '%f\n')" = "amari"
+"$install_root/bin/amari" capabilities --json \
+  | jq -e '.data.binary == "amari" and .provenance.catalog.version == "0.24.0"'
+"$install_root/bin/amari" discover search tropical --json \
+  | jq -e '.data.results | length > 0'
+```
+
+Only after verified source, verified package, actual publication, registry
+installation, smoke tests, the release commit on `main`, and the `v0.24.0` tag
+exist may the release be called shipped. npm publication and WASM smoke tests
+remain separate required gates; if automated npm authentication still returns
+E401, use the documented reviewed manual publication sequence rather than
+claiming success.

--- a/docs/roadmap/V0_20_0_TO_V0_25_0_RELEASE_SEQUENCE.md
+++ b/docs/roadmap/V0_20_0_TO_V0_25_0_RELEASE_SEQUENCE.md
@@ -101,7 +101,14 @@ Primary outcome:
   - confluence / termination analysis scaffolding
   - `infer_rules` with negative-example filtering and heuristic specialization (currently only `infer_rule` with positive examples)
 - **`amari-discovery`**: publish an agent-first discovery runtime with the installed `amari` command. It combines a generated API index and semantic capability catalog, read-only Rust/TypeScript project inspection, an Amari-native recommendation/planning engine, and bounded real probes. Human-readable output and a versioned JSON/NDJSON protocol share one typed core. See `docs/plans/2026-07-09-amari-discovery-design.md`
-- **`BindingAlgebra::superpose` + `scale`** (PR #176): additive superposition trait on `amari-holographic`, default implementations via existing trait methods, non-breaking. Unblocks Minuet `DenseTrace` recall-decay bug fix and supports correct holographic candidate accumulation in `amari-discovery`
+- **`BindingAlgebra::superpose` + `scale`** (PR #189): additive superposition trait on `amari-holographic`, canonical defaults via existing coefficient methods, and an FHRR correctness override. Supports correct holographic candidate accumulation in `amari-discovery`
+
+Verified status (2026-07-23):
+
+- additive superposition and scaling merged in PR #189
+- discovery implementation through planner/replay, inspection, probe isolation, agent contracts, fuzz/property hardening, and output goldens merged through PR #214
+- `amari-discovery` is the sole workspace owner of the `amari` command and the dependency-safe publish-order checks include it after every direct Amari dependency
+- public documentation, path-install/package evidence, functional budgets, the separately approved rewrite expansion, aggregate versioning/catalog regeneration, and registry package acceptance remain release gates; 0.24.0 is not yet released
 
 Non-goals:
 

--- a/scripts/measure-discovery-binary.sh
+++ b/scripts/measure-discovery-binary.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Build and record the release-mode amari discovery binary measurement.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BINARY="$ROOT/target/release/amari"
+REPORT="$ROOT/amari-discovery/benchmarks.md"
+START='<!-- discovery-binary-measurement:start -->'
+END='<!-- discovery-binary-measurement:end -->'
+
+cd "$ROOT"
+cargo build --release -p amari-discovery --bin amari
+
+test -f "$BINARY"
+test -f "$REPORT"
+
+bytes=$(wc -c < "$BINARY" | tr -d '[:space:]')
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256=$(sha256sum "$BINARY" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+    sha256=$(shasum -a 256 "$BINARY" | awk '{print $1}')
+else
+    echo "error: sha256sum or shasum is required" >&2
+    exit 1
+fi
+rustc_version=$(rustc --version)
+host=$(rustc -vV | awk '/^host: / {print $2}')
+measured_utc=$(date -u +%Y-%m-%d)
+mebibytes=$(python3 - "$bytes" <<'PY'
+import sys
+print(f"{int(sys.argv[1]) / (1024 * 1024):.2f}")
+PY
+)
+
+python3 - "$REPORT" "$START" "$END" "$measured_utc" "$rustc_version" "$host" "$bytes" "$mebibytes" "$sha256" <<'PY'
+from pathlib import Path
+import sys
+
+report_path = Path(sys.argv[1])
+start, end = sys.argv[2], sys.argv[3]
+measured_utc, rustc_version, host = sys.argv[4], sys.argv[5], sys.argv[6]
+bytes_value, mebibytes, sha256 = sys.argv[7], sys.argv[8], sys.argv[9]
+text = report_path.read_text()
+if text.count(start) != 1 or text.count(end) != 1 or text.index(start) >= text.index(end):
+    raise SystemExit("binary measurement markers are missing, duplicated, or out of order")
+managed = "\n".join(
+    [
+        start,
+        "",
+        f"- Measured UTC: `{measured_utc}`",
+        "- Build: `cargo build --release -p amari-discovery --bin amari`",
+        f"- Toolchain: `{rustc_version}`",
+        f"- Host target: `{host}`",
+        "- Profile: `release`",
+        "- Binary: `target/release/amari`",
+        f"- Size: `{bytes_value}` bytes (`{mebibytes}` MiB)",
+        f"- SHA-256: `{sha256}`",
+        "",
+        end,
+    ]
+)
+prefix, remainder = text.split(start, 1)
+_, suffix = remainder.split(end, 1)
+report_path.write_text(prefix + managed + suffix)
+PY
+
+cat <<EOF
+amari discovery release binary
+  path: $BINARY
+  host: $host
+  size: $bytes bytes ($mebibytes MiB)
+  sha256: $sha256
+  report: $REPORT
+EOF

--- a/scripts/run-discovery-test-shard.py
+++ b/scripts/run-discovery-test-shard.py
@@ -46,6 +46,7 @@ SHARDS: dict[str, tuple[str, ...]] = {
     "planner": (
         "agent_contract",
         "ai_contract",
+        "budgets",
         "cli_capabilities",
         "cli_discover",
         "cli_plan_replay",


### PR DESCRIPTION
## Summary

Completes discovery Tasks 27–30 for the 0.24.0 feature branch while preserving the explicit distinction between feature readiness and aggregate release acceptance.

### Task 27 — public and contributor documentation (`2026ee8`)

- expands `amari-discovery/README.md` and adds `docs/guide/amari-discovery.md`
- documents and executes the human and agent loops: capabilities → inspect → recommend → plan → probe
- documents JSON/NDJSON/shell contracts, exit codes, Rust/TypeScript scope, read-only/privacy limits, probe isolation, AI boundaries, catalog generation, and sole `amari` ownership
- adds accurate 0.24.0 preview notes to the root README, changelog, docs index, and release sequence
- keeps the workspace/release status explicitly at 0.23.0/unreleased

### Task 28 — publication-order audit (verification-only)

- derives all ten direct Amari dependencies from Cargo metadata
- confirms every dependency precedes `amari-discovery`, which precedes root `amari`
- confirms workflow coverage, sole binary ownership, and fatal publish behavior
- required no workflow or verifier changes, so no artificial Task 28 commit was created

### Task 29 — packaging and aggregate release gates (`a3eb44a`)

- proves path installation creates exactly one command, `amari`, and passes capabilities/search smoke tests
- inspects the explicitly **unverified** feature-branch archive: 178 files, 19.6 MiB uncompressed, 1,205,656 bytes compressed
- records why `--no-verify` is not registry verification: published `amari-holographic@0.23.0` lacks `superpose`
- adds `docs/releases/v0.24.0-aggregate-release-gates.md` with version sync, catalog regeneration, source verification, dependency-indexed packaging, publish dry-runs, verified archive installation, and post-publication gates
- does not claim 0.24.0 release acceptance

### Task 30 — functional and release reporting budgets (`74abe3d`)

- adds portable budgets for capabilities/search bytes, deterministic recommendation bytes, and a coarse small-fixture inspection deadline
- registers `budgets` exactly once; discovery sharding now covers 57 targets
- adds idempotent `scripts/measure-discovery-binary.sh`
- records the report-only x86_64 release binary measurement: 23,982,928 bytes (22.87 MiB)
- fixes three pre-existing `amari-holographic` rustdoc defects exposed by the required `-D warnings` gate

## Review

Independent DeepSeek review and focused re-review: **APPROVE**. No actionable Critical or Important blockers remain.

## Verification

Passed fresh from clean head `74abe3ddaaf415d9fdd9e064964261b9d4413318`:

- `cargo fmt --all -- --check`
- `git diff --check origin/develop...HEAD`
- `./scripts/measure-discovery-binary.sh`
- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features --test probe_engine --test cli_capabilities`
- `cargo check -p amari-discovery --no-default-features`
- `cargo test -p amari-holographic`
- `cargo test --workspace --quiet`
- `cargo clippy -p amari-discovery -p amari-holographic --all-targets --all-features -- -D warnings`
- `./scripts/version-sync.sh verify 0.23.0`
- `./scripts/verify-workflow-crates.sh`
- `python3 scripts/verify-amari-binary-owner.py`
- `python3 scripts/verify-publish-order.py`
- `python3 scripts/run-discovery-test-shard.py --verify` (57 unique/exhaustive targets)
- `python3 scripts/verify-discovery-ci-sharding.py`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p amari-discovery -p amari-holographic --all-features --no-deps`
- `bash -n scripts/measure-discovery-binary.sh`

The repository hook still encounters the documented unrelated `amari-core/src/generic.rs` `clippy::needless-range-loop` warnings; commits used `--no-verify` only after the scoped warning-denied matrices and mandated verification above passed.

## Remaining release boundary

This PR does **not** bump to or release 0.24.0. The separately approved rewrite expansion must complete before aggregate Task 31 performs version sync, final catalog regeneration, registry-ordered package/publish verification, publication, tag creation, and post-publication installation.
