### PR TITLE
docs: close v0.24.0 release evidence

### DIFF
--- a/docs/releases/v0.24.0-publication-evidence.md
+++ b/docs/releases/v0.24.0-publication-evidence.md
@@ -226,7 +226,7 @@ Release was created only after these checks passed.
 | npm artifact visible | PASS | [`@justinelliottcobb/amari-wasm@0.24.0`](https://www.npmjs.com/package/@justinelliottcobb/amari-wasm/v/0.24.0), manually published |
 | Clean npm smoke test | PASS | Exact registry install, 186-export import, zero audit findings |
 | GitHub Release | PASS | [Amari v0.24.0](https://github.com/Industrial-Algebra/Amari/releases/tag/v0.24.0), published 2026-07-27 |
-| `master → develop` merge-commit backmerge | In progress | `backmerge/v0.24.0-master-to-develop`; `origin/master` is an ancestor of branch merge `e6148a3` |
+| `master → develop` merge-commit backmerge | PASS | [PR #224](https://github.com/Industrial-Algebra/Amari/pull/224), merge `747827e`; production `bcd20ac` is an ancestor of `origin/develop` |
 
 ## Final artifact checksums
 
@@ -249,8 +249,11 @@ and its SHA-1 shasum is `bbda38670838974e74f7f6dc01e56f8160ae8b1d`.
 
 ## Shipped decision
 
-**Status: NOT SHIPPED.**
+**Status: SHIPPED on 2026-07-27.**
 
-The release may be marked shipped only after exact registry visibility, clean
-Rust/npm installation tests, approved public release record, and the mandatory
-merge-commit backmerge are recorded above.
+All 26 exact Rust artifacts and the npm artifact are publicly visible; registry
+checksums and clean Rust/npm installation tests passed; the approved public
+GitHub Release exists; the annotated tag remains unchanged; and merge-commit
+backmerge PR #224 makes production `bcd20ac` an ancestor of integration commit
+`747827e`. Amari 0.24.0 is therefore complete under the repository's definition
+of shipped.


### PR DESCRIPTION
## Purpose

Close the v0.24.0 recovery record after all shipping criteria completed.

## Final evidence

- 26/26 exact Rust crates public; downloaded SHA-256 values match crates.io metadata
- clean Rust 1.97.1 project resolved and checked all 26 registry packages
- clean `cargo install amari-discovery 0.24.0` and capabilities check passed
- npm `@justinelliottcobb/amari-wasm@0.24.0` public; clean install/import exposed 186 exports with zero audit findings
- public GitHub Release: https://github.com/Industrial-Algebra/Amari/releases/tag/v0.24.0
- annotated tag object remains `1bcfc2425a9893bffacdc043cf93dca4439b1824`, peeling to `eb2e15d`
- mandatory merge-commit backmerge PR #224 merged as `747827e`
- `origin/master` production head `bcd20ac` is an ancestor of `origin/develop`

This docs-only PR marks v0.24.0 **SHIPPED** under the repository definition of done.
