### PR TITLE
fix: enforce v0.24 publish toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # rust-toolchain.toml selects nightly for Creusot development. Publication
+  # must override that directory selection with the verified release toolchain.
+  RUSTUP_TOOLCHAIN: 1.97.1
 
 jobs:
   validate:

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -148,24 +148,33 @@ therefore performs the authoritative discovery dry-run only after prerequisites
 are published and indexed. No local discovery archive is represented as current
 registry-resolution evidence.
 
-## First approved dispatch outcome
+## Approved dispatch outcomes and effective-toolchain root cause
 
 Gate B authorized both registry publication and later GitHub Release creation
 after registry verification. Workflow run
 [30212036351](https://github.com/Industrial-Algebra/Amari/actions/runs/30212036351)
 was dispatched from exact `master` commit
-`b44efe8be5ae8ed0aecddb767e0ae4544927391f`. It failed safely in validation;
-all publication jobs were skipped and a renewed inventory found 0/26 Rust
-artifacts, no npm 0.24.0 artifact, and no GitHub Release.
+`b44efe8be5ae8ed0aecddb767e0ae4544927391f`. It failed safely in validation.
+The first repair pinned all four `dtolnay/rust-toolchain` action refs to 1.97.1,
+and renewed Gate A/Gate B approvals authorized a retry from exact merge
+`dab62bf29f147077db695368cf95e7c8a39f7674`. That retry, workflow run
+[30213633091](https://github.com/Industrial-Algebra/Amari/actions/runs/30213633091),
+also failed safely in validation. Both times every publication job was skipped;
+renewed inventories found 0/26 Rust artifacts, no npm 0.24.0 artifact, and no
+GitHub Release.
 
-The failure was caused by `dtolnay/rust-toolchain@stable` resolving to a newer
-moving toolchain than the locally verified Rust 1.97.1 release toolchain. The
-new Clippy added `clippy::manual_slice_fill`, producing a warning-denied error in
-`amari-dynamics/src/stochastic/fokker_planck.rs:171`. No release source change or
-new lint exception is appropriate. The recovery instead pins all four publish
-jobs to Rust 1.97.1 and extends the static verifier to reject a moving release
-toolchain. Retry requires a reviewed production PR and renewed Gate A/Gate B
-approval.
+The complete root cause is Rustup toolchain precedence. Although the action
+installed and selected Rust 1.97.1, the repository's `rust-toolchain.toml`
+selects nightly for Creusot development and overrode unqualified `cargo`
+commands. The second run's setup log explicitly reports that nightly remained
+in use. Nightly Clippy added `clippy::manual_slice_fill`, producing the
+warning-denied error at
+`amari-dynamics/src/stochastic/fokker_planck.rs:171`. Pinning only the action ref
+was therefore insufficient. No release source change or new lint exception is
+appropriate. The workflow must also set global `RUSTUP_TOOLCHAIN: 1.97.1`, which
+has higher precedence than the directory toolchain file; the static verifier
+must require both the action pins and effective global override. Retry again
+requires a reviewed production PR and renewed Gate A/Gate B approval.
 
 ## Recovery evidence
 
@@ -178,8 +187,11 @@ approval.
 | Recovery hotfix PR/merge | Complete | [PR #220](https://github.com/Industrial-Algebra/Amari/pull/220), merge `b44efe8` |
 | Gate B publication approval | Approved and exercised for first dispatch | Registries plus later verified GitHub Release |
 | First recovery workflow dispatch | Failed safely | [Run 30212036351](https://github.com/Industrial-Algebra/Amari/actions/runs/30212036351); validation only, publication jobs skipped |
-| Toolchain-pin hotfix | In progress | `hotfix/v0.24.0-publish-toolchain-pin` |
-| Toolchain-pin retry approvals | Pending | New Gate A and Gate B required |
+| Toolchain-pin hotfix | Complete | [PR #221](https://github.com/Industrial-Algebra/Amari/pull/221), merge `dab62bf` |
+| Toolchain-pin retry approvals | Approved and exercised | Exact PR #221 head `e9e5b8a`; registries plus later verified GitHub Release |
+| Second recovery workflow dispatch | Failed safely | [Run 30213633091](https://github.com/Industrial-Algebra/Amari/actions/runs/30213633091); validation only, publication jobs skipped |
+| Effective-toolchain override hotfix | In progress | `hotfix/v0.24.0-publish-toolchain-override` |
+| Effective-toolchain retry approvals | Pending | New Gate A and Gate B required |
 | All 26 crates.io artifacts visible | Pending | — |
 | Registry-resolved Rust smoke tests | Pending | — |
 | npm artifact visible | Pending | — |

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -57,11 +57,14 @@ if clippy_commands != expected_clippy:
         f"lint exception, found: {clippy_commands!r}"
     )
 
+active_lines = [
+    line.split("#", 1)[0].strip()
+    for line in workflow.splitlines()
+    if line.split("#", 1)[0].strip()
+]
 release_toolchain = "uses: dtolnay/rust-toolchain@1.97.1"
 toolchain_uses = [
-    line.strip()
-    for line in workflow.splitlines()
-    if line.strip().startswith("uses: dtolnay/rust-toolchain@")
+    line for line in active_lines if line.startswith("uses: dtolnay/rust-toolchain@")
 ]
 if toolchain_uses != [release_toolchain] * 4:
     raise AssertionError(
@@ -69,4 +72,21 @@ if toolchain_uses != [release_toolchain] * 4:
         f"toolchain; found: {toolchain_uses!r}"
     )
 
-print("publish test scope and release toolchain are pinned")
+workflow_preamble = workflow.split("\njobs:", 1)[0]
+preamble_lines = [
+    line.split("#", 1)[0].strip()
+    for line in workflow_preamble.splitlines()
+    if line.split("#", 1)[0].strip()
+]
+release_override = "RUSTUP_TOOLCHAIN: 1.97.1"
+preamble_overrides = [
+    line for line in preamble_lines if line.startswith("RUSTUP_TOOLCHAIN:")
+]
+all_overrides = [line for line in active_lines if line.startswith("RUSTUP_TOOLCHAIN:")]
+if preamble_overrides != [release_override] or all_overrides != [release_override]:
+    raise AssertionError(
+        "publish workflow must have exactly one global rust-toolchain.toml "
+        f"override, RUSTUP_TOOLCHAIN 1.97.1; found: {all_overrides!r}"
+    )
+
+print("publish test scope and effective release toolchain are pinned")


### PR DESCRIPTION
## Purpose

Make Rust 1.97.1 the **effective** toolchain for every v0.24.0 publish job by overriding the repository's nightly `rust-toolchain.toml` selection.

## Second safe failure

Renewed Gate B authorized [run 30213633091](https://github.com/Industrial-Algebra/Amari/actions/runs/30213633091) from exact `master` merge `dab62bf`. The prior hotfix correctly installed and selected Rust 1.97.1 as the default, but the action log also reported:

> toolchain 'nightly' is currently in use (overridden by rust-toolchain.toml)

Unqualified workflow `cargo` commands therefore still ran nightly Clippy and failed on `clippy::manual_slice_fill` in `amari-dynamics/src/stochastic/fokker_planck.rs:171`.

All publication jobs were skipped again. Registry state remains 0/26 crates, npm 0.24.0 absent, and GitHub Release absent.

## Complete root-cause repair

The workflow-level environment now sets:

```yaml
env:
  RUSTUP_TOOLCHAIN: 1.97.1
```

Rustup environment selection has higher precedence than `rust-toolchain.toml`, and is inherited by validation, `cargo publish`, and `wasm-pack` subprocesses in all jobs. The four existing action pins remain.

The verifier now requires:

- exactly four active `dtolnay/rust-toolchain@1.97.1` action refs;
- exactly one active `RUSTUP_TOOLCHAIN` assignment;
- that assignment must be global and equal to `1.97.1`;
- comments cannot false-pass or false-fail these checks.

No source, Cargo metadata, catalog, npm metadata, tag, runtime scope, or lint exception changed.

## Verification

- RED verifier against missing global override: **PASS**
- verifier on repaired workflow: **PASS**
- comment and duplicate/rogue-override fixtures: **PASS**
- `RUSTUP_TOOLCHAIN=1.97.1 rustc --version`: exact 1.97.1
- workflow-equivalent unqualified normal-target Clippy: **PASS**
- workflow-equivalent unqualified all-target Clippy: **PASS**
- `wasm-pack` under effective override: **PASS**, exact npm package 0.24.0
- independent review/rereview: **APPROVE**, no remaining Critical/Important findings

## Approval scope

This PR requires another explicit Gate A approval. Merge does not authorize retrying publication; a new Gate B is required after readiness reconfirmation.
