### PR TITLE
fix: pin v0.24 publish toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: rustfmt, clippy
 
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Cache cargo dependencies
         uses: actions/cache@v5
@@ -191,7 +191,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           targets: wasm32-unknown-unknown
 
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           targets: wasm32-unknown-unknown
 

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -118,7 +118,7 @@ The repaired workflow scope was verified from a clean recovery worktree:
 
 | Check | Result | Evidence |
 |---|---|---|
-| Publish-scope verifier | PASS | Explicit GPU exclusion, finite timeout, no global serialization, no `run_all_tests.sh` |
+| Publish-scope verifier | PASS | Explicit GPU exclusion, finite timeout, pinned Rust 1.97.1, no global serialization, no `run_all_tests.sh` |
 | Publish order | PASS | All 26 crates dependency-safe |
 | Binary owner/workflow crates | PASS | `amari-discovery` remains sole `amari` binary owner |
 | Version sync fixture/current version | PASS | All active metadata at 0.24.0 |
@@ -148,17 +148,38 @@ therefore performs the authoritative discovery dry-run only after prerequisites
 are published and indexed. No local discovery archive is represented as current
 registry-resolution evidence.
 
+## First approved dispatch outcome
+
+Gate B authorized both registry publication and later GitHub Release creation
+after registry verification. Workflow run
+[30212036351](https://github.com/Industrial-Algebra/Amari/actions/runs/30212036351)
+was dispatched from exact `master` commit
+`b44efe8be5ae8ed0aecddb767e0ae4544927391f`. It failed safely in validation;
+all publication jobs were skipped and a renewed inventory found 0/26 Rust
+artifacts, no npm 0.24.0 artifact, and no GitHub Release.
+
+The failure was caused by `dtolnay/rust-toolchain@stable` resolving to a newer
+moving toolchain than the locally verified Rust 1.97.1 release toolchain. The
+new Clippy added `clippy::manual_slice_fill`, producing a warning-denied error in
+`amari-dynamics/src/stochastic/fokker_planck.rs:171`. No release source change or
+new lint exception is appropriate. The recovery instead pins all four publish
+jobs to Rust 1.97.1 and extends the static verifier to reject a moving release
+toolchain. Retry requires a reviewed production PR and renewed Gate A/Gate B
+approval.
+
 ## Recovery evidence
 
 | Gate | Status | Evidence |
 |---|---|---|
-| Recovery hotfix branch | In progress | `hotfix/v0.24.0-publish-recovery` |
+| Recovery hotfix branch | Complete | `hotfix/v0.24.0-publish-recovery` |
 | Local repaired-matrix verification | PASS | Detailed above |
-| Independent hotfix review | Pending | — |
-| Gate A production-merge approval | Pending | — |
-| Recovery hotfix PR/merge | Pending | — |
-| Gate B publication approval | Pending | — |
-| Recovery workflow dispatch | Pending | — |
+| Independent hotfix review | PASS | APPROVE; no Critical or Important findings |
+| Gate A production-merge approval | Approved and exercised | Exact PR #220 head `e378bd4` |
+| Recovery hotfix PR/merge | Complete | [PR #220](https://github.com/Industrial-Algebra/Amari/pull/220), merge `b44efe8` |
+| Gate B publication approval | Approved and exercised for first dispatch | Registries plus later verified GitHub Release |
+| First recovery workflow dispatch | Failed safely | [Run 30212036351](https://github.com/Industrial-Algebra/Amari/actions/runs/30212036351); validation only, publication jobs skipped |
+| Toolchain-pin hotfix | In progress | `hotfix/v0.24.0-publish-toolchain-pin` |
+| Toolchain-pin retry approvals | Pending | New Gate A and Gate B required |
 | All 26 crates.io artifacts visible | Pending | — |
 | Registry-resolved Rust smoke tests | Pending | — |
 | npm artifact visible | Pending | — |

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -57,4 +57,16 @@ if clippy_commands != expected_clippy:
         f"lint exception, found: {clippy_commands!r}"
     )
 
-print("publish test scope excludes amari-gpu runtime execution")
+release_toolchain = "uses: dtolnay/rust-toolchain@1.97.1"
+toolchain_uses = [
+    line.strip()
+    for line in workflow.splitlines()
+    if line.strip().startswith("uses: dtolnay/rust-toolchain@")
+]
+if toolchain_uses != [release_toolchain] * 4:
+    raise AssertionError(
+        "all and only the four publish jobs must pin the verified Rust 1.97.1 "
+        f"toolchain; found: {toolchain_uses!r}"
+    )
+
+print("publish test scope and release toolchain are pinned")


### PR DESCRIPTION
## Purpose

Pin the verified Rust 1.97.1 release toolchain after the first approved v0.24.0 recovery dispatch failed safely under a newer moving `stable` Clippy.

## Failed run

[Run 30212036351](https://github.com/Industrial-Algebra/Amari/actions/runs/30212036351) was dispatched from exact `master` commit `b44efe8` after Gate B approval. It failed in validation at:

- `amari-dynamics/src/stochastic/fokker_planck.rs:171`
- new `clippy::manual_slice_fill` warning from the moving stable toolchain

All publication jobs were skipped. Renewed inventory confirms:

- crates.io 0.24.0: **0/26 present**
- npm `@justinelliottcobb/amari-wasm@0.24.0`: **absent**
- GitHub Release: **absent**

## Minimal repair

All four publish workflow Rust setup paths now use:

```yaml
uses: dtolnay/rust-toolchain@1.97.1
```

This covers validation, crates publication, the standalone WASM build, and npm publication. The action ref exists at `refs/heads/1.97.1`.

The static verifier now extracts every `dtolnay/rust-toolchain@...` use and requires exactly four 1.97.1 pins. A regression fixture with an added `@stable` use fails correctly.

No source, Cargo metadata, catalog, npm metadata, runtime scope, tag, or publication ordering changed. No new lint exception was introduced.

## Verification

- publish scope/toolchain verifier: **PASS**
- verifier RED against moving-toolchain regression fixture: **PASS**
- Rust 1.97.1 normal-target Clippy with `-D warnings`: **PASS**
- Rust 1.97.1 all-target Clippy with only the already-approved test lint exceptions: **PASS**
- formatting/diff checks: **PASS**
- independent review and rereview: **APPROVE**, no remaining Critical/Important findings

## Approval scope

This PR requires renewed **Gate A** approval before merge. Merging does not authorize another workflow dispatch, registry action, tag operation, or GitHub Release. A renewed **Gate B** is required after merge and readiness reconfirmation.
