### PR TITLE
fix: recover Amari v0.24.0 publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,14 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        # Tagged 0.24.0 test code contains four pre-existing warnings: three
+        # needless_range_loop findings in amari-core/src/generic.rs and one
+        # collapsible_match in amari-enumerative/tests/classical_problems.rs.
+        # Keep normal targets warning-denied, then compile every target while
+        # allowing only those test-only lints. Fix forward on develop.
+        run: |
+          cargo clippy --workspace --all-features -- -D warnings
+          cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::needless_range_loop -A clippy::collapsible_match
 
       - name: Verify publish test scope
         run: python3 scripts/verify-publish-test-scope.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
   validate:
     name: Validate and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -52,18 +53,17 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Run tests
-        # Keep legacy opt-in GPU hardware execution out of the headless release
-        # validator until the planned 0.26 wgpu modernization. The complete
-        # default workspace and the 0.24 discovery/holographic feature surfaces
-        # still run, serialized to avoid concurrent EGL context initialization.
-        run: |
-          cargo test --workspace -- --test-threads=1
-          cargo test -p amari-discovery --all-features -- --test-threads=1
-          cargo test -p amari-holographic --all-features -- --test-threads=1
+      - name: Verify publish test scope
+        run: python3 scripts/verify-publish-test-scope.py
 
-      - name: Run integration tests
-        run: ./run_all_tests.sh
+      - name: Run approved CPU release tests
+        # The 0.24.0 headless validator explicitly excludes legacy amari-gpu
+        # runtime tests while retaining all-feature compilation through Clippy.
+        # GPU runtime restoration belongs to the planned 0.26.0 modernization.
+        run: |
+          cargo test --workspace --exclude amari-gpu
+          cargo test -p amari-discovery --all-features
+          cargo test -p amari-holographic --all-features
 
   publish-crates:
     name: Publish to crates.io
@@ -161,6 +161,8 @@ jobs:
             if cargo search "$crate" --limit 1 | grep -q "^$crate = \"$TARGET_VERSION\""; then
               echo "$crate version $TARGET_VERSION already published, skipping..."
             else
+              echo "Verifying $crate version $TARGET_VERSION package..."
+              cargo publish --dry-run --allow-dirty
               echo "Publishing $crate version $TARGET_VERSION..."
               cargo publish --allow-dirty
               echo "Waiting for crates.io indexing and rate limit reset..."
@@ -269,6 +271,12 @@ jobs:
             echo "version-exists=false" >> $GITHUB_OUTPUT
             echo "Version $PACKAGE_VERSION does not exist, proceeding with publish"
           fi
+
+      - name: Verify npm publishing identity
+        if: steps.npm-version-check.outputs.version-exists == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
 
       - name: Publish to npm
         if: steps.npm-version-check.outputs.version-exists == 'false'

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -87,6 +87,31 @@ a substitute for exclusion. GPU/WGSL/current-`wgpu`/Borsalino remediation is
 owned by 0.26.0; broad publish-workflow modernization is owned by a separate
 1.0.0-polish spike.
 
+### Approved tagged-test Clippy exception
+
+A clean all-target Clippy inventory exposed four pre-existing test-only
+warnings: three `clippy::needless_range_loop` findings at
+`amari-core/src/generic.rs:178`, `:200`, and `:226`, plus one
+`clippy::collapsible_match` finding at
+`amari-enumerative/tests/classical_problems.rs:376`. Earlier GitHub checks were
+cache-contaminated and did not relint those test targets. Rewriting the tagged
+tests during recovery would make published 0.24.0 source differ from
+`v0.24.0`, so the approved recovery matrix runs warning-denied Clippy on all
+normal workspace targets, then compiles all targets while allowing only those
+two test-only lint classes:
+
+```bash
+cargo clippy --workspace --all-features -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- \
+  -D warnings \
+  -A clippy::needless_range_loop \
+  -A clippy::collapsible_match
+```
+
+A clean warning-only inventory found no other warnings. This exception is
+explicit and limited to the immutable tagged release. All four findings must be
+fixed forward on `develop`; no other warning is allowed.
+
 ## Recovery evidence
 
 | Gate | Status | Evidence |

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -1,0 +1,129 @@
+# Amari v0.24.0 Publication Evidence
+
+This document is the authoritative recovery and publication record for Amari
+0.24.0. A checked source tree, merged release PR, or tag is not publication
+evidence. Do not mark this release shipped until every final gate is complete.
+
+## Immutable release state
+
+Recorded at `2026-07-25T21:23:39Z`:
+
+| Item | Evidence |
+|---|---|
+| Release PR | [#218](https://github.com/Industrial-Algebra/Amari/pull/218) |
+| `master` release merge | `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe` |
+| Annotated tag object | `1bcfc2425a9893bffacdc043cf93dca4439b1824` |
+| `v0.24.0` peeled commit | `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe` |
+| Integration branch before recovery | `ea547d157b72c16341334ed53c6ff1ab8c4daf64` |
+| Original publish run | [30125712924](https://github.com/Industrial-Algebra/Amari/actions/runs/30125712924) — `completed/cancelled` |
+| GitHub Release | Absent |
+
+The original publish run completed checkout, formatting, and warning-denied
+all-feature Clippy. Its monolithic `Run tests` step was cancelled. The crates.io,
+WASM-build, and npm jobs did not start, and no publication occurred.
+
+The existing annotated tag is immutable during recovery: do not move, delete, or
+recreate `v0.24.0`. Recovery uses a reviewed workflow hotfix on `master` and an
+explicitly approved `workflow_dispatch` invocation.
+
+## Pre-recovery registry baseline
+
+All exact-version checks below were absent at `2026-07-25T21:23:39Z`.
+
+| Registry | Expected 0.24.0 artifacts | Baseline |
+|---|---:|---|
+| crates.io | 26 | 0 present |
+| npm | `@justinelliottcobb/amari-wasm@0.24.0` | Absent |
+
+Crates.io targets checked:
+
+```text
+amari-core
+amari-tropical
+amari-dual
+amari-network
+amari-info-geom
+amari-relativistic
+amari-holographic
+amari-fusion
+amari-automata
+amari-cgt
+amari-surreal
+amari-surcomplex
+amari-enumerative
+amari-flynn-macros
+amari-flynn
+amari-measure
+amari-calculus
+amari-functional
+amari-topology
+amari-probabilistic
+amari-dynamics
+amari-rewrite
+amari-gpu
+amari-optimization
+amari-discovery
+amari
+```
+
+`amari-wasm` is intentionally the npm/WASM source package and is not part of the
+crates.io publication array.
+
+## Approved runtime-test boundary
+
+The 0.24.0 headless publish validator must explicitly exclude `amari-gpu`
+runtime tests from every execution path. It must still compile the all-feature
+workspace under warning-denied Clippy and run:
+
+```bash
+cargo test --workspace --exclude amari-gpu
+cargo test -p amari-discovery --all-features
+cargo test -p amari-holographic --all-features
+```
+
+The legacy `run_all_tests.sh` step is not permitted in this workflow because its
+workspace-lib command reintroduces `amari-gpu`. Global test serialization is not
+a substitute for exclusion. GPU/WGSL/current-`wgpu`/Borsalino remediation is
+owned by 0.26.0; broad publish-workflow modernization is owned by a separate
+1.0.0-polish spike.
+
+## Recovery evidence
+
+| Gate | Status | Evidence |
+|---|---|---|
+| Recovery hotfix branch | In progress | `hotfix/v0.24.0-publish-recovery` |
+| Local repaired-matrix verification | Pending | — |
+| Independent hotfix review | Pending | — |
+| Gate A production-merge approval | Pending | — |
+| Recovery hotfix PR/merge | Pending | — |
+| Gate B publication approval | Pending | — |
+| Recovery workflow dispatch | Pending | — |
+| All 26 crates.io artifacts visible | Pending | — |
+| Registry-resolved Rust smoke tests | Pending | — |
+| npm artifact visible | Pending | — |
+| Clean npm smoke test | Pending | — |
+| GitHub Release | Pending explicit approval | — |
+| `master → develop` merge-commit backmerge | Pending | — |
+
+## Final artifact checksums
+
+Record checksums only after downloading immutable public registry artifacts.
+Pre-publication local archives are package-shape evidence, not registry evidence.
+
+| Artifact | Registry URL | SHA-256 | Files |
+|---|---|---|---:|
+| `amari-core-0.24.0.crate` | Pending | Pending | — |
+| `amari-holographic-0.24.0.crate` | Pending | Pending | — |
+| `amari-rewrite-0.24.0.crate` | Pending | Pending | — |
+| `amari-gpu-0.24.0.crate` | Pending | Pending | — |
+| `amari-discovery-0.24.0.crate` | Pending | Pending | — |
+| `amari-0.24.0.crate` | Pending | Pending | — |
+| `@justinelliottcobb/amari-wasm@0.24.0` | Pending | Pending integrity | — |
+
+## Shipped decision
+
+**Status: NOT SHIPPED.**
+
+The release may be marked shipped only after exact registry visibility, clean
+Rust/npm installation tests, approved public release record, and the mandatory
+merge-commit backmerge are recorded above.

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -14,7 +14,7 @@ Recorded at `2026-07-25T21:23:39Z`:
 | `master` release merge | `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe` |
 | Annotated tag object | `1bcfc2425a9893bffacdc043cf93dca4439b1824` |
 | `v0.24.0` peeled commit | `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe` |
-| Integration branch before recovery | `ea547d157b72c16341334ed53c6ff1ab8c4daf64` |
+| Integration branch after control-docs PR, before publication hotfix | `ea547d157b72c16341334ed53c6ff1ab8c4daf64` |
 | Original publish run | [30125712924](https://github.com/Industrial-Algebra/Amari/actions/runs/30125712924) — `completed/cancelled` |
 | GitHub Release | Absent |
 
@@ -112,12 +112,48 @@ A clean warning-only inventory found no other warnings. This exception is
 explicit and limited to the immutable tagged release. All four findings must be
 fixed forward on `develop`; no other warning is allowed.
 
+## Local recovery verification
+
+The repaired workflow scope was verified from a clean recovery worktree:
+
+| Check | Result | Evidence |
+|---|---|---|
+| Publish-scope verifier | PASS | Explicit GPU exclusion, finite timeout, no global serialization, no `run_all_tests.sh` |
+| Publish order | PASS | All 26 crates dependency-safe |
+| Binary owner/workflow crates | PASS | `amari-discovery` remains sole `amari` binary owner |
+| Version sync fixture/current version | PASS | All active metadata at 0.24.0 |
+| Workspace runtime excluding `amari-gpu` | PASS | 528 seconds |
+| `amari-discovery --all-features` | PASS | 513 seconds |
+| `amari-holographic --all-features` | PASS | 3 seconds |
+| Normal-target Clippy 1.97.1, `-D warnings` | PASS | Clean target directory |
+| All-target Clippy 1.97.1, approved test-only lints | PASS | Clean warning inventory found exactly four documented warnings |
+| Formatting/diff checks | PASS | No source formatting or whitespace drift |
+| Scoped warning-denied rustdoc | PASS | `amari-core`, `amari-holographic`, `amari-rewrite`, and `amari-discovery` |
+| Structural catalog determinism | PASS | SHA-256 `f0f31763f68ad7be46b58b81924392c4c07af56e18b780c0d956b2525c2e3aaf` |
+| WASM catalog determinism | PASS | SHA-256 `b34bf6e51b2df1c0bbce9c1264d9df57e8f5b3725a0214d1a24a81d300453265` |
+| `amari-core` package/dry-run | PASS | 33 files; local archive SHA-256 `03c31e95893429f8f6389664dedc6aa02f6adf98fe1e1da5e110312aa46876d3` |
+
+Full workspace warning-denied rustdoc remains blocked by pre-existing broken
+intra-doc links in `amari-enumerative/src/matroid.rs:748`,
+`amari-enumerative/src/weight_enumerator.rs:220`, and
+`src/deterministic/ga2d.rs:164-165`, plus Cargo's known `amari` output-name
+collision. These are outside the workflow hotfix; release-critical 0.24.0 crates
+passed the scoped command above.
+
+A pre-publication `cargo package -p amari-discovery --no-verify` cannot create an
+archive after the workspace version bump: Cargo still resolves the unpublished
+`amari-cgt = ^0.24.0` registry dependency before packaging. `--no-verify` skips
+archive compilation, not dependency resolution. The dependency-ordered workflow
+therefore performs the authoritative discovery dry-run only after prerequisites
+are published and indexed. No local discovery archive is represented as current
+registry-resolution evidence.
+
 ## Recovery evidence
 
 | Gate | Status | Evidence |
 |---|---|---|
 | Recovery hotfix branch | In progress | `hotfix/v0.24.0-publish-recovery` |
-| Local repaired-matrix verification | Pending | — |
+| Local repaired-matrix verification | PASS | Detailed above |
 | Independent hotfix review | Pending | — |
 | Gate A production-merge approval | Pending | — |
 | Recovery hotfix PR/merge | Pending | — |

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -39,7 +39,22 @@ if "--test-threads" in validate:
     raise AssertionError("publish tests must not use global serialization")
 if "./run_all_tests.sh" in validate:
     raise AssertionError("run_all_tests.sh reintroduces amari-gpu runtime tests")
-if "cargo clippy --all-targets --all-features -- -D warnings" not in validate:
-    raise AssertionError("warning-denied all-feature clippy gate is missing")
+clippy_commands = [
+    line.strip()
+    for line in validate.splitlines()
+    if line.strip().startswith("cargo clippy ")
+]
+expected_clippy = [
+    "cargo clippy --workspace --all-features -- -D warnings",
+    (
+        "cargo clippy --workspace --all-targets --all-features -- "
+        "-D warnings -A clippy::needless_range_loop -A clippy::collapsible_match"
+    ),
+]
+if clippy_commands != expected_clippy:
+    raise AssertionError(
+        "expected warning-denied normal targets plus the documented tagged-test "
+        f"lint exception, found: {clippy_commands!r}"
+    )
 
 print("publish test scope excludes amari-gpu runtime execution")

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Verify that publish validation never executes legacy GPU runtime tests."""
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+workflow = (ROOT / ".github/workflows/publish.yml").read_text()
+match = re.search(
+    r"(?ms)^  validate:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n)", workflow
+)
+if match is None:
+    raise AssertionError("publish workflow validate job not found")
+
+validate = match.group("body")
+commands = [
+    line.strip()
+    for line in validate.splitlines()
+    if line.strip().startswith("cargo test ")
+]
+workspace = [line for line in commands if line.startswith("cargo test --workspace")]
+expected_workspace = ["cargo test --workspace --exclude amari-gpu"]
+if workspace != expected_workspace:
+    raise AssertionError(
+        f"expected one GPU-excluded workspace test, found: {workspace!r}"
+    )
+
+for required in (
+    "cargo test -p amari-discovery --all-features",
+    "cargo test -p amari-holographic --all-features",
+):
+    if required not in commands:
+        raise AssertionError(f"missing required publish test: {required}")
+
+if "timeout-minutes:" not in validate:
+    raise AssertionError("validate job must have timeout-minutes")
+if "--test-threads" in validate:
+    raise AssertionError("publish tests must not use global serialization")
+if "./run_all_tests.sh" in validate:
+    raise AssertionError("run_all_tests.sh reintroduces amari-gpu runtime tests")
+if "cargo clippy --all-targets --all-features -- -D warnings" not in validate:
+    raise AssertionError("warning-denied all-feature clippy gate is missing")
+
+print("publish test scope excludes amari-gpu runtime execution")


### PR DESCRIPTION
## Purpose

Recover Amari 0.24.0 publication without moving the existing tag, changing tagged package source, or executing legacy GPU runtime tests.

This PR changes only:

- `.github/workflows/publish.yml`
- `scripts/verify-publish-test-scope.py`
- `docs/releases/v0.24.0-publication-evidence.md`

No Rust source, Cargo metadata, catalogs, or tag changed.

## Immutable state

- Release merge: `eb2e15de62ad958fd41baaa27dea31a7d4e5c1fe`
- Annotated `v0.24.0` peels to that commit and remains unchanged.
- Original workflow run [30125712924](https://github.com/Industrial-Algebra/Amari/actions/runs/30125712924) was cancelled during its monolithic test step.
- Publication jobs did not start.
- Registry baseline: 0/26 crates.io 0.24.0 artifacts; npm 0.24.0 absent; GitHub Release absent.

## Workflow recovery

### Runtime scope

Replaces global workspace serialization with the approved explicit matrix:

```bash
cargo test --workspace --exclude amari-gpu
cargo test -p amari-discovery --all-features
cargo test -p amari-holographic --all-features
```

`run_all_tests.sh` is removed from the publish validator because its workspace-lib command reintroduces `amari-gpu`. A static verifier prevents regression. `validate` is bounded to 45 minutes.

GPU/WGSL/current-`wgpu`/Borsalino runtime remediation remains 0.26.0. Broader legacy workflow modernization, including the redundant unconsumed WASM artifact job, remains a 1.0.0-polish spike.

### Tagged-test Clippy exception

A clean uncached inventory exposed four pre-existing test-only warnings that cached GitHub checks did not relint:

- three `clippy::needless_range_loop` findings in `amari-core/src/generic.rs`;
- one `clippy::collapsible_match` finding in `amari-enumerative/tests/classical_problems.rs`.

To preserve tag/source identity, all normal workspace targets remain warning-denied, while all-target compilation permits only those two lint classes:

```bash
cargo clippy --workspace --all-features -- -D warnings
cargo clippy --workspace --all-targets --all-features -- \
  -D warnings \
  -A clippy::needless_range_loop \
  -A clippy::collapsible_match
```

Both exceptions were explicitly approved for the immutable 0.24.0 recovery and must be fixed forward on `develop`.

### Publication safety

- Adds `cargo publish --dry-run --allow-dirty` before each new crates.io publish.
- Preserves the dependency-ordered, idempotent 26-crate loop.
- Adds `npm whoami` using the scoped GitHub secret before immutable npm publication.
- Does not alter tag triggers or publish automatically when this PR merges.
- Recovery publication will use `workflow_dispatch` only after a separate explicit Gate B approval.

## Fresh evidence

- Static publish scope/order/binary owner/workflow/version guards: **PASS**
- `cargo test --workspace --exclude amari-gpu`: **PASS**, 528s
- `amari-discovery --all-features`: **PASS**, 513s
- `amari-holographic --all-features`: **PASS**, 3s
- Normal-target Clippy 1.97.1 with `-D warnings`: **PASS**
- All-target Clippy with only approved test lint exceptions: **PASS**
- Warning-denied rustdoc for core/holographic/rewrite/discovery: **PASS**
- Full workspace rustdoc has documented pre-existing broken links in enumerative/root and is not represented as green.
- Structural catalog deterministic: `f0f31763f68ad7be46b58b81924392c4c07af56e18b780c0d956b2525c2e3aaf`
- WASM catalog deterministic: `b34bf6e51b2df1c0bbce9c1264d9df57e8f5b3725a0214d1a24a81d300453265`
- `amari-core` package and publish dry-run: **PASS**
- `amari-discovery` prepublication packaging cannot resolve unpublished 0.24 internal crates even with `--no-verify`; its dependency-ordered workflow dry-run remains authoritative.
- Independent hotfix review: **APPROVE**, no Critical or Important findings.

## Human gates

This PR is **Gate A only**. Merging it does not authorize tag mutation, workflow dispatch, crates.io/npm publication, or GitHub Release creation.

After merge, the recovery process will recheck tag/source identity, secrets, registries, and active workflows, then stop at separate **Gate B** for explicit publication approval.
