### PR TITLE
chore: synchronize versions for 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tr
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Amari Contributors"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -86,32 +86,32 @@ rust-version = "1.75"
 
 [workspace.dependencies]
 # Amari crates (internal dependencies)
-amari = { path = ".", version = "0.23.0" }
-amari-core = { path = "amari-core", version = "0.23.0" }
-amari-tropical = { path = "amari-tropical", version = "0.23.0" }
-amari-dual = { path = "amari-dual", version = "0.23.0" }
-amari-fusion = { path = "amari-fusion", version = "0.23.0" }
-amari-info-geom = { path = "amari-info-geom", version = "0.23.0" }
-amari-automata = { path = "amari-automata", version = "0.23.0" }
-amari-enumerative = { path = "amari-enumerative", version = "0.23.0" }
-amari-relativistic = { path = "amari-relativistic", version = "0.23.0" }
-amari-gpu = { path = "amari-gpu", version = "0.23.0" }
-amari-network = { path = "amari-network", version = "0.23.0" }
-amari-optimization = { path = "amari-optimization", version = "0.23.0" }
-amari-flynn = { path = "amari-flynn", version = "0.23.0" }
-amari-flynn-macros = { path = "amari-flynn-macros", version = "0.23.0" }
-amari-measure = { path = "amari-measure", version = "0.23.0" }
-amari-calculus = { path = "amari-calculus", version = "0.23.0" }
-amari-holographic = { path = "amari-holographic", version = "0.23.0" }
-amari-probabilistic = { path = "amari-probabilistic", version = "0.23.0" }
-amari-functional = { path = "amari-functional", version = "0.23.0" }
-amari-topology = { path = "amari-topology", version = "0.23.0" }
-amari-dynamics = { path = "amari-dynamics", version = "0.23.0" }
-amari-cgt = { path = "amari-cgt", version = "0.23.0" }
-amari-surreal = { path = "amari-surreal", version = "0.23.0" }
-amari-surcomplex = { path = "amari-surcomplex", version = "0.23.0" }
-amari-rewrite = { path = "amari-rewrite", version = "0.23.0" }
-amari-wasm = { path = "amari-wasm", version = "0.23.0" }
+amari = { path = ".", version = "0.24.0" }
+amari-core = { path = "amari-core", version = "0.24.0" }
+amari-tropical = { path = "amari-tropical", version = "0.24.0" }
+amari-dual = { path = "amari-dual", version = "0.24.0" }
+amari-fusion = { path = "amari-fusion", version = "0.24.0" }
+amari-info-geom = { path = "amari-info-geom", version = "0.24.0" }
+amari-automata = { path = "amari-automata", version = "0.24.0" }
+amari-enumerative = { path = "amari-enumerative", version = "0.24.0" }
+amari-relativistic = { path = "amari-relativistic", version = "0.24.0" }
+amari-gpu = { path = "amari-gpu", version = "0.24.0" }
+amari-network = { path = "amari-network", version = "0.24.0" }
+amari-optimization = { path = "amari-optimization", version = "0.24.0" }
+amari-flynn = { path = "amari-flynn", version = "0.24.0" }
+amari-flynn-macros = { path = "amari-flynn-macros", version = "0.24.0" }
+amari-measure = { path = "amari-measure", version = "0.24.0" }
+amari-calculus = { path = "amari-calculus", version = "0.24.0" }
+amari-holographic = { path = "amari-holographic", version = "0.24.0" }
+amari-probabilistic = { path = "amari-probabilistic", version = "0.24.0" }
+amari-functional = { path = "amari-functional", version = "0.24.0" }
+amari-topology = { path = "amari-topology", version = "0.24.0" }
+amari-dynamics = { path = "amari-dynamics", version = "0.24.0" }
+amari-cgt = { path = "amari-cgt", version = "0.24.0" }
+amari-surreal = { path = "amari-surreal", version = "0.24.0" }
+amari-surcomplex = { path = "amari-surcomplex", version = "0.24.0" }
+amari-rewrite = { path = "amari-rewrite", version = "0.24.0" }
+amari-wasm = { path = "amari-wasm", version = "0.24.0" }
 
 # External dependencies
 num-rational = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Amari v0.23.0
+# Amari
 
 **Comprehensive Mathematical Computing Platform with Geometric Algebra, Differential Calculus, Measure Theory, Probability Theory, Functional Analysis, Algebraic Topology, Dynamical Systems, and Vector Symbolic Architectures**
 
-A unified mathematical computing library featuring geometric algebra, differential calculus, measure theory, probability theory on geometric spaces, functional analysis (Hilbert spaces, operators, spectral theory), algebraic topology (homology, persistent homology, Morse theory), dynamical systems analysis (ODE solvers, stability, bifurcations, chaos, Lyapunov exponents), relativistic physics, tropical algebra, automatic differentiation, holographic associative memory (Vector Symbolic Architectures), optical field operations for holographic displays, term rewriting (ARS/TRS), and information geometry. The library provides multi-GPU infrastructure with intelligent workload distribution and complete WebAssembly support for browser deployment. Version 0.23.0 releases the `RationalSurreal` exact rational scalar layer, experimental epsilon rational functions, the new `amari-surcomplex` exact rational complex crate, `WasmGenericMultivector` for arbitrary-signature Clifford algebra, and the `amari-rewrite` term-rewriting crate while preserving the v0.22.0 CGT/surreal surface and the v0.21.0 tropical/dual extension surface.
+A unified mathematical computing library featuring geometric algebra, differential calculus, measure theory, probability theory on geometric spaces, functional analysis (Hilbert spaces, operators, spectral theory), algebraic topology (homology, persistent homology, Morse theory), dynamical systems analysis (ODE solvers, stability, bifurcations, chaos, Lyapunov exponents), relativistic physics, tropical algebra, automatic differentiation, holographic associative memory (Vector Symbolic Architectures), optical field operations for holographic displays, term rewriting (ARS/TRS), and information geometry. The library provides multi-GPU infrastructure with intelligent workload distribution and complete WebAssembly support for browser deployment. The 0.24.0 cycle adds the agent-first `amari-discovery` runtime and canonical additive holographic `superpose`/`scale` operations while preserving the 0.23 exact rational, surcomplex, arbitrary-signature WASM, and rewrite foundations.
 
 [![Rust](https://img.shields.io/badge/Rust-1.75+-orange.svg)](https://www.rust-lang.org/)
 [![WebAssembly](https://img.shields.io/badge/WebAssembly-Ready-blue.svg)](https://webassembly.org/)
@@ -21,9 +21,9 @@ A unified mathematical computing library featuring geometric algebra, differenti
 - **Arbitrary-signature WASM** — `WasmGenericMultivector(p, q, r)` lets users select any Clifford algebra signature at runtime. Operations for DIM ≤ 6 dispatch through a compile-time match table (84 signatures); larger dimensions fall back to a cached Cayley-table path. 8 fast-path aliases (`WasmMultivector300`, `210`, `310`, `200`, `030`, `410`, `500`, `110`) provide pre-built convenience for the most common physics/engineering signatures.
 - **`amari-rewrite`** is a new crate providing foundational ARS/TRS term-rewriting with `Rewritable` traits, path replacement, substitution/matching, bounded inverse rewriting, anti-unification, and rule inference scaffolding. Experimental `neural`, `smt`, and `amari-network` feature gates offer rewrite-search guidance hooks.
 
-## v0.24.0 Development Preview: Amari Discovery
+## v0.24.0 Release Candidate: Amari Discovery
 
-The unreleased `amari-discovery` crate is the sole owner of the installed
+The `amari-discovery` crate is the sole owner of the installed
 `amari` command. It provides deterministic catalog exploration, bounded
 read-only Rust/Cargo and npm TypeScript inspection, holographic candidate
 recall, Pareto ranking, replayable integration plans, registered mathematical
@@ -42,8 +42,9 @@ Discovery never edits inspected projects or runs their compilers, build
 scripts, lifecycle scripts, arbitrary commands, providers, or network access.
 See the [Amari Discovery Guide](docs/guide/amari-discovery.md) for the human and
 agent loops, privacy boundary, probe isolation, catalog maintenance, and
-release-status caveats. This preview is not a 0.24.0 publication claim; the
-workspace remains at 0.23.0 until aggregate release acceptance.
+release-status caveats. The workspace and catalogs are synchronized to 0.24.0,
+but this release candidate is not a publication claim until crates.io/npm
+publication, registry installation, and the `v0.24.0` tag are verified.
 
 ## v0.22.0 Highlights
 
@@ -120,7 +121,7 @@ At the umbrella-crate level these are exposed through optional features:
 
 ```toml
 [dependencies]
-amari = { version = "0.23.0", features = ["surreal", "surcomplex"] }
+amari = { version = "0.24.0", features = ["surreal", "surcomplex"] }
 ```
 
 `surcomplex` implies `surreal`, which implies `cgt`. The `surreal` feature also gates `RationalSurreal` and the opt-in `experimental-epsilon` feature.
@@ -134,72 +135,72 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Complete library with all features
-amari = "0.23.0"
+amari = "0.24.0"
 
 # Or individual crates:
 
 # Core geometric algebra and mathematical foundations
-amari-core = "0.23.0"
+amari-core = "0.24.0"
 
 # Differential calculus with geometric algebra
-amari-calculus = "0.23.0"
+amari-calculus = "0.24.0"
 
 # Measure theory and integration
-amari-measure = "0.23.0"
+amari-measure = "0.24.0"
 
 # Probability theory on geometric algebra spaces
-amari-probabilistic = "0.23.0"
+amari-probabilistic = "0.24.0"
 
 # Functional analysis: Hilbert spaces, operators, spectral theory
-amari-functional = "0.23.0"
+amari-functional = "0.24.0"
 
 # Algebraic topology: homology, persistent homology, Morse theory
-amari-topology = "0.23.0"
+amari-topology = "0.24.0"
 
 # Dynamical systems: ODE solvers, stability, bifurcations, Lyapunov exponents
-amari-dynamics = "0.23.0"
+amari-dynamics = "0.24.0"
 
 # Vector Symbolic Architectures, holographic memory, and optical fields
-amari-holographic = "0.23.0"
+amari-holographic = "0.24.0"
 
 # High-precision relativistic physics
-amari-relativistic = { version = "0.23.0", features = ["high-precision"] }
+amari-relativistic = { version = "0.24.0", features = ["high-precision"] }
 
 # GPU acceleration (includes optical field GPU operations)
-amari-gpu = "0.23.0"
+amari-gpu = "0.24.0"
 
 # Optimization algorithms
-amari-optimization = "0.23.0"
+amari-optimization = "0.24.0"
 
 # Additional mathematical systems
-amari-tropical = "0.23.0"    # max-plus semiring + ordinal weights below ε₀
-amari-dual = "0.23.0"        # forward-mode AD + branch policies + static gradients
-amari-info-geom = "0.23.0"
-amari-automata = "0.23.0"
-amari-fusion = "0.23.0"
-amari-network = "0.23.0"
-amari-enumerative = "0.23.0"
-amari-cgt = "0.23.0"         # short combinatorial games + nimbers
-amari-surreal = "0.23.0"    # exact rational surreal scalars + epsilon rationals
-amari-surcomplex = "0.23.0" # exact rational surcomplex arithmetic
+amari-tropical = "0.24.0"    # max-plus semiring + ordinal weights below ε₀
+amari-dual = "0.24.0"        # forward-mode AD + branch policies + static gradients
+amari-info-geom = "0.24.0"
+amari-automata = "0.24.0"
+amari-fusion = "0.24.0"
+amari-network = "0.24.0"
+amari-enumerative = "0.24.0"
+amari-cgt = "0.24.0"         # short combinatorial games + nimbers
+amari-surreal = "0.24.0"    # exact rational surreal scalars + epsilon rationals
+amari-surcomplex = "0.24.0" # exact rational surcomplex arithmetic
 
 # Probabilistic verification contracts (SMT-LIB2, Monte Carlo)
-amari-flynn = "0.23.0"
+amari-flynn = "0.24.0"
 
 # Optional Rust-side WebAssembly crate
-amari-wasm = "0.23.0"
+amari-wasm = "0.24.0"
 ```
 
 ### JavaScript/TypeScript (WebAssembly)
 
 ```bash
-npm install @justinelliottcobb/amari-wasm@0.23.0
+npm install @justinelliottcobb/amari-wasm@0.24.0
 ```
 
 Or with yarn:
 
 ```bash
-yarn add @justinelliottcobb/amari-wasm@0.23.0
+yarn add @justinelliottcobb/amari-wasm@0.24.0
 ```
 
 ## Quick Start
@@ -863,9 +864,9 @@ The **[Amari Examples Suite](https://amari-math.netlify.app)** provides comprehe
 
 - **Interactive Playground**: Write and run JavaScript code with live WASM execution
 
-## Examples & Documentation (v0.23.0)
+## Examples & Documentation (v0.24.0)
 
-The examples suite is versioned for `0.23.0` and now includes release-focused rational surreal / surcomplex workflows alongside the v0.22 CGT/surreal workflows and the broader mathematical catalog:
+The examples suite is versioned for `0.24.0` and includes discovery-era catalog workflows plus release-focused rational surreal / surcomplex examples, v0.22 CGT/surreal workflows, and the broader mathematical catalog:
 
 - **CGT 0.22.0 WASM examples**: `WasmCgtArena`, short-game cuts, outcomes, comparison, nimbers, and `WasmGameInspection`
 - **Surreal 0.22.0 WASM examples**: `WasmDyadic`, `WasmShortSurreal`, exact dyadic arithmetic, checked division, and numeric-game conversion

--- a/amari-discovery/catalog/probes.toml
+++ b/amari-discovery/catalog/probes.toml
@@ -1,4 +1,4 @@
-catalog_version = "0.23.0"
+catalog_version = "0.24.0"
 
 [[probes]]
 id = "amari-probe:core:geometric-product:v1"

--- a/amari-discovery/catalog/semantic/core.toml
+++ b/amari-discovery/catalog/semantic/core.toml
@@ -1,4 +1,4 @@
-catalog_version = "0.23.0"
+catalog_version = "0.24.0"
 
 [[capabilities]]
 id = "amari:amari-core:product:geometric-product"

--- a/amari-discovery/tests/catalog_generation.rs
+++ b/amari-discovery/tests/catalog_generation.rs
@@ -489,11 +489,14 @@ fn modified_copy_produces_drift_error() {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let temp_path = temp_dir.path().join("modified.json");
 
-    // Write a deliberately corrupted version.
-    let modified = String::from_utf8_lossy(&json).replace(
-        "\"version\": \"0.23.0\"",
+    // Write a deliberately corrupted version without coupling the test to a release.
+    let version_field = format!("\"version\": \"{}\"", catalog.version);
+    let modified = String::from_utf8_lossy(&json).replacen(
+        &version_field,
         "\"version\": \"0.0.0-corrupted\"",
+        1,
     );
+    assert_ne!(modified.as_bytes(), json, "test mutation must change bytes");
     fs::write(&temp_path, modified.as_bytes()).unwrap();
 
     let result = verify_checked_in(workspace_root(), &temp_path);
@@ -579,10 +582,13 @@ fn verify_checked_in_drift_message_includes_first_differing_line() {
     let temp_path = temp_dir.path().join("corrupted.json");
 
     // Corrupt the version string which appears early in the JSON.
-    let modified = String::from_utf8_lossy(&json).replace(
-        "\"version\": \"0.23.0\"",
+    let version_field = format!("\"version\": \"{}\"", catalog.version);
+    let modified = String::from_utf8_lossy(&json).replacen(
+        &version_field,
         "\"version\": \"0.0.0-corrupted\"",
+        1,
     );
+    assert_ne!(modified.as_bytes(), json, "test mutation must change bytes");
     fs::write(&temp_path, modified.as_bytes()).unwrap();
 
     let result = verify_checked_in(workspace_root(), &temp_path);

--- a/amari-discovery/tests/catalog_package_links.rs
+++ b/amari-discovery/tests/catalog_package_links.rs
@@ -228,7 +228,7 @@ fn real_workspace_links_match_cargo_manifests() {
         .find(|dependency| dependency.alias == "amari-core")
         .unwrap();
     assert_eq!(core.package, "amari-core");
-    assert_eq!(core.version.as_deref(), Some("0.23.0"));
+    assert_eq!(core.version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
     assert_eq!(core.path.as_deref(), Some("amari-core"));
     assert_eq!(core.kind, DependencyKind::Normal);
     assert!(!core.optional);

--- a/amari-discovery/tests/catalog_packages.rs
+++ b/amari-discovery/tests/catalog_packages.rs
@@ -123,7 +123,12 @@ fn real_inventory_includes_root_and_wasm_but_excludes_discovery() {
     }
 
     for package in &inventory.packages {
-        assert_eq!(package.version, "0.23.0", "{} version", package.name);
+        assert_eq!(
+            package.version,
+            env!("CARGO_PKG_VERSION"),
+            "{} version",
+            package.name
+        );
         assert_eq!(package.edition, "2021", "{} edition", package.name);
         assert_eq!(
             package.license, "MIT OR Apache-2.0",

--- a/amari-discovery/tests/cli_capabilities.rs
+++ b/amari-discovery/tests/cli_capabilities.rs
@@ -59,7 +59,10 @@ fn capabilities_json_self_describes_schema_and_exit_codes() {
 fn embedded_catalog_capabilities_derive_probe_execution_from_registry() {
     let value = capabilities_json();
 
-    assert_eq!(value["data"]["catalog"]["version"], "0.23.0");
+    assert_eq!(
+        value["data"]["catalog"]["version"],
+        env!("CARGO_PKG_VERSION")
+    );
     assert_eq!(value["data"]["catalog"]["available"], true);
     assert_eq!(
         value["provenance"]["catalog"]["hash"],
@@ -174,7 +177,10 @@ fn capabilities_human_output_is_concise() {
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("Amari Discovery"))
         .stdout(predicate::str::contains("Project inspectors"))
-        .stdout(predicate::str::contains("Catalog: 0.23.0 (available)"))
+        .stdout(predicate::str::contains(format!(
+            "Catalog: {} (available)",
+            env!("CARGO_PKG_VERSION")
+        )))
         .stdout(predicate::str::contains("Resource limits"))
         .stdout(predicate::str::contains("max_per_file_bytes"))
         .stdout(predicate::str::contains("max_inspection_wall_millis"))

--- a/amari-discovery/tests/cli_discover.rs
+++ b/amari-discovery/tests/cli_discover.rs
@@ -91,7 +91,10 @@ fn search_tropical_json_returns_compact_results() {
     }
 
     // Provenance: catalog identity present, no project context
-    assert_eq!(value["provenance"]["catalog"]["version"], "0.23.0");
+    assert_eq!(
+        value["provenance"]["catalog"]["version"],
+        env!("CARGO_PKG_VERSION")
+    );
     assert!(value["provenance"]["catalog"]["hash"].is_string());
     assert_eq!(value["provenance"]["project_hash"], Value::Null);
     assert_eq!(value["provenance"]["input_hash"], Value::Null);
@@ -626,7 +629,10 @@ fn discover_provenance_identifies_embedded_catalog_and_non_project() {
     ]);
     for args in &args_sets {
         let value = discover_json(args);
-        assert_eq!(value["provenance"]["catalog"]["version"], "0.23.0");
+        assert_eq!(
+            value["provenance"]["catalog"]["version"],
+            env!("CARGO_PKG_VERSION")
+        );
         assert!(value["provenance"]["catalog"]["hash"].is_string());
         assert_eq!(value["provenance"]["project_hash"], Value::Null);
         assert_eq!(value["provenance"]["compatibility"]["status"], "compatible");

--- a/amari-gpu/Cargo.toml
+++ b/amari-gpu/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["mathematics", "science", "algorithms"]
 # Default to no high-precision for GPU (and WASM compatibility)
 # These are specified directly instead of via workspace inheritance so
 # `default-features = false` is honored without Cargo warnings.
-amari-core = { path = "../amari-core", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
-amari-info-geom = { path = "../amari-info-geom", version = "0.23.0", default-features = false, features = ["std"] }
-amari-network = { path = "../amari-network", version = "0.23.0", default-features = false, features = ["std"] }
-amari-relativistic = { path = "../amari-relativistic", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
+amari-info-geom = { path = "../amari-info-geom", version = "0.24.0", default-features = false, features = ["std"] }
+amari-network = { path = "../amari-network", version = "0.24.0", default-features = false, features = ["std"] }
+amari-relativistic = { path = "../amari-relativistic", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
 amari-measure = { workspace = true, optional = true }
 amari-calculus = { workspace = true, optional = true }
 amari-tropical = { workspace = true, optional = true }

--- a/amari-relativistic/Cargo.toml
+++ b/amari-relativistic/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["mathematics", "science", "simulation", "algorithms"]
 [dependencies]
 # Use a direct dependency instead of workspace inheritance so `default-features = false`
 # is honored (Cargo ignores it unless the workspace dependency also sets it).
-amari-core = { path = "../amari-core", version = "0.23.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
 nalgebra = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 num-traits = { workspace = true }

--- a/amari-wasm/examples/package.json
+++ b/amari-wasm/examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amari-wasm-examples",
-  "version": "0.23.0",
-  "description": "Comprehensive examples for Amari v0.23.0 WebAssembly mathematical computing library",
+  "version": "0.24.0",
+  "description": "Comprehensive examples for Amari v0.24.0 WebAssembly mathematical computing library",
   "type": "module",
   "scripts": {
     "demo": "node --loader ts-node/esm complete-demo.ts",
@@ -15,7 +15,7 @@
     "all": "npm run demo && npm run geometric && npm run tropical && npm run autodiff && npm run infogeom && npm run fusion && npm run flynn && npm run gf2"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.23.0"
+    "@justinelliottcobb/amari-wasm": "^0.24.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/amari-wasm/package.json
+++ b/amari-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justinelliottcobb/amari-wasm",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "WebAssembly bindings for Amari mathematical computing library",
   "scripts": {
     "build": "wasm-pack build --target web --out-dir pkg --scope justinelliottcobb",

--- a/docs/development/VERSION_MANAGEMENT.md
+++ b/docs/development/VERSION_MANAGEMENT.md
@@ -7,8 +7,9 @@ This document describes the version management system for the Amari project, whi
 The Amari project consists of multiple components that need to stay version-synchronized:
 
 - **Rust Workspace**: Main workspace defined in `Cargo.toml`
-- **Individual Rust Crates**: All amari-* crates inherit from workspace version
-- **WebAssembly Package**: `amari-wasm/package.json` (npm package)
+- **Individual Rust Crates**: Workspace versions plus every versioned internal path dependency
+- **JavaScript Packages**: WASM, TypeScript, examples, and package-lock root metadata
+- **Discovery Catalogs**: Semantic and probe catalog versions
 
 ## Automated Version Synchronization
 
@@ -36,9 +37,15 @@ The `scripts/version-sync.sh` script provides automated version management:
 
 The script synchronizes versions across:
 
-1. **Cargo.toml workspace.package.version** - Main workspace version
-2. **Cargo.toml workspace.dependencies** - All internal crate references
-3. **amari-wasm/package.json version** - npm package version
+1. **Cargo workspace package/dependencies** - Main version and root internal references
+2. **Nested Cargo manifests** - Every versioned `amari-*` path dependency
+3. **JavaScript package metadata** - Published packages, examples, and package-lock root
+4. **Internal WASM requirements** - Versioned `@justinelliottcobb/amari-wasm` example dependencies
+5. **Discovery catalogs** - Semantic and probe `catalog_version` values
+
+Run `./scripts/test-version-sync.sh` after changing synchronization behavior.
+The legacy `scripts/bump-version.sh <version>` entry point delegates to
+`version-sync.sh set <version>` so there is only one synchronization authority.
 
 ## Release Process
 
@@ -66,8 +73,8 @@ The script synchronizes versions across:
 
 4. **Commit version changes**:
    ```bash
-   git add Cargo.toml amari-wasm/package.json
-   git commit -m "Bump version to 0.9.3"
+   git add -A
+   git commit -m "chore: bump version to 0.9.3"
    ```
 
 5. **Continue with normal release process** (PR, testing, merge, tag)

--- a/docs/guide/amari-discovery.md
+++ b/docs/guide/amari-discovery.md
@@ -6,10 +6,10 @@ checked-in capability catalog, bounded project inspection, deterministic
 candidate retrieval and ranking, replayable plans, and registered mathematical
 probes.
 
-This guide describes the 0.24.0 feature surface while the workspace is still at
-0.23.0. Passing feature-branch checks is not a 0.24.0 release claim; aggregate
-versioning, catalog regeneration, package verification, publication, and
-post-publication installation remain separate release gates. Every `bash`
+This guide describes the 0.24.0 feature surface. The workspace and catalogs are
+synchronized to the release candidate, but passing source checks is not a
+0.24.0 publication claim; package verification, publication, registry
+installation, and tagging remain separate release gates. Every `bash`
 block in this guide is runnable in the stated checkout or inspected-project
 context. Contributor commands with additional WASM/toolchain prerequisites use
 `text` blocks instead.

--- a/docs/releases/v0.24.0-aggregate-release-gates.md
+++ b/docs/releases/v0.24.0-aggregate-release-gates.md
@@ -17,11 +17,17 @@ As of 2026-07-24:
   PR #214.
 - Public discovery documentation, package-shape evidence, and functional
   budgets merged through PR #215.
-- The workspace and embedded catalog still identify version 0.23.0.
-- Required 0.24.0 internal dependencies have not been published and indexed.
+- The release-prep branch synchronizes workspace/internal/npm metadata and the
+  embedded Rust catalog to 0.24.0.
+- The regenerated Rust catalog content hash is
+  `fd286f4d76d4d20afa4490cb55b16daae5cb3edd44e43b2bbfadd30a9507ae1f`;
+  the authoritative WASM source hash remains
+  `d9487f0fdc2055eb5a6f45505db8f1ac212a51396e36eb5af6bc52a90361e93c`.
+- Required 0.24.0 internal dependencies have not yet been published and
+  indexed.
 
-Therefore 0.24.0 is ready to enter aggregate release acceptance, but it is
-**not shipped** until the gates below complete.
+Therefore aggregate release acceptance is in progress, but 0.24.0 is **not
+shipped** until the gates below complete.
 
 ## Task 28 publication-order audit
 

--- a/examples-suite/package-lock.json
+++ b/examples-suite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amari-examples-suite",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@justinelliottcobb/amari-wasm": "*",
         "@mantine/code-highlight": "^8.3.16",

--- a/examples-suite/package.json
+++ b/examples-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Interactive API examples for the Amari Mathematical Computing Library",
   "private": true,
   "type": "module",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-typescript-example",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Example TypeScript project using the Amari mathematical computing library",
   "main": "dist/example.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.23.0"
+    "@justinelliottcobb/amari-wasm": "^0.24.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/web/interactive-demos/package.json
+++ b/examples/web/interactive-demos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-interactive-demos",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Interactive web demonstrations of Amari mathematical computing library",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "wasm-pack": "wasm-pack build --target web --out-dir pkg ../../../amari-wasm"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.23.0",
+    "@justinelliottcobb/amari-wasm": "^0.24.0",
     "three": "^0.158.0",
     "dat.gui": "^0.7.9",
     "katex": "^0.16.8",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,94 +1,14 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# Compatibility entry point. version-sync.sh is the sole version authority.
 
-# Script to bump version numbers across the entire Amari workspace
-# Usage: ./scripts/bump-version.sh <new_version>
-# Example: ./scripts/bump-version.sh 0.6.1
+set -euo pipefail
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <new_version>"
-    echo "Example: $0 0.6.1"
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <new_version>" >&2
     exit 1
 fi
 
-NEW_VERSION="$1"
-
-# Validate version format (basic check)
-if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$'; then
-    echo "Error: Invalid version format. Expected format: X.Y.Z or X.Y.Z-suffix"
-    exit 1
-fi
-
-echo "Bumping version to $NEW_VERSION across the workspace..."
-
-# Extract major.minor for dependency specifications (e.g., 0.6 from 0.6.1)
-MAJOR_MINOR=$(echo "$NEW_VERSION" | sed 's/\([0-9]*\.[0-9]*\).*/\1/')
-
-# Update root workspace version
-echo "Updating root Cargo.toml..."
-sed -i "s/^version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" Cargo.toml
-
-# Update all workspace member Cargo.toml files
-for crate_dir in amari-*; do
-    if [ -d "$crate_dir" ] && [ -f "$crate_dir/Cargo.toml" ]; then
-        echo "Updating $crate_dir/Cargo.toml..."
-
-        # Update inter-crate dependencies to use the new major.minor version
-        sed -i "s/\(amari-[a-z-]* = {.*version = \"\)[^\"]*/\1$MAJOR_MINOR/" "$crate_dir/Cargo.toml"
-    fi
-done
-
-# Update root Cargo.toml dependencies
-echo "Updating root dependencies..."
-sed -i "s/\(amari-[a-z-]* = {.*version = \"\)[^\"]*/\1$MAJOR_MINOR/" Cargo.toml
-
-# Update package.json files if they exist
-if [ -f "typescript/package.json" ]; then
-    echo "Updating typescript/package.json..."
-    sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" typescript/package.json
-fi
-
-if [ -f "amari-wasm/pkg/package.json" ]; then
-    echo "Updating amari-wasm/pkg/package.json..."
-    sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" amari-wasm/pkg/package.json
-fi
-
-if [ -f "examples/typescript/package.json" ]; then
-    echo "Updating examples/typescript/package.json..."
-    sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" examples/typescript/package.json
-fi
-
-if [ -f "examples-suite/package.json" ]; then
-    echo "Updating examples-suite/package.json..."
-    sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_VERSION\"/" examples-suite/package.json
-fi
-
-# Update README badges if they contain version numbers
-if [ -f "README.md" ]; then
-    echo "Updating README.md badges..."
-    sed -i "s/\(crates\.io-v\)[0-9.]*\(-\)/\1$NEW_VERSION\2/g" README.md
-    sed -i "s/\(npm-v\)[0-9.]*\(-\)/\1$NEW_VERSION\2/g" README.md
-fi
-
-# Update CHANGELOG if it exists
-if [ -f "CHANGELOG.md" ]; then
-    echo "Adding entry to CHANGELOG.md..."
-    # Add a new unreleased section if this is a new version
-    if ! grep -q "## \[$NEW_VERSION\]" CHANGELOG.md; then
-        DATE=$(date +%Y-%m-%d)
-        sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$NEW_VERSION] - $DATE/" CHANGELOG.md
-    fi
-fi
-
-echo ""
-echo "✅ Version bumped to $NEW_VERSION successfully!"
-echo ""
-echo "Summary of changes:"
-echo "  - Workspace version: $NEW_VERSION"
-echo "  - Dependency versions: $MAJOR_MINOR"
-echo ""
-echo "Next steps:"
-echo "  1. Review the changes: git diff"
-echo "  2. Commit the changes: git commit -am \"chore: bump version to $NEW_VERSION\""
-echo "  3. Tag the release: git tag v$NEW_VERSION"
-echo "  4. Push changes: git push && git push --tags"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+echo "NOTICE: bump-version.sh delegates to version-sync.sh set" >&2
+exec "$script_dir/version-sync.sh" set "$1"

--- a/scripts/test-version-sync.sh
+++ b/scripts/test-version-sync.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p \
+  "$fixture/scripts" \
+  "$fixture/member" \
+  "$fixture/amari-wasm/examples" \
+  "$fixture/amari-discovery/catalog/semantic" \
+  "$fixture/typescript" \
+  "$fixture/examples/typescript" \
+  "$fixture/examples/web/interactive-demos" \
+  "$fixture/examples-suite"
+cp "$repo_root/scripts/version-sync.sh" "$fixture/scripts/version-sync.sh"
+cp "$repo_root/scripts/bump-version.sh" "$fixture/scripts/bump-version.sh"
+
+cat > "$fixture/Cargo.toml" <<'TOML'
+[workspace]
+members = ["member"]
+
+[workspace.package]
+version = "0.23.0"
+
+[workspace.dependencies]
+amari-core = { path = "member", version = "0.23.0" }
+serde = { version = "1.0.219", features = ["derive"] }
+TOML
+
+cat > "$fixture/member/Cargo.toml" <<'TOML'
+[package]
+name = "member"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+amari-core = { path = "../member", version = "0.23.0" }
+fixture-shared = { path = "../vendor", version = "9.8.7" }
+serde = { version = "1.0.219" }
+TOML
+mkdir -p "$fixture/member/src"
+printf '%s\n' '' > "$fixture/member/src/lib.rs"
+
+write_package() {
+  local path=$1
+  local name=$2
+  cat > "$path" <<JSON
+{
+  "name": "$name",
+  "version": "0.23.0",
+  "dependencies": {
+    "@justinelliottcobb/amari-wasm": "^0.23.0",
+    "unrelated": "^9.8.7"
+  }
+}
+JSON
+}
+
+write_package "$fixture/amari-wasm/package.json" "@justinelliottcobb/amari-wasm"
+write_package "$fixture/amari-wasm/examples/package.json" "amari-wasm-examples"
+write_package "$fixture/typescript/package.json" "amari-typescript"
+write_package "$fixture/examples/typescript/package.json" "amari-typescript-example"
+write_package "$fixture/examples/web/interactive-demos/package.json" "amari-web-example"
+write_package "$fixture/examples-suite/package.json" "amari-examples-suite"
+cat > "$fixture/examples-suite/package-lock.json" <<'JSON'
+{
+  "name": "amari-examples-suite",
+  "version": "0.23.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "amari-examples-suite",
+      "version": "0.23.0"
+    },
+    "node_modules/unrelated": {
+      "version": "9.8.7"
+    }
+  }
+}
+JSON
+
+printf 'catalog_version = "0.23.0"\n' > "$fixture/amari-discovery/catalog/probes.toml"
+printf 'catalog_version = "0.23.0"\n' > "$fixture/amari-discovery/catalog/semantic/core.toml"
+
+(
+  cd "$fixture"
+  ./scripts/version-sync.sh set 0.24.0 >/dev/null
+)
+
+grep -q 'version = "0.24.0"' "$fixture/Cargo.toml"
+grep -q 'path = "../member", version = "0.24.0"' "$fixture/member/Cargo.toml"
+grep -q 'fixture-shared = { path = "../vendor", version = "9.8.7" }' "$fixture/member/Cargo.toml"
+grep -q 'serde = { version = "1.0.219" }' "$fixture/member/Cargo.toml"
+grep -q 'catalog_version = "0.24.0"' "$fixture/amari-discovery/catalog/probes.toml"
+
+python3 - "$fixture" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+for relative in (
+    "amari-wasm/package.json",
+    "amari-wasm/examples/package.json",
+    "typescript/package.json",
+    "examples/typescript/package.json",
+    "examples/web/interactive-demos/package.json",
+    "examples-suite/package.json",
+):
+    data = json.loads((root / relative).read_text())
+    assert data["version"] == "0.24.0", (relative, data["version"])
+    assert data["dependencies"]["@justinelliottcobb/amari-wasm"] == "^0.24.0"
+    assert data["dependencies"]["unrelated"] == "^9.8.7"
+
+lock = json.loads((root / "examples-suite/package-lock.json").read_text())
+assert lock["version"] == "0.24.0"
+assert lock["packages"][""]["version"] == "0.24.0"
+assert lock["packages"]["node_modules/unrelated"]["version"] == "9.8.7"
+PY
+
+# The legacy entry point must delegate to the same exhaustive authority.
+(
+  cd "$fixture"
+  ./scripts/bump-version.sh 0.25.0 >/dev/null
+  ./scripts/version-sync.sh verify 0.25.0 >/dev/null
+)
+
+# Verification must inspect nested manifests, not just count root matches.
+sed -i 's/version = "0.25.0"/version = "0.23.0"/' "$fixture/member/Cargo.toml"
+if (cd "$fixture" && ./scripts/version-sync.sh verify 0.25.0 >/dev/null 2>&1); then
+  echo "version verification accepted a stale nested path dependency" >&2
+  exit 1
+fi
+
+printf 'version-sync fixture passed\n'

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -12,9 +12,22 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Default files to update
+# Version authorities and active JavaScript package metadata.
 CARGO_TOML="Cargo.toml"
 PACKAGE_JSON="amari-wasm/package.json"
+NPM_PACKAGE_FILES=(
+    "amari-wasm/package.json"
+    "amari-wasm/examples/package.json"
+    "typescript/package.json"
+    "examples/typescript/package.json"
+    "examples/web/interactive-demos/package.json"
+    "examples-suite/package.json"
+    "examples-suite/package-lock.json"
+)
+CATALOG_FILES=(
+    "amari-discovery/catalog/probes.toml"
+    "amari-discovery/catalog/semantic/core.toml"
+)
 
 # Function to print colored output
 print_status() {
@@ -83,19 +96,61 @@ update_cargo_version() {
     print_success "Updated Cargo.toml versions"
 }
 
-# Function to update package.json version
-update_package_json_version() {
+# Update every path dependency version in every workspace manifest.
+update_path_dependency_versions() {
     local new_version=$1
 
-    print_status "Updating package.json version to $new_version..."
+    while IFS= read -r -d '' manifest; do
+        sed -E -i.bak "/^[[:space:]]*amari(-[[:alnum:]-]+)?[[:space:]]*=.*path[[:space:]]*=/s/version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"$new_version\"/g" "$manifest"
+        rm -f "$manifest.bak"
+    done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.worktrees/*' -print0)
+}
 
-    # Only update the main version field (not in scripts section)
-    sed -i.bak "/^\s*\"version\":/s/\"version\": \".*\"/\"version\": \"$new_version\"/" "$PACKAGE_JSON"
+# Update active JavaScript package versions without touching external packages.
+update_npm_versions() {
+    local new_version=$1
 
-    # Remove backup file
-    rm -f "$PACKAGE_JSON.bak"
+    print_status "Updating JavaScript package metadata to $new_version..."
+    python3 - "$new_version" "${NPM_PACKAGE_FILES[@]}" <<'PY'
+import json
+import pathlib
+import re
+import sys
 
-    print_success "Updated package.json version"
+new_version = sys.argv[1]
+for raw_path in sys.argv[2:]:
+    path = pathlib.Path(raw_path)
+    if not path.is_file():
+        continue
+    data = json.loads(path.read_text())
+    if "version" in data:
+        data["version"] = new_version
+    root_package = data.get("packages", {}).get("")
+    if isinstance(root_package, dict) and "version" in root_package:
+        root_package["version"] = new_version
+    for section in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        dependencies = data.get(section)
+        if not isinstance(dependencies, dict):
+            continue
+        requirement = dependencies.get("@justinelliottcobb/amari-wasm")
+        if not isinstance(requirement, str) or requirement == "latest":
+            continue
+        match = re.fullmatch(r"([~^]?)[0-9]+\.[0-9]+\.[0-9]+", requirement)
+        if match:
+            dependencies["@justinelliottcobb/amari-wasm"] = f"{match.group(1)}{new_version}"
+    path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+    print_success "Updated JavaScript package metadata"
+}
+
+update_catalog_versions() {
+    local new_version=$1
+
+    for catalog in "${CATALOG_FILES[@]}"; do
+        [[ -f "$catalog" ]] || continue
+        sed -E -i.bak "s/^catalog_version = \"[^\"]+\"/catalog_version = \"$new_version\"/" "$catalog"
+        rm -f "$catalog.bak"
+    done
 }
 
 # Function to verify all versions are synchronized
@@ -111,18 +166,63 @@ verify_versions() {
         return 1
     fi
 
-    # Check package.json version
-    local package_version=$(get_package_json_version)
-    if [[ "$package_version" != "$expected_version" ]]; then
-        print_error "package.json version mismatch: expected $expected_version, found $package_version"
+    # Check every path dependency in every manifest.
+    local stale_manifest_lines
+    stale_manifest_lines=$(find . -name Cargo.toml -not -path './target/*' -not -path './.worktrees/*' -print0 \
+        | xargs -0 grep -H -E '^[[:space:]]*amari(-[[:alnum:]-]+)?[[:space:]]*=.*path[[:space:]]*=' \
+        | grep 'version = ' \
+        | grep -v "version = \"$expected_version\"" || true)
+    if [[ -n "$stale_manifest_lines" ]]; then
+        print_error "Stale path dependency versions found:"
+        printf '%s\n' "$stale_manifest_lines" >&2
         return 1
     fi
 
-    # Check that all workspace dependencies have the correct version
-    local workspace_deps_count=$(grep -c "version = \"$expected_version\"" "$CARGO_TOML" || true)
-    if [[ $workspace_deps_count -lt 10 ]]; then  # We have 11+ internal crates
-        print_warning "Some workspace dependencies may not be updated (found $workspace_deps_count matches)"
+    # Check active JavaScript package metadata and internal requirements.
+    if ! python3 - "$expected_version" "${NPM_PACKAGE_FILES[@]}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+expected = sys.argv[1]
+errors = []
+for raw_path in sys.argv[2:]:
+    path = pathlib.Path(raw_path)
+    if not path.is_file():
+        continue
+    data = json.loads(path.read_text())
+    if "version" in data and data["version"] != expected:
+        errors.append(f"{path}: top-level version {data['version']}")
+    root_package = data.get("packages", {}).get("")
+    if isinstance(root_package, dict) and "version" in root_package and root_package["version"] != expected:
+        errors.append(f"{path}: root lock package version {root_package['version']}")
+    for section in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        dependencies = data.get(section)
+        if not isinstance(dependencies, dict):
+            continue
+        requirement = dependencies.get("@justinelliottcobb/amari-wasm")
+        if not isinstance(requirement, str) or requirement == "latest":
+            continue
+        match = re.fullmatch(r"[~^]?([0-9]+\.[0-9]+\.[0-9]+)", requirement)
+        if match and match.group(1) != expected:
+            errors.append(f"{path}: {section} amari-wasm requirement {requirement}")
+if errors:
+    print("\n".join(errors), file=sys.stderr)
+    raise SystemExit(1)
+PY
+    then
+        print_error "JavaScript package versions are not synchronized"
+        return 1
     fi
+
+    for catalog in "${CATALOG_FILES[@]}"; do
+        [[ -f "$catalog" ]] || continue
+        if ! grep -q "^catalog_version = \"$expected_version\"$" "$catalog"; then
+            print_error "$catalog catalog_version is not $expected_version"
+            return 1
+        fi
+    done
 
     print_success "All versions synchronized to $expected_version"
     return 0
@@ -209,8 +309,10 @@ Examples:
 
 This script synchronizes versions between:
 - Cargo.toml workspace.package.version
-- Cargo.toml workspace.dependencies versions
-- amari-wasm/package.json version
+- every internal path dependency version in workspace manifests
+- active JavaScript package and package-lock metadata
+- amari-wasm dependency requirements in examples
+- discovery semantic/probe catalog versions
 EOF
 }
 
@@ -239,7 +341,9 @@ main() {
 
             print_status "Setting all versions to $new_version"
             update_cargo_version "$new_version"
-            update_package_json_version "$new_version"
+            update_path_dependency_versions "$new_version"
+            update_npm_versions "$new_version"
+            update_catalog_versions "$new_version"
             verify_versions "$new_version"
             ;;
         bump)
@@ -255,7 +359,9 @@ main() {
 
             print_status "Bumping $bump_type version to $new_version"
             update_cargo_version "$new_version"
-            update_package_json_version "$new_version"
+            update_path_dependency_versions "$new_version"
+            update_npm_versions "$new_version"
+            update_catalog_versions "$new_version"
             verify_versions "$new_version"
             ;;
         verify)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "High-performance Geometric Algebra/Clifford Algebra library with TypeScript bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Synchronizes Amari’s complete active release metadata and discovery authorities to **0.24.0** after the discovery/holographic scope was approved for release.

- bumps workspace package and all root internal dependencies to 0.24.0
- fixes previously missed nested internal path requirements in `amari-gpu` and `amari-relativistic`
- synchronizes active WASM/TypeScript/examples/package-lock metadata
- updates versioned `amari-wasm` example requirements
- regenerates the Rust discovery catalog at 0.24.0
- updates semantic/probe catalog versions
- removes release-number coupling from catalog/CLI tests
- makes `version-sync.sh` exhaustive across nested manifests, JS metadata, lock root, and discovery catalogs
- converts legacy `bump-version.sh` into a tested wrapper around the sole version authority
- updates README/install examples and release-candidate documentation without rewriting historical 0.23 feature prose

## Catalog evidence

- Rust catalog version: `0.24.0`
- Rust content hash: `fd286f4d76d4d20afa4490cb55b16daae5cb3edd44e43b2bbfadd30a9507ae1f`
- Rust file SHA-256: `f0f31763f68ad7be46b58b81924392c4c07af56e18b780c0d956b2525c2e3aaf`
- WASM source hash: `d9487f0fdc2055eb5a6f45505db8f1ac212a51396e36eb5af6bc52a90361e93c`
- WASM file SHA-256: `b34bf6e51b2df1c0bbce9c1264d9df57e8f5b3725a0214d1a24a81d300453265`
- both generators rerun byte-identically

## RED → GREEN fixes

1. `version-sync.sh verify` previously passed with stale nested 0.23 path dependencies.
   - Added a hermetic fixture proving stale nested requirements were missed.
   - Added exhaustive update/verification while preserving unrelated path and npm dependencies.
2. Catalog drift/current-version tests hardcoded `0.23.0` and failed after regeneration.
   - Reproduced failures.
   - Replaced release coupling with generated/package authority and explicit mutation assertions.
3. Legacy `bump-version.sh` had a conflicting partial implementation.
   - Extended the fixture to fail against it.
   - Replaced it with a tested delegation wrapper.

## Verification

Passed sequentially:

- `cargo fmt --all -- --check`
- `git diff --check`
- Rust and WASM catalog generation twice with byte-identical output
- catalog generation/integrity/WASM tests
- `cargo test -p amari-discovery --all-features`
- `cargo test -p amari-discovery --no-default-features`
- `cargo check -p amari-discovery --no-default-features`
- `cargo test -p amari-holographic`
- `cargo test --workspace --quiet`
- scoped all-feature warning-denied Clippy
- scoped rustdoc with `-D warnings`
- version-sync fixture and `verify 0.24.0`
- workflow crate, binary owner, publish order, and 57-target sharding checks
- shell syntax checks

Independent review initially requested changes for stale public docs and the legacy version script. All findings were fixed; focused re-review verdict: **APPROVE**, no Critical or Important findings.

## Release boundary

This is a version-sync/release-preparation PR. It does **not** claim 0.24.0 is shipped. Full verified packaging, publication, registry installation, npm publication, release PR, tag, and backmerge remain outstanding.
