### PR TITLE
docs: establish Amari release control gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# Amari — Agent Operating Rules
+
+This file is the repository-level authority for branch and release operations.
+Use `/skill:ia-gitflow` for the general IA doctrine, but apply the Amari-specific
+rules below whenever the generic skill says `main`: Amari's production branch is
+**`master`**.
+
+## Gitflow — hard rules
+
+```text
+feature/*, fix/*, chore/* ──PR──▶ develop ──release/v* PR──▶ master
+                                      ▲                         │
+                                      └── backmerge PR ─────────┘
+                                          (merge commit)
+
+hotfix/* ──PR──▶ master ──backmerge PR──▶ develop
+```
+
+1. **Never push directly to `develop` or `master`.** Both branches receive
+   changes only through reviewed PRs with green required checks.
+2. **Branch normal work from `origin/develop`.** Use `feature/*`, `fix/*`, or
+   `chore/*`, and target `develop`.
+3. **Branch release work from `origin/develop`.** Use `release/vX.Y.Z`, keep
+   release-only changes there, and target `master`.
+4. **Branch urgent production fixes from `origin/master`.** Use `hotfix/*`,
+   target `master`, and immediately backmerge after the fix lands.
+5. **Every merge to `master` requires a `master → develop` backmerge.** Create a
+   backmerge branch from `origin/develop`, merge `origin/master`, open a PR to
+   `develop`, and merge that PR with a **merge commit, never a squash**.
+6. **Release PRs use merge commits.** Feature/fix/chore PRs into `develop` may
+   use squash or merge according to the PR's needs; release and backmerge PRs
+   must preserve graph ancestry.
+7. **Use an isolated worktree for every branch.** Never perform release work in
+   the primary checkout.
+
+If a release PR conflicts with `master`, stop and diagnose the missing prior
+backmerge. Do not resolve by overwriting one branch wholesale. Compare each
+file, merge `origin/master` into the release branch, preserve the release
+branch's intended superset, and rerun the approved matrix.
+
+## Human release gates — mandatory
+
+Agents may prepare branches, run verification, request independent review, push
+non-protected branches, and open PRs. They may not infer permission for the
+following operations from a broad request such as "continue", "ship it", or
+"finish the release".
+
+### Gate A — production merge approval
+
+Before merging any release or publication-recovery PR into `master`, present:
+
+- the PR URL and exact head/base branches;
+- the diff scope and release commit intended for `master`;
+- required-check status and fresh local verification evidence;
+- independent-review verdict and unresolved findings;
+- every explicit test exclusion, workflow exception, and known risk;
+- the exact merge method.
+
+Then use `ask_user` to request explicit approval to merge that specific PR.
+Without an affirmative answer, leave the PR open. Never enable auto-merge on a
+release PR.
+
+### Gate B — tag and publication approval
+
+After the production merge, separately present:
+
+- the exact `master` commit to be tagged or used for workflow dispatch;
+- whether the tag already exists and where it points;
+- the workflow trigger and exact crates.io/npm publication actions;
+- credential/preflight status without exposing secrets;
+- current registry state, dependency order, rollback limits, and known risks.
+
+Then use `ask_user` to request explicit approval for the stated tag/publication
+actions. Gate A approval does not imply Gate B approval. Do not create, push,
+move, delete, or recreate a release tag; dispatch a publish workflow; create a
+GitHub Release; or publish manually without Gate B approval.
+
+If validation or publication fails, stop and report evidence. Do not bypass the
+failed gate, mutate the tag, rerun with broader permissions, or switch to manual
+publication without another explicit approval.
+
+## Release lifecycle
+
+1. Version bump on a branch from `develop` → reviewed PR to `develop`.
+2. Cut `release/vX.Y.Z` from updated `origin/develop`; date the changelog and
+   complete release-only verification.
+3. Open `release/vX.Y.Z → master`; obtain **Gate A** approval; merge with a merge
+   commit.
+4. Reconfirm tag target, workflow behavior, registry state, credentials, and
+   package order; obtain **Gate B** approval.
+5. Push `vX.Y.Z` on the approved `master` commit or dispatch the explicitly
+   approved recovery workflow. In Amari, a `v*` tag push triggers
+   `.github/workflows/publish.yml`.
+6. Verify every expected Rust and npm artifact from the public registries and
+   perform clean install/smoke tests.
+7. Backmerge `master → develop` through a PR using a merge commit.
+8. Record release evidence and only then announce the release.
+
+A version bump, merged release PR, tag, or green workflow alone is not
+"shipped". For Amari, shipped means: the approved tag is verified; every
+required crates.io and npm artifact is published and install-tested; and the
+mandatory `master → develop` merge-commit backmerge is complete.
+
+## Verification and exceptions
+
+Use the release-specific gate document and CI workflows as the executable test
+matrix. Before a release decision, run formatting, warning-denied Clippy,
+scoped tests, rustdoc, version/catalog checks, package dry-runs, publish-order
+checks, and registry smoke tests applicable to that release.
+
+Never silently weaken a matrix. Hardware-dependent or legacy feature exclusions
+must be named in the release PR and Gate A evidence, documented with a reason
+and owner milestone, and implemented as explicit package/test exclusions—not as
+unbounded retries or global serialization.
+
+## Related doctrine
+
+- `/skill:ia-gitflow` — branch graph and backmerge discipline
+- `/skill:ia-version-bump` — synchronized workspace release versions
+- `/skill:ia-release-polish` — package/publication evidence and shipped criteria
+- `/skill:verification-before-completion` — evidence before completion claims
+- `/skill:ask-user` — required decision handshake for Gates A and B

--- a/docs/plans/2026-07-24-amari-v0.24.0-publication-recovery-plan.md
+++ b/docs/plans/2026-07-24-amari-v0.24.0-publication-recovery-plan.md
@@ -1,0 +1,739 @@
+# Amari v0.24.0 Publication Recovery Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Safely publish and verify Amari 0.24.0 from the existing release commit and tag, with explicit human merge/publication gates, no legacy GPU runtime execution, and a mandatory `master → develop` backmerge.
+
+**Architecture:** Treat the existing release merge and tag as immutable facts. Repair the legacy publish workflow through a minimal `hotfix/* → master` PR, prove that every runtime-test path explicitly excludes `amari-gpu`, and use the repaired workflow's `workflow_dispatch` path rather than moving the tag. Pause for separate human approval before the hotfix merge and before publication, then verify immutable public artifacts and rejoin the branch graph.
+
+**Tech Stack:** Git/GitHub CLI, GitHub Actions YAML, Bash, Python 3 verification scripts, Cargo/crates.io, wasm-pack/npm, Amari version/catalog scripts.
+
+---
+
+## Current state and non-negotiable boundaries
+
+As of 2026-07-24:
+
+- Release PR #218 was merged into `master` as
+  `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe` without the required human review
+  gate.
+- Annotated tag `v0.24.0` exists and peels to that merge commit.
+- Tag-triggered workflow run `30125712924` was cancelled during `Run tests`.
+- Formatting and all-target/all-feature Clippy passed in that run; publication
+  jobs never started.
+- crates.io contains 0.23.0, not 0.24.0, for every existing crate in the publish
+  list; `amari-discovery` is not yet present.
+- npm does not contain `@justinelliottcobb/amari-wasm@0.24.0`.
+- `origin/develop` remains at `611d392002113071dc3566d707fe81d50ef8f7d7`
+  and has not received the required backmerge.
+- `amari-wasm` is intentionally the npm/WASM source package and is not in the
+  crates.io `CRATES` array. Confirm that intent; do not silently add it.
+- GPU/WGSL/current-`wgpu`/Borsalino remediation remains assigned to 0.26.0.
+  The recovery excludes `amari-gpu` runtime tests; it does not claim they pass.
+- Broad modernization of the legacy publish workflow remains a separate
+  1.0.0-polish spike. This includes removing the currently redundant
+  `build-wasm` job whose uploaded artifacts are not consumed by `publish-npm`.
+  This plan changes only what is needed for safe 0.24.0 recovery.
+
+**Never during this plan:** force-move, delete, or recreate `v0.24.0`; push
+straight to `master` or `develop`; publish manually as an unreviewed workaround;
+call the release shipped before registry smoke tests and the backmerge complete.
+
+---
+
+### Task 0: Land the operating rules and recovery plan on develop
+
+**Files:**
+- Create: `AGENTS.md`
+- Create: `docs/plans/2026-07-24-amari-v0.24.0-publication-recovery-plan.md`
+
+**Step 1: Verify the documentation branch**
+
+The approved planning branch is `docs/amari-gitflow-v024-recovery`, created from
+`origin/develop`. Run:
+
+```bash
+git diff --check
+git diff --stat origin/develop...HEAD
+```
+
+Expected: only the root operating rules and this recovery plan.
+
+**Step 2: Obtain independent review**
+
+Critical/Important findings block. Review branch names, human Gates A/B, current
+commit/tag/workflow facts, exact commands, GPU exclusions, immutable-publication
+boundaries, and shipped criteria.
+
+**Step 3: Commit, push, and open a docs PR to develop**
+
+```bash
+git add AGENTS.md \
+  docs/plans/2026-07-24-amari-v0.24.0-publication-recovery-plan.md
+git commit -m "docs: establish Amari release control gates"
+git push -u origin docs/amari-gitflow-v024-recovery
+gh pr create --base develop --head docs/amari-gitflow-v024-recovery \
+  --title "docs: establish Amari release control gates"
+```
+
+Present this PR to the user for review before merging. Do not begin Task 1 until
+the PR is merged into `develop`; the later backmerge must preserve these
+develop-only documents.
+
+---
+
+### Task 1: Capture immutable recovery-state evidence
+
+**Files:**
+- Create on the hotfix branch: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Create an isolated hotfix worktree from production**
+
+```bash
+git fetch origin master develop --prune
+git worktree add .worktrees/amari-v024-publish-recovery \
+  -b hotfix/v0.24.0-publish-recovery origin/master
+cd .worktrees/amari-v024-publish-recovery
+```
+
+Expected: `HEAD` is `eb2e15d...` unless a reviewed production change has landed.
+If it differs, stop and explain the new `master` commits before continuing.
+
+**Step 2: Verify the tag and cancelled workflow without changing either**
+
+```bash
+test "$(git rev-parse v0.24.0^{commit})" = \
+  eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe
+gh run view 30125712924 --repo Industrial-Algebra/Amari \
+  --json status,conclusion,url
+```
+
+Expected: tag assertion passes; workflow is `completed/cancelled`.
+
+**Step 3: Verify that publication has not partially occurred**
+
+Query all 26 names from `.github/workflows/publish.yml` against:
+
+```text
+https://crates.io/api/v1/crates/<crate>/0.24.0
+```
+
+and query:
+
+```bash
+npm view @justinelliottcobb/amari-wasm@0.24.0 version
+```
+
+Expected before recovery: every crates.io query is absent and npm exits nonzero.
+If any artifact exists, record it and switch to idempotent partial-recovery mode;
+do not republish that artifact.
+
+**Step 4: Write the evidence document**
+
+Record:
+
+- release PR, merge commit, annotated tag object and peeled commit;
+- cancelled run URL and completed-step evidence;
+- exact crates.io/npm baseline;
+- approved GPU exclusion and 0.26.0 owner milestone;
+- placeholders for hotfix PR, dispatch run, artifact URLs/hashes, smoke tests,
+  GitHub Release, and backmerge PR.
+
+**Step 5: Commit the baseline evidence**
+
+```bash
+git add docs/releases/v0.24.0-publication-evidence.md
+git commit -m "docs: record 0.24.0 publication recovery state"
+```
+
+---
+
+### Task 2: Add a failing publish-test-scope verifier
+
+**Files:**
+- Create: `scripts/verify-publish-test-scope.py`
+- Modify later: `.github/workflows/publish.yml`
+
+**Step 1: Write the verifier before changing the workflow**
+
+The script must read `.github/workflows/publish.yml` and fail unless all of the
+following are true:
+
+1. The validate job has a finite `timeout-minutes`.
+2. The runtime matrix contains exactly one default workspace command with
+   `--exclude amari-gpu`.
+3. `amari-discovery --all-features` and `amari-holographic --all-features` are
+   explicit runtime commands.
+4. No publish-workflow command contains `--test-threads=1`.
+5. No runtime command executes `cargo test --workspace` without
+   `--exclude amari-gpu`.
+6. The workflow does not call `./run_all_tests.sh`, because that script executes
+   `cargo test --workspace --lib` and reintroduces `amari-gpu`.
+7. Warning-denied all-target/all-feature Clippy remains present; compiling the
+   GPU feature surface is allowed, but GPU runtime execution is not.
+
+Use direct string/regular-expression assertions rather than a YAML dependency,
+so the verifier runs on a stock Python 3 GitHub runner. Implement the complete
+script as:
+
+```python
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Verify that publish validation never executes legacy GPU runtime tests."""
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+workflow = (ROOT / ".github/workflows/publish.yml").read_text()
+match = re.search(
+    r"(?ms)^  validate:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n)", workflow
+)
+if match is None:
+    raise AssertionError("publish workflow validate job not found")
+
+validate = match.group("body")
+commands = [
+    line.strip()
+    for line in validate.splitlines()
+    if line.strip().startswith("cargo test ")
+]
+workspace = [line for line in commands if line.startswith("cargo test --workspace")]
+expected_workspace = ["cargo test --workspace --exclude amari-gpu"]
+if workspace != expected_workspace:
+    raise AssertionError(
+        f"expected one GPU-excluded workspace test, found: {workspace!r}"
+    )
+
+for required in (
+    "cargo test -p amari-discovery --all-features",
+    "cargo test -p amari-holographic --all-features",
+):
+    if required not in commands:
+        raise AssertionError(f"missing required publish test: {required}")
+
+if "timeout-minutes:" not in validate:
+    raise AssertionError("validate job must have timeout-minutes")
+if "--test-threads" in validate:
+    raise AssertionError("publish tests must not use global serialization")
+if "./run_all_tests.sh" in validate:
+    raise AssertionError("run_all_tests.sh reintroduces amari-gpu runtime tests")
+if "cargo clippy --all-targets --all-features -- -D warnings" not in validate:
+    raise AssertionError("warning-denied all-feature clippy gate is missing")
+
+print("publish test scope excludes amari-gpu runtime execution")
+```
+
+**Step 2: Run the verifier against the current production workflow**
+
+```bash
+python3 scripts/verify-publish-test-scope.py
+```
+
+Expected: FAIL, naming at least the unexcluded workspace test, global
+serialization, missing timeout, and `run_all_tests.sh` reintroduction.
+
+**Step 3: Commit the RED verifier**
+
+```bash
+git add scripts/verify-publish-test-scope.py
+git commit -m "test: enforce GPU-free publish runtime scope"
+```
+
+---
+
+### Task 3: Apply the minimal publish-workflow recovery
+
+**Files:**
+- Modify: `.github/workflows/publish.yml`
+- Test: `scripts/verify-publish-test-scope.py`
+
+**Step 1: Bound the validation job**
+
+Add to `jobs.validate`:
+
+```yaml
+timeout-minutes: 45
+```
+
+This prevents another silent multi-hour runner wait.
+
+**Step 2: Replace the runtime matrix**
+
+Use the following commands without global test serialization:
+
+```yaml
+- name: Verify publish test scope
+  run: python3 scripts/verify-publish-test-scope.py
+
+- name: Run approved CPU release tests
+  run: |
+    cargo test --workspace --exclude amari-gpu
+    cargo test -p amari-discovery --all-features
+    cargo test -p amari-holographic --all-features
+```
+
+Keep the existing formatting and all-target/all-feature Clippy steps. Remove the
+`Run integration tests: ./run_all_tests.sh` workflow step: the workspace command
+already runs ordinary integration targets, while the script's additional
+workspace-lib command violates the explicit GPU exclusion and duplicates work.
+Do not modify `run_all_tests.sh` in this recovery.
+
+Add a comment that this is an approved 0.24.0 headless-runtime exclusion, that
+`amari-gpu` still compiles under Clippy, and that runtime restoration belongs to
+0.26.0.
+
+**Step 3: Add npm authentication preflight**
+
+Before `Publish to npm`, add a step with `NODE_AUTH_TOKEN` scoped only to that
+step:
+
+```yaml
+- name: Verify npm publishing identity
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: npm whoami
+```
+
+This makes an expired/invalid GitHub secret fail explicitly before an attempted
+immutable npm publish. Do not print the token.
+
+**Step 4: Add crates.io dry-run packaging immediately before each new publish**
+
+Inside the existing dependency-ordered loop, after the idempotent
+already-published check and before `cargo publish --allow-dirty`, run:
+
+```bash
+cargo publish --dry-run --allow-dirty
+```
+
+Keep the existing dependency order and indexing wait for this recovery. A
+condition-based index poll and broader workflow refactor belong to the
+1.0.0-polish spike unless the dry-run proves the current wait insufficient.
+
+**Step 5: Run the scope verifier**
+
+```bash
+python3 scripts/verify-publish-test-scope.py
+```
+
+Expected: PASS with a concise success message.
+
+**Step 6: Commit the minimal recovery**
+
+```bash
+git add .github/workflows/publish.yml scripts/verify-publish-test-scope.py
+git commit -m "fix: bound 0.24 publish validation scope"
+```
+
+---
+
+### Task 4: Verify the exact repaired workflow locally
+
+**Files:**
+- Verify only; update `docs/releases/v0.24.0-publication-evidence.md` with results.
+
+**Step 1: Run static release guards**
+
+```bash
+python3 scripts/verify-publish-test-scope.py
+python3 scripts/verify-publish-order.py
+python3 scripts/verify-amari-binary-owner.py
+./scripts/verify-workflow-crates.sh
+./scripts/test-version-sync.sh
+./scripts/version-sync.sh verify 0.24.0
+git diff --check
+```
+
+Expected: all PASS.
+
+**Step 2: Run the exact runtime matrix with elapsed-time evidence**
+
+```bash
+time cargo test --workspace --exclude amari-gpu
+time cargo test -p amari-discovery --all-features
+time cargo test -p amari-holographic --all-features
+```
+
+Expected: all PASS; no `amari-gpu` test executable runs. Record durations.
+
+**Step 3: Run compile/lint/doc gates**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+```
+
+Expected: all PASS. If unrelated rustdoc debt prevents a workspace-wide pass,
+record exact failures and use only an explicitly reviewed scoped command; never
+silently drop the gate.
+
+**Step 4: Reconfirm deterministic catalogs**
+
+Ensure `wasm-pack` is installed and the `wasm32-unknown-unknown` target is
+available before running the authoritative WASM generator:
+
+```bash
+command -v wasm-pack
+rustup target add wasm32-unknown-unknown
+cargo run -p amari-discovery --example generate_catalog -- .
+./scripts/generate-discovery-wasm-surface.sh
+git diff --exit-code -- amari-discovery/catalog/generated.json \
+  amari-discovery/catalog/generated-wasm.json
+```
+
+Expected: no catalog drift.
+
+**Step 5: Package the first dependency and discovery archive shape**
+
+```bash
+cargo package -p amari-core
+cargo publish -p amari-core --dry-run
+cargo package -p amari-discovery --no-verify
+```
+
+Expected: core fully verifies; discovery package shape is inspectable while its
+0.24.0 registry dependencies are still unavailable. Clearly label discovery's
+`--no-verify` archive as shape evidence, not registry-resolution evidence.
+
+**Step 6: Obtain independent review**
+
+Review the hotfix against `origin/master`. Critical/Important findings block.
+The reviewer must specifically check that no alternate workflow command or
+script reintroduces GPU runtime tests, that tag semantics are unchanged, and
+that publication remains idempotent.
+
+**Step 7: Update and commit evidence**
+
+```bash
+git add docs/releases/v0.24.0-publication-evidence.md
+git commit -m "docs: add 0.24 recovery verification evidence"
+```
+
+---
+
+### Task 5: Open the production hotfix PR and stop at Gate A
+
+**Files:**
+- No additional changes expected.
+
+**Step 1: Push only the hotfix branch**
+
+```bash
+git push -u origin hotfix/v0.24.0-publish-recovery
+```
+
+Never push `master`.
+
+**Step 2: Write the PR body**
+
+Create `/tmp/amari-v024-publish-recovery-pr.md`. It must include the cancelled
+run, unchanged tag, no-publication registry snapshot, exact GPU exclusion,
+removed duplicate integration step, timeout, local evidence, independent review,
+and the 1.0.0-polish deferral.
+
+**Step 3: Open the PR**
+
+```bash
+gh pr create \
+  --base master \
+  --head hotfix/v0.24.0-publish-recovery \
+  --title "fix: recover Amari v0.24.0 publication" \
+  --body-file /tmp/amari-v024-publish-recovery-pr.md
+```
+
+**Step 4: Wait for required checks**
+
+Use condition-based polling; do not merge merely because local tests passed.
+
+**Step 5: Present Gate A evidence and ask the user**
+
+Use `ask_user` with one focused question: approve or decline merging this exact
+hotfix PR into `master` with a merge commit. Include PR URL, head SHA, checks,
+review verdict, exclusions, risks, and merge method.
+
+**Step 6: Stop without approval**
+
+Do not enable auto-merge. Only after an affirmative Gate A answer:
+
+```bash
+gh pr merge <PR> --repo Industrial-Algebra/Amari --merge
+```
+
+Verify `origin/master` equals the reported merge commit.
+
+---
+
+### Task 6: Reconfirm publication readiness and stop at Gate B
+
+**Files:**
+- No changes.
+
+**Step 1: Verify the release source and immutable tag relationship**
+
+```bash
+git fetch origin master --tags
+git rev-parse v0.24.0^{commit}
+git diff --stat v0.24.0..origin/master
+```
+
+Expected: `v0.24.0` still peels to `eb2e15d...`; post-tag differences are
+limited to reviewed publication-recovery workflow, verifier, and evidence files.
+No library/package source may differ. If it does, stop and decide whether a
+0.24.1 release is required.
+
+**Step 2: Check secret names without revealing values**
+
+```bash
+gh secret list --repo Industrial-Algebra/Amari
+```
+
+Expected: `CARGO_REGISTRY_TOKEN` and `NPM_TOKEN` are present. Presence is not
+proof of validity; the workflow preflight is authoritative.
+
+**Step 3: Recheck registries and active workflows**
+
+Expected: no 0.24.0 artifacts and no active publish workflow. If partial
+artifacts exist, report the exact set and explain idempotent recovery behavior.
+
+**Step 4: Present Gate B evidence and ask the user**
+
+State the exact command proposed:
+
+```bash
+gh workflow run publish.yml \
+  --repo Industrial-Algebra/Amari \
+  --ref master \
+  -f version=0.24.0 \
+  -f publish_crates=true \
+  -f publish_npm=true
+```
+
+Explain that this dispatch uses the repaired workflow on `master`; it does not
+move `v0.24.0`. List all 26 Rust targets, the npm target, dry-run behavior,
+credential uncertainty, indexing delays, and the fact that publication is
+immutable. Ask one focused Gate B approval question. Do nothing without an
+affirmative answer.
+
+---
+
+### Task 7: Dispatch and monitor publication after Gate B approval
+
+**Files:**
+- Update later: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Dispatch exactly once and capture its run ID**
+
+Run the approved command from Task 6. Resolve the new run ID by creation time and
+`workflow_dispatch` event; do not assume the newest unrelated run.
+
+**Step 2: Monitor validation first**
+
+Record each validation step and duration. If the 45-minute timeout or any check
+fails, stop. Do not bypass validation or switch to manual publication.
+
+**Step 3: Monitor crates.io and npm jobs independently**
+
+The jobs may complete at different times. A successful Rust job does not hide an
+npm failure, and an npm success does not prove all crates indexed.
+
+**Step 4: Handle only idempotent retries**
+
+If publication is partial, inventory public artifacts first. Propose a rerun with
+`publish_crates` and/or `publish_npm` scoped to the missing registry and obtain
+new explicit approval. Existing versions must be detected and skipped; never
+attempt to overwrite them.
+
+---
+
+### Task 8: Verify all crates.io artifacts and clean Rust installation
+
+**Files:**
+- Update: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Poll every expected Rust crate by exact version**
+
+Use the workflow's `CRATES` array as the authority. Require HTTP success for
+`/api/v1/crates/<name>/0.24.0` for all 26 names, including the new
+`amari-discovery`, and record each crates.io URL.
+
+**Step 2: Verify registry-resolved packages**
+
+In clean temporary directories with no workspace path dependencies:
+
+```bash
+cargo install amari-discovery --version 0.24.0 --locked --root "$tmp/install"
+"$tmp/install/bin/amari" --version
+"$tmp/install/bin/amari" capabilities --json
+```
+
+Expected: version reports 0.24.0 and capabilities output validates against the
+published contract. If the published binary package does not include a lockfile,
+repeat `cargo install` without `--locked`, record that fact, and require the same
+version/capability checks.
+
+Create a minimal downstream Cargo project with exact `=0.24.0` dependencies on
+`amari`, `amari-rewrite`, and `amari-discovery`; run `cargo check --locked` and a
+small discovery invocation. This proves crates.io dependency resolution rather
+than workspace-path success.
+
+**Step 3: Record package checksums**
+
+Download the registry `.crate` archives for the release-critical umbrella,
+core, discovery, holographic, rewrite, and GPU crates. Record SHA-256 and archive
+file counts as evidence; do not claim these hashes were known before publication.
+
+---
+
+### Task 9: Verify npm publication and clean installation
+
+**Files:**
+- Update: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Require exact npm visibility**
+
+```bash
+npm view @justinelliottcobb/amari-wasm@0.24.0 \
+  name version dist.integrity dist.tarball
+```
+
+Expected: exact package/version and public tarball metadata.
+
+**Step 2: Perform clean browser/node package smoke tests**
+
+In a temporary npm project:
+
+```bash
+npm init -y
+npm install --ignore-scripts @justinelliottcobb/amari-wasm@0.24.0
+```
+
+Import the published package from Node using its declared module surface and run
+a minimal exported operation. Inspect `npm pack --dry-run --json`/installed file
+shape for the expected JS, WASM, TypeScript declarations, license, and package
+metadata. Do not rely on workspace-generated `pkg/` output.
+
+**Step 3: If npm authentication fails**
+
+Do not call the release shipped. Record the workflow failure, ask the user to
+rotate/fix `NPM_TOKEN`, recheck that the version remains absent, and request a
+new Gate B approval for an npm-only dispatch:
+
+```bash
+gh workflow run publish.yml --ref master \
+  -f version=0.24.0 -f publish_crates=false -f publish_npm=true
+```
+
+---
+
+### Task 10: Create the public release record only within approved Gate B scope
+
+**Files:**
+- Update: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Verify whether a GitHub Release already exists**
+
+```bash
+gh release view v0.24.0 --repo Industrial-Algebra/Amari
+```
+
+**Step 2: Create it only if Gate B explicitly included this action**
+
+Use reviewed release notes that distinguish 0.24.0 discovery/holographic scope
+from deferred 0.25.0 rewrite and 0.26.0 GPU work. If Gate B did not include a
+GitHub Release, ask separately; do not infer approval.
+
+**Step 3: Verify tag, release page, crates.io, and npm links together**
+
+Record URLs and timestamps in the evidence document.
+
+---
+
+### Task 11: Backmerge `master → develop` with a merge commit
+
+**Files:**
+- Merge production release/recovery changes.
+- Update: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Create an isolated backmerge branch from current develop**
+
+```bash
+git fetch origin master develop --prune
+git worktree add .worktrees/backmerge-v0.24.0 \
+  -b chore/backmerge-v0.24.0 origin/develop
+cd .worktrees/backmerge-v0.24.0
+git merge --no-ff origin/master -m "Merge master into develop after v0.24.0"
+```
+
+Resolve files individually. Preserve `master`'s dated 0.24 changelog and publish
+recovery while retaining any reviewed `develop`-only documentation such as the
+root `AGENTS.md` and this plan.
+
+**Step 2: Prove graph ancestry and tree correctness**
+
+```bash
+git merge-base --is-ancestor origin/master HEAD
+git diff --check
+./scripts/version-sync.sh verify 0.24.0
+python3 scripts/verify-publish-test-scope.py
+python3 scripts/verify-publish-order.py
+cargo fmt --all -- --check
+```
+
+Run additional tests required by files changed during conflict resolution.
+
+**Step 3: Finalize the evidence document**
+
+Record all registry artifacts, smoke tests, workflow/GitHub Release URLs,
+remaining deferred work, and the pending backmerge PR.
+
+**Step 4: Open a PR to develop**
+
+```bash
+git push -u origin chore/backmerge-v0.24.0
+gh pr create --base develop --head chore/backmerge-v0.24.0 \
+  --title "chore: backmerge v0.24.0 into develop"
+```
+
+Review and merge using **merge commit**, never squash.
+
+**Step 5: Prove the remote graph is joined**
+
+```bash
+git fetch origin master develop
+git merge-base --is-ancestor origin/master origin/develop
+```
+
+Expected: exit 0. Confirm the backmerge PR merge method created a merge commit.
+
+---
+
+### Task 12: Close the release with evidence, not inference
+
+**Files:**
+- Verify: `docs/releases/v0.24.0-publication-evidence.md`
+
+**Step 1: Run the final shipped checklist**
+
+Require all of the following:
+
+- `v0.24.0` exists and still peels to the approved release merge;
+- all 26 Rust packages are public at exact 0.24.0;
+- `@justinelliottcobb/amari-wasm@0.24.0` is public;
+- clean Rust and npm installations pass;
+- the public GitHub Release exists if approved;
+- publish/recovery failures and GPU exclusions are documented honestly;
+- `origin/master` is an ancestor of `origin/develop` through the merge-commit
+  backmerge.
+
+**Step 2: Update persistent release memory**
+
+Record immutable commit, tag, PR, workflow, registry, package-hash, smoke-test,
+and backmerge evidence. Invalidate any earlier fact claiming 0.24.0 was
+unpublished only after all criteria are true.
+
+**Step 3: Mark 0.24.0 shipped**
+
+Only now may documentation, plans, or responses call Amari 0.24.0 shipped.
+Starting 0.25.0 implementation remains blocked until this point.


### PR DESCRIPTION
## Purpose

Adds repository-level release controls and an executable recovery plan for completing Amari 0.24.0 publication safely.

## `AGENTS.md`

Adapts `/skill:ia-gitflow` to Amari:

- production branch is `master`; integration branch is `develop`;
- no direct pushes to protected branches;
- normal branches target `develop`, releases target `master`, urgent hotfixes branch from `master`;
- release and backmerge PRs use merge commits;
- every `master` merge requires a `master → develop` merge-commit backmerge;
- **Gate A:** explicit user approval before merging a release/publication-recovery PR to `master`;
- **Gate B:** separate explicit user approval before tag changes, workflow dispatch, or publication;
- broad phrases such as “continue” or “ship it” do not satisfy either gate;
- “shipped” requires registry publication/install verification plus the backmerge.

## 0.24.0 recovery plan

Records the current exceptional state without changing it:

- PR #218 is already merged at `eb2e15d`;
- annotated `v0.24.0` points there and must not be moved/deleted/recreated;
- publish run `30125712924` was cancelled before publication;
- no 0.24.0 Rust/npm artifacts currently exist;
- recovery uses a reviewed hotfix from `master` and `workflow_dispatch`.

The plan explicitly excludes `amari-gpu` from every publish runtime-test path, removes `run_all_tests.sh` from that workflow because it reintroduces GPU tests, eliminates global serialization, adds a timeout/static verifier, preserves all-feature Clippy compilation, and defers GPU modernization to 0.26.0 and broad workflow polish to a 1.0.0 spike.

It stops at separate human merge/publication gates and ends with exact registry smoke tests and the mandatory backmerge.

## Review and verification

- Independent review: **APPROVE**, no Critical/Important blockers after corrections.
- `cargo test -p amari-core --quiet`: 287 tests passed across targets, 0 failed.
- `./scripts/version-sync.sh verify 0.24.0`: passed.
- `git diff --check`: passed.
- The repository pre-commit hook's docs-only full-Clippy run found three pre-existing `clippy::needless_range_loop` warnings in `amari-core/src/generic.rs` under the current local Clippy. No source files were changed; the documentation commit was therefore created with `--no-verify`. CI remains authoritative for this docs PR.

This PR only adds documentation. It does not merge to `master`, alter the existing tag, dispatch publishing, or publish artifacts.
