### PR TITLE
fix: extend bounded v0.24 publish validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,9 @@ jobs:
   validate:
     name: Validate and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # A cold GitHub runner was canceled by the 45-minute limit near the end of
+    # the approved CPU matrix; retain a finite bound with enough headroom.
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -173,8 +173,18 @@ warning-denied error at
 was therefore insufficient. No release source change or new lint exception is
 appropriate. The workflow must also set global `RUSTUP_TOOLCHAIN: 1.97.1`, which
 has higher precedence than the directory toolchain file; the static verifier
-must require both the action pins and effective global override. Retry again
-requires a reviewed production PR and renewed Gate A/Gate B approval.
+must require both the action pins and effective global override.
+
+After that repair merged, explicit approval authorized a validation-only
+preflight with both publication flags false. Run
+[30215540321](https://github.com/Industrial-Algebra/Amari/actions/runs/30215540321)
+proved the effective toolchain repair: formatting, both Clippy passes, and the
+static verifier succeeded, and the CPU matrix reported only passing test
+results. The job was canceled by its finite 45-minute timeout near the end of
+the approved matrix. All publication jobs were conditionally skipped. A cold
+GitHub runner therefore needs a 90-minute finite validation bound; the static
+verifier enforces that exact value. Registry publication still requires a
+reviewed timeout PR and renewed Gate A/Gate B approval.
 
 ## Recovery evidence
 
@@ -190,8 +200,11 @@ requires a reviewed production PR and renewed Gate A/Gate B approval.
 | Toolchain-pin hotfix | Complete | [PR #221](https://github.com/Industrial-Algebra/Amari/pull/221), merge `dab62bf` |
 | Toolchain-pin retry approvals | Approved and exercised | Exact PR #221 head `e9e5b8a`; registries plus later verified GitHub Release |
 | Second recovery workflow dispatch | Failed safely | [Run 30213633091](https://github.com/Industrial-Algebra/Amari/actions/runs/30213633091); validation only, publication jobs skipped |
-| Effective-toolchain override hotfix | In progress | `hotfix/v0.24.0-publish-toolchain-override` |
-| Effective-toolchain retry approvals | Pending | New Gate A and Gate B required |
+| Effective-toolchain override hotfix | Complete | [PR #222](https://github.com/Industrial-Algebra/Amari/pull/222), merge `6cda92a` |
+| Validation-only preflight approval | Approved and exercised | Both publication inputs explicitly false |
+| Validation-only preflight | Canceled at finite bound | [Run 30215540321](https://github.com/Industrial-Algebra/Amari/actions/runs/30215540321); format/Clippy/scope passed, CPU results were passing but incomplete, publication jobs skipped |
+| Finite-timeout hotfix | In progress | `hotfix/v0.24.0-publish-timeout` |
+| Registry retry approvals | Pending | New Gate A and Gate B required |
 | All 26 crates.io artifacts visible | Pending | — |
 | Registry-resolved Rust smoke tests | Pending | — |
 | npm artifact visible | Pending | — |

--- a/scripts/verify-publish-test-scope.py
+++ b/scripts/verify-publish-test-scope.py
@@ -33,8 +33,16 @@ for required in (
     if required not in commands:
         raise AssertionError(f"missing required publish test: {required}")
 
-if "timeout-minutes:" not in validate:
-    raise AssertionError("validate job must have timeout-minutes")
+timeout_lines = [
+    line.strip()
+    for line in validate.splitlines()
+    if line.strip().startswith("timeout-minutes:")
+]
+if timeout_lines != ["timeout-minutes: 90"]:
+    raise AssertionError(
+        "validate job must use the empirically bounded 90-minute timeout; "
+        f"found: {timeout_lines!r}"
+    )
 if "--test-threads" in validate:
     raise AssertionError("publish tests must not use global serialization")
 if "./run_all_tests.sh" in validate:


### PR DESCRIPTION
## Purpose

Raise the finite publish-validation timeout from 45 to 90 minutes after an explicitly approved validation-only preflight proved the repaired toolchain and reached the end of its prior time budget with only passing, but incomplete, CPU results.

## Preflight evidence

[Run 30215540321](https://github.com/Industrial-Algebra/Amari/actions/runs/30215540321) used:

- `publish_crates=false`
- `publish_npm=false`
- exact `master` commit `6cda92a`

It confirmed:

- effective Rust 1.97.1 setup: **PASS**
- formatting: **PASS**
- normal and all-target Clippy: **PASS**
- publish scope/toolchain verifier: **PASS**
- observed CPU test results: **all passing**

The validate job was canceled by its 45-minute limit near the end of the mandated CPU matrix. The matrix was therefore incomplete, and no success is claimed. Every publication job was skipped by condition. No artifacts exist.

## Minimal repair

```yaml
timeout-minutes: 90
```

This remains a finite bound and applies only to `validate`. The static verifier now requires exactly 90 minutes, forcing review of future timeout changes.

No source, tests, matrix commands, GPU scope, toolchain, lint exceptions, Cargo/npm metadata, publication order, or tag changed.

## Review

Independent review/rereview: **APPROVE**, no remaining Critical/Important findings.

## Approval scope

This PR requires explicit Gate A approval. Merge does not authorize another validation or publication dispatch. Registry publication still requires a new Gate B after a successful validation-only preflight.
