### PR TITLE
feat: attach wire contracts to discovery probes

### DIFF
--- a/amari-discovery/Cargo.toml
+++ b/amari-discovery/Cargo.toml
@@ -48,6 +48,8 @@ amari-cgt = { workspace = true, optional = true }
 amari-surreal = { workspace = true, optional = true }
 amari-surcomplex = { workspace = true, optional = true }
 amari-rewrite = { workspace = true }
+amari-discovery-macros = { workspace = true }
+schemars = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1", features = ["system", "fs"] }

--- a/amari-discovery/README.md
+++ b/amari-discovery/README.md
@@ -79,6 +79,88 @@ tool version, recall seed, catalog identity, project/input hashes, and saved
 probe hashes. A dry run validates compatibility only; actual probe execution
 requires an explicit typed input JSON file.
 
+## Probe wire schema authority
+
+Every executable probe resolves a complete DTO-derived input and output
+schema. `probe describe` remains compact but now includes `schema_hashes` for
+both directions:
+
+```bash
+amari probe describe amari-probe:dual:polynomial-derivative:v1 --json
+```
+
+Resolve the exported documents and their canonical SHA-256 hash explicitly:
+
+```bash
+amari probe schema amari-probe:dual:polynomial-derivative:v1 --direction input --json
+amari probe schema amari-probe:dual:polynomial-derivative:v1 --direction output --json
+```
+
+The response remains an `amari.discovery/v1` envelope. Its `data.document` is
+the exported JSON Schema plus Amari metadata, and `data.hash` is the canonical
+SHA-256 hash of that document. For the dual polynomial-derivative input, the
+complete document is:
+
+```json
+{
+  "$id": "amari.discovery/probe/dual-polynomial-derivative/input/v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "PolynomialDerivativeRequest",
+  "description": "Typed input for dual-number evaluation of a scalar polynomial and derivative.",
+  "required": ["coefficients", "at"],
+  "additionalProperties": false,
+  "properties": {
+    "coefficients": {
+      "type": "array",
+      "description": "Polynomial coefficients in descending-power order.",
+      "items": { "type": "number", "format": "double" }
+    },
+    "at": {
+      "type": "number",
+      "format": "double",
+      "description": "Point at which to evaluate the polynomial and its first derivative."
+    }
+  },
+  "x-amari-schema-role": "input",
+  "x-amari-protocol-version": "amari.discovery/v1",
+  "x-amari-semantic-constraints": [
+    {
+      "id": "coefficient_count_limit",
+      "description": "at most 5000 coefficients are accepted per request"
+    },
+    {
+      "id": "finite_numbers",
+      "description": "all coefficients and the evaluation point must be finite"
+    },
+    {
+      "id": "nonempty_coefficients",
+      "description": "the polynomial requires at least one coefficient"
+    }
+  ],
+  "x-amari-examples": [
+    {
+      "label": "quadratic",
+      "value": { "coefficients": [1.0, 2.0, 3.0], "at": 2.0 }
+    }
+  ],
+  "x-amari-compatibility": "additive_patch"
+}
+```
+
+Structural JSON Schema describes the accepted JSON shape. The
+`x-amari-semantic-constraints` metadata is authoritative documentation for
+checks that still require semantic Rust validation, such as finite numbers,
+nonempty polynomials, exact rational bounds, term depth, and deterministic
+truncation behavior. Agents should validate structure from the schema but must
+not treat JSON Schema alone as proof that a payload satisfies the probe's
+semantic contract.
+
+The known but non-executable
+`amari-probe:tropical:shortest-path:v1` descriptor remains declared-only: its
+identity is visible, but the command does not fabricate a compiled contract
+when no adapter is present.
+
 ## Output and errors
 
 - Human output is the default.

--- a/amari-discovery/src/cli.rs
+++ b/amari-discovery/src/cli.rs
@@ -13,7 +13,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use crate::inspect::{inspect_project_envelope, InspectionLimits};
 use crate::{
     commands, render, Capabilities, Catalog, CatalogIdentity, Compatibility, DiscoveryError,
-    DiscoveryResult, Envelope, GoalSpec, ReplayMetadata,
+    DiscoveryResult, Envelope, GoalSpec, ReplayMetadata, WireSchemaRole,
 };
 
 #[derive(Debug, Parser)]
@@ -140,6 +140,14 @@ enum ProbeCommand {
         /// Stable probe ID.
         probe_id: String,
     },
+    /// Resolve one complete DTO-derived probe wire schema.
+    Schema {
+        /// Stable probe ID.
+        probe_id: String,
+        /// Schema direction: input or output.
+        #[arg(long)]
+        direction: String,
+    },
     /// Run or dry-run a registered probe.
     Run {
         /// Stable probe ID.
@@ -235,6 +243,13 @@ impl ProbeCommand {
             Self::Describe { probe_id } => {
                 let _ = probe_id;
                 "probe describe"
+            }
+            Self::Schema {
+                probe_id,
+                direction,
+            } => {
+                let _ = (probe_id, direction);
+                "probe schema"
             }
             Self::Run {
                 probe_id,
@@ -488,6 +503,23 @@ fn run_probe<W: Write>(
                 mode,
                 render::write_probe_description_human,
             )
+        }
+        ProbeCommand::Schema {
+            probe_id,
+            direction,
+        } => {
+            let probe_id = probe_id.parse()?;
+            let role = match direction.as_str() {
+                "input" => WireSchemaRole::Input,
+                "output" => WireSchemaRole::Output,
+                _ => {
+                    return Err(DiscoveryError::InvalidInput(
+                        "probe schema direction must be `input` or `output`".to_owned(),
+                    ));
+                }
+            };
+            let envelope = commands::probe::schema_envelope(&catalog, &probe_id, role)?;
+            render::write_envelope(writer, &envelope, mode, render::write_probe_schema_human)
         }
         ProbeCommand::Run {
             probe_id,

--- a/amari-discovery/src/commands/probe.rs
+++ b/amari-discovery/src/commands/probe.rs
@@ -12,8 +12,8 @@ use super::recommend::read_bounded_input;
 use crate::{
     CandidatePlan, Capabilities, Catalog, CatalogIdentity, Compatibility, DiscoveryError,
     DiscoveryResult, Envelope, PlanStep, ProbeBackend, ProbeDescriptor, ProbeEngineLimits, ProbeId,
-    ProbeIsolation, ProbeResult, ProbeSchemaBinding, ProbeSchemaDocument, Provenance,
-    ReplayMetadata, ResourceLimits, WireSchemaRole, SCHEMA_V1,
+    ProbeIsolation, ProbeResult, ProbeSchemaBinding, Provenance, ReplayMetadata, ResourceLimits,
+    WireSchemaRole, SCHEMA_V1,
 };
 
 const MAX_PROBE_INPUT_BYTES: u64 = 1_048_576;
@@ -62,6 +62,15 @@ pub struct ProbeDescription {
     pub schema_hashes: ProbeSchemaBinding,
     /// Qualification for the runtime state.
     pub reason: Option<String>,
+}
+
+/// Complete exported wire schema plus its canonical identity hash.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProbeSchemaResolution {
+    /// Exported JSON Schema document including Amari metadata.
+    pub document: Value,
+    /// Lowercase SHA-256 hash of the canonical exported document bytes.
+    pub hash: String,
 }
 
 /// Compatibility-only result for a probe step in a saved plan.
@@ -174,7 +183,7 @@ pub fn schema_envelope(
     catalog: &Catalog,
     probe_id: &ProbeId,
     role: WireSchemaRole,
-) -> DiscoveryResult<Envelope<ProbeSchemaDocument>> {
+) -> DiscoveryResult<Envelope<ProbeSchemaResolution>> {
     let descriptor = descriptor(catalog, probe_id)?;
     let schema_id = match role {
         WireSchemaRole::Input => descriptor.input_schema.as_str(),
@@ -187,7 +196,13 @@ pub fn schema_envelope(
             role = role.as_str()
         ))
     })?;
-    Ok(catalog_envelope(catalog, document.clone()))
+    Ok(catalog_envelope(
+        catalog,
+        ProbeSchemaResolution {
+            document: document.exported_value()?,
+            hash: document.canonical_hash()?,
+        },
+    ))
 }
 
 /// Validates a saved plan's catalog-backed probe step without execution.

--- a/amari-discovery/src/commands/probe.rs
+++ b/amari-discovery/src/commands/probe.rs
@@ -12,7 +12,8 @@ use super::recommend::read_bounded_input;
 use crate::{
     CandidatePlan, Capabilities, Catalog, CatalogIdentity, Compatibility, DiscoveryError,
     DiscoveryResult, Envelope, PlanStep, ProbeBackend, ProbeDescriptor, ProbeEngineLimits, ProbeId,
-    ProbeIsolation, ProbeResult, Provenance, ReplayMetadata, ResourceLimits, SCHEMA_V1,
+    ProbeIsolation, ProbeResult, ProbeSchemaBinding, ProbeSchemaDocument, Provenance,
+    ReplayMetadata, ResourceLimits, WireSchemaRole, SCHEMA_V1,
 };
 
 const MAX_PROBE_INPUT_BYTES: u64 = 1_048_576;
@@ -57,6 +58,8 @@ pub struct ProbeDescription {
     pub hard_timeout: bool,
     /// Whether worker crashes are isolated from the CLI process.
     pub crash_isolation: bool,
+    /// Compact resolved or declared wire schema identities and hashes.
+    pub schema_hashes: ProbeSchemaBinding,
     /// Qualification for the runtime state.
     pub reason: Option<String>,
 }
@@ -136,6 +139,15 @@ pub fn describe_envelope(
 ) -> DiscoveryResult<Envelope<ProbeDescription>> {
     let descriptor = descriptor(catalog, probe_id)?.clone();
     let state = runtime_state(probe_id)?;
+    let schema_registry = crate::probes::wire_schema_registry(catalog)?;
+    let schema_hashes = schema_registry
+        .binding(probe_id)
+        .ok_or_else(|| {
+            DiscoveryError::CatalogCorruption(format!(
+                "probe `{probe_id}` has no wire schema binding"
+            ))
+        })?
+        .clone();
     Ok(catalog_envelope(
         catalog,
         ProbeDescription {
@@ -146,9 +158,36 @@ pub fn describe_envelope(
             isolation: ProbeIsolation::Process,
             hard_timeout: true,
             crash_isolation: true,
+            schema_hashes,
             reason: state.reason,
         },
     ))
+}
+
+/// Returns the complete DTO-derived wire schema for one probe direction.
+///
+/// # Errors
+///
+/// Returns invalid input for an unknown probe or a known probe whose contract
+/// is only declarative in this build, or a catalog/registry corruption error.
+pub fn schema_envelope(
+    catalog: &Catalog,
+    probe_id: &ProbeId,
+    role: WireSchemaRole,
+) -> DiscoveryResult<Envelope<ProbeSchemaDocument>> {
+    let descriptor = descriptor(catalog, probe_id)?;
+    let schema_id = match role {
+        WireSchemaRole::Input => descriptor.input_schema.as_str(),
+        WireSchemaRole::Output => descriptor.output_schema.as_str(),
+    };
+    let schema_registry = crate::probes::wire_schema_registry(catalog)?;
+    let document = schema_registry.document(schema_id).ok_or_else(|| {
+        DiscoveryError::InvalidInput(format!(
+            "probe `{probe_id}` has only a declared {role} wire schema in this build",
+            role = role.as_str()
+        ))
+    })?;
+    Ok(catalog_envelope(catalog, document.clone()))
 }
 
 /// Validates a saved plan's catalog-backed probe step without execution.

--- a/amari-discovery/src/lib.rs
+++ b/amari-discovery/src/lib.rs
@@ -61,7 +61,7 @@ pub use commands::discover::{
     SearchResults,
 };
 pub use commands::probe::{
-    ProbeDescription, ProbeDryRun, ProbeList, ProbeListItem, ProbeRunResult,
+    ProbeDescription, ProbeDryRun, ProbeList, ProbeListItem, ProbeRunResult, ProbeSchemaResolution,
 };
 pub use error::{DiscoveryError, DiscoveryResult};
 pub use inspect::{

--- a/amari-discovery/src/probes/cgt.rs
+++ b/amari-discovery/src/probes/cgt.rs
@@ -24,15 +24,56 @@ const OPERATIONS_PER_OPTION_ENTRY: u64 = 4;
 const OPERATIONS_PER_REQUESTED_HEAP: u64 = 2;
 
 /// Typed input for exact nim-sum evaluation through Sprague-Grundy values.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/cgt-nim-sum/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        heap_count_limit = "at most 256 Nim heaps are accepted per request",
+        heap_value_limit = "each Nim heap value must be no greater than 64"
+    ),
+    example(label = "three_heaps", value = "{\"heaps\":[1,2,3]}")
+)]
 pub struct CgtNimSumRequest {
     /// Sizes of the independent Nim heaps.
     pub heaps: Vec<u32>,
 }
 
 /// Typed output from exact nim-sum evaluation.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/cgt-nim-sum/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        grundy_values_align_with_heaps = "grundy_values has exactly one entry for each requested heap, in request order",
+        nim_sum_is_xor = "nim_sum is the bitwise XOR of every grundy_values entry"
+    ),
+    example(
+        label = "three_heaps",
+        value = "{\"grundy_values\":[1,2,3],\"nim_sum\":0}"
+    )
+)]
 pub struct CgtNimSumOutput {
     /// Sprague-Grundy value computed directly for each requested heap.
     pub grundy_values: Vec<u32>,

--- a/amari-discovery/src/probes/core.rs
+++ b/amari-discovery/src/probes/core.rs
@@ -24,8 +24,29 @@ const PRODUCT_NODES: u64 = COEFFICIENT_COUNT * 3;
 const PRODUCT_ITERATIONS: u64 = PRODUCT_OPERATIONS;
 
 /// Typed input for a geometric product in Euclidean Cl(3,0,0).
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/core-geometric-product/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        finite_numbers = "all Cl(3,0,0) input coefficients must be finite",
+        fixed_coefficient_length = "each operand must contain exactly eight coefficients in binary basis-blade order"
+    ),
+    example(
+        label = "basis_product",
+        value = "{\"left\":[0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0],\"right\":[0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0]}"
+    )
+)]
 pub struct Cl3ProductRequest {
     /// Left coefficients in binary basis-blade order.
     pub left: [f64; 8],
@@ -34,7 +55,28 @@ pub struct Cl3ProductRequest {
 }
 
 /// Typed output from a Euclidean Cl(3,0,0) geometric product.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/core-geometric-product/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        finite_numbers = "all Cl(3,0,0) output coefficients are finite",
+        fixed_coefficient_length = "the result contains exactly eight coefficients in binary basis-blade order"
+    ),
+    example(
+        label = "basis_product",
+        value = "{\"coefficients\":[0.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0]}"
+    )
+)]
 pub struct Cl3ProductOutput {
     /// Product coefficients in binary basis-blade order.
     pub coefficients: [f64; 8],

--- a/amari-discovery/src/probes/dual.rs
+++ b/amari-discovery/src/probes/dual.rs
@@ -22,8 +22,30 @@ const OPERATIONS_PER_COEFFICIENT: u64 = 2;
 const MAX_COEFFICIENTS: u64 = MAX_OPERATIONS / OPERATIONS_PER_COEFFICIENT;
 
 /// Typed input for dual-number evaluation of a scalar polynomial and derivative.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/dual-polynomial-derivative/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        coefficient_count_limit = "at most 5000 coefficients are accepted per request",
+        finite_numbers = "all coefficients and the evaluation point must be finite",
+        nonempty_coefficients = "the polynomial requires at least one coefficient"
+    ),
+    example(
+        label = "quadratic",
+        value = "{\"coefficients\":[1.0,2.0,3.0],\"at\":2.0}"
+    )
+)]
 pub struct PolynomialDerivativeRequest {
     /// Polynomial coefficients in descending-power order.
     pub coefficients: Vec<f64>,
@@ -32,7 +54,22 @@ pub struct PolynomialDerivativeRequest {
 }
 
 /// Typed output from dual-number polynomial evaluation.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/dual-polynomial-derivative/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(finite_numbers = "the polynomial value and derivative are finite"),
+    example(label = "quadratic", value = "{\"value\":11.0,\"derivative\":6.0}")
+)]
 pub struct PolynomialDerivativeOutput {
     /// Polynomial value at the requested point.
     pub value: f64,

--- a/amari-discovery/src/probes/holographic.rs
+++ b/amari-discovery/src/probes/holographic.rs
@@ -26,22 +26,58 @@ const RECALL_PASSES_PER_ENTRY: u64 = 11;
 const RECALL_FIXED_PASSES: u64 = 6;
 
 /// Typed request for deterministic additive MAP256 superposition.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/holographic-superposition/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        integer_seeds = "every seed is an unsigned 64-bit integer",
+        nonempty_seeds = "at least one seed is required",
+        seed_count_limit = "at most 256 seeds are accepted"
+    ),
+    example(label = "two_seeds", value = "{\"seeds\":[1,2]}")
+)]
 pub struct HolographicSuperpositionRequest {
     /// Seeds converted deterministically with `MAP256::from_seed`.
     pub seeds: Vec<u64>,
 }
 
 /// Typed output from additive MAP256 superposition.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/holographic-superposition/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        finite_coefficients = "every returned MAP coefficient is finite",
+        map256_dimension = "the coefficient vector contains exactly 256 MAP components"
+    )
+)]
 pub struct HolographicSuperpositionOutput {
     /// Additive trace coefficients in MAP component order.
     pub coefficients: Vec<f64>,
 }
 
 /// One deterministic key-value entry for holographic memory.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct HolographicEntry {
     /// Seed for the MAP256 key.
@@ -51,8 +87,31 @@ pub struct HolographicEntry {
 }
 
 /// Typed request for MAP256 associative-memory retrieval.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/holographic-recall/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        entry_count_limit = "at most 32 key-value entries are accepted",
+        integer_seeds = "entry and query seeds are unsigned 64-bit integers",
+        nonempty_entries = "at least one key-value entry is required"
+    ),
+    example(
+        label = "one_entry",
+        value = "{\"entries\":[{\"key_seed\":1,\"value_seed\":2}],\"query_seed\":1}"
+    )
+)]
 pub struct HolographicRecallRequest {
     /// Ordered key-value entries stored with existing memory semantics.
     pub entries: Vec<HolographicEntry>,
@@ -61,7 +120,7 @@ pub struct HolographicRecallRequest {
 }
 
 /// One normalized key-attribution weight.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct HolographicAttribution {
     /// Entry index in storage order.
     pub index: usize,
@@ -70,7 +129,7 @@ pub struct HolographicAttribution {
 }
 
 /// Capacity metrics reported by `HolographicMemory<MAP256>`.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct HolographicCapacity {
     /// Number of stored entries.
     pub item_count: usize,
@@ -85,7 +144,27 @@ pub struct HolographicCapacity {
 }
 
 /// Typed output from MAP256 associative-memory retrieval.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/holographic-recall/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        bounded_warnings = "warnings are deterministic and bounded to known capacity conditions",
+        capacity_metrics_consistent = "capacity item count, theoretical capacity, and near_capacity reflect the stored entries",
+        finite_metrics = "all returned coefficients, confidence, similarity, attribution weights, and SNR metrics are finite",
+        map256_dimension = "raw and cleaned coefficient vectors each contain exactly 256 MAP components",
+        nonnegative_attribution_weights = "every key-attribution weight is nonnegative"
+    )
+)]
 pub struct HolographicRecallOutput {
     /// Retrieved value after configured cleanup.
     pub value_coefficients: Vec<f64>,

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -46,8 +46,8 @@ pub use surreal::{
 pub use tropical::{TropicalViterbiOutput, TropicalViterbiRequest};
 
 use crate::{
-    Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ProbeSchemaDocument,
-    ProbeSchemaRegistration, ProbeWireSchemaRegistry, ResourceObservations,
+    Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ProbeSchemaBinding,
+    ProbeSchemaDocument, ProbeSchemaRegistration, ProbeWireSchemaRegistry, ResourceObservations,
 };
 
 /// Caller-selected ceilings for cooperative in-process probe execution.
@@ -98,6 +98,8 @@ pub struct ProbeExecution {
     pub input_schema: String,
     /// Versioned response schema emitted by the adapter.
     pub output_schema: String,
+    /// Compact resolved wire schema identities and hashes.
+    pub schema_hashes: ProbeSchemaBinding,
     /// Execution backend.
     pub backend: ProbeBackend,
     /// Available isolation boundary.
@@ -113,6 +115,7 @@ pub struct ProbeExecution {
 /// Public cooperative executor over the fixed private probe registry.
 pub struct ProbeEngine {
     registry: ProbeRegistry,
+    schema_registry: ProbeWireSchemaRegistry,
     limits: ProbeEngineLimits,
 }
 
@@ -165,8 +168,10 @@ impl ProbeEngine {
                 "cooperative probe limits must be greater than zero".to_owned(),
             ));
         }
+        let (registry, schema_registry) = build_registries(catalog)?;
         Ok(Self {
-            registry: ProbeRegistry::build(catalog, compiled_registrations()?)?,
+            registry,
+            schema_registry,
             limits,
         })
     }
@@ -249,6 +254,15 @@ impl ProbeEngine {
             probe_id: id.clone(),
             input_schema: registered.input_schema.clone(),
             output_schema: registered.output_schema.clone(),
+            schema_hashes: self
+                .schema_registry
+                .binding(id)
+                .ok_or_else(|| {
+                    DiscoveryError::CatalogCorruption(format!(
+                        "executable probe `{id}` has no wire schema binding"
+                    ))
+                })?
+                .clone(),
             backend: ProbeBackend::Cpu,
             isolation: ProbeIsolation::Cooperative,
             deterministic: registered.deterministic,
@@ -268,20 +282,32 @@ pub(crate) fn execute_isolated(
 }
 
 pub(crate) fn wire_schema_registry(catalog: &Catalog) -> DiscoveryResult<ProbeWireSchemaRegistry> {
-    let executable_ids = compiled_registrations()?
-        .into_iter()
-        .map(|registration| registration.id);
-    ProbeWireSchemaRegistry::build(catalog, executable_ids, compiled_schema_registrations()?)
+    Ok(build_registries(catalog)?.1)
+}
+
+fn build_registries(
+    catalog: &Catalog,
+) -> DiscoveryResult<(ProbeRegistry, ProbeWireSchemaRegistry)> {
+    let adapters = compiled_registrations()?;
+    let executable_ids = adapters
+        .iter()
+        .map(|registration| registration.id.clone())
+        .collect::<Vec<_>>();
+    let schema_registrations = compiled_schema_registrations(catalog, &adapters)?;
+    Ok((
+        ProbeRegistry::build(catalog, adapters)?,
+        ProbeWireSchemaRegistry::build(catalog, executable_ids, schema_registrations)?,
+    ))
 }
 
 #[cfg(feature = "standard-probes")]
-fn compiled_schema_registrations() -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
-    let catalog = Catalog::embedded()?;
+fn compiled_schema_registrations(
+    catalog: &Catalog,
+    adapters: &[AdapterRegistration],
+) -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
     let mut registrations = Vec::new();
-    for probe_id in compiled_registrations()?
-        .into_iter()
-        .map(|registration| registration.id)
-    {
+    for adapter in adapters {
+        let probe_id = adapter.id.clone();
         let probe = catalog
             .probes()
             .iter()
@@ -391,7 +417,10 @@ fn schema_document(schema_id: &str) -> DiscoveryResult<ProbeSchemaDocument> {
 }
 
 #[cfg(not(feature = "standard-probes"))]
-fn compiled_schema_registrations() -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
+fn compiled_schema_registrations(
+    _catalog: &Catalog,
+    _adapters: &[AdapterRegistration],
+) -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
     Ok(Vec::new())
 }
 

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -424,6 +424,20 @@ fn compiled_schema_registrations(
     Ok(Vec::new())
 }
 
+#[cfg(all(test, feature = "standard-probes"))]
+mod tests {
+    use crate::DiscoveryError;
+
+    #[test]
+    fn unknown_compiled_schema_contract_is_catalog_corruption() {
+        assert!(matches!(
+            super::schema_document("amari.discovery/probe/not-registered/input/v1"),
+            Err(DiscoveryError::CatalogCorruption(message))
+                if message.contains("no compiled wire contract")
+        ));
+    }
+}
+
 fn enforce_limit(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {
     if observed <= maximum {
         Ok(())

--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -46,7 +46,8 @@ pub use surreal::{
 pub use tropical::{TropicalViterbiOutput, TropicalViterbiRequest};
 
 use crate::{
-    Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ResourceObservations,
+    Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ProbeSchemaDocument,
+    ProbeSchemaRegistration, ProbeWireSchemaRegistry, ResourceObservations,
 };
 
 /// Caller-selected ceilings for cooperative in-process probe execution.
@@ -264,6 +265,134 @@ pub(crate) fn execute_isolated(
     provenance: crate::Provenance,
 ) -> DiscoveryResult<ProbeExecution> {
     supervisor::execute_isolated(id, input, limits, provenance)
+}
+
+pub(crate) fn wire_schema_registry(catalog: &Catalog) -> DiscoveryResult<ProbeWireSchemaRegistry> {
+    let executable_ids = compiled_registrations()?
+        .into_iter()
+        .map(|registration| registration.id);
+    ProbeWireSchemaRegistry::build(catalog, executable_ids, compiled_schema_registrations()?)
+}
+
+#[cfg(feature = "standard-probes")]
+fn compiled_schema_registrations() -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
+    let catalog = Catalog::embedded()?;
+    let mut registrations = Vec::new();
+    for probe_id in compiled_registrations()?
+        .into_iter()
+        .map(|registration| registration.id)
+    {
+        let probe = catalog
+            .probes()
+            .iter()
+            .find(|probe| probe.id == probe_id)
+            .ok_or_else(|| {
+                DiscoveryError::CatalogCorruption(format!(
+                    "executable probe `{probe_id}` has no descriptor"
+                ))
+            })?;
+        registrations.push(ProbeSchemaRegistration::new(
+            probe_id.clone(),
+            schema_document(&probe.input_schema)?,
+        ));
+        registrations.push(ProbeSchemaRegistration::new(
+            probe_id,
+            schema_document(&probe.output_schema)?,
+        ));
+    }
+    Ok(registrations)
+}
+
+#[cfg(feature = "standard-probes")]
+fn schema_document(schema_id: &str) -> DiscoveryResult<ProbeSchemaDocument> {
+    match schema_id {
+        "amari.discovery/probe/cgt-nim-sum/input/v1" => {
+            ProbeSchemaDocument::from_contract::<CgtNimSumRequest>()
+        }
+        "amari.discovery/probe/cgt-nim-sum/output/v1" => {
+            ProbeSchemaDocument::from_contract::<CgtNimSumOutput>()
+        }
+        "amari.discovery/probe/core-geometric-product/input/v1" => {
+            ProbeSchemaDocument::from_contract::<Cl3ProductRequest>()
+        }
+        "amari.discovery/probe/core-geometric-product/output/v1" => {
+            ProbeSchemaDocument::from_contract::<Cl3ProductOutput>()
+        }
+        "amari.discovery/probe/dual-polynomial-derivative/input/v1" => {
+            ProbeSchemaDocument::from_contract::<PolynomialDerivativeRequest>()
+        }
+        "amari.discovery/probe/dual-polynomial-derivative/output/v1" => {
+            ProbeSchemaDocument::from_contract::<PolynomialDerivativeOutput>()
+        }
+        "amari.discovery/probe/holographic-recall/input/v1" => {
+            ProbeSchemaDocument::from_contract::<HolographicRecallRequest>()
+        }
+        "amari.discovery/probe/holographic-recall/output/v1" => {
+            ProbeSchemaDocument::from_contract::<HolographicRecallOutput>()
+        }
+        "amari.discovery/probe/holographic-superposition/input/v1" => {
+            ProbeSchemaDocument::from_contract::<HolographicSuperpositionRequest>()
+        }
+        "amari.discovery/probe/holographic-superposition/output/v1" => {
+            ProbeSchemaDocument::from_contract::<HolographicSuperpositionOutput>()
+        }
+        "amari.discovery/probe/network-shortest-path/input/v1" => {
+            ProbeSchemaDocument::from_contract::<NetworkShortestPathRequest>()
+        }
+        "amari.discovery/probe/network-shortest-path/output/v1" => {
+            ProbeSchemaDocument::from_contract::<NetworkShortestPathOutput>()
+        }
+        "amari.discovery/probe/optimization-pareto-front/input/v1" => {
+            ProbeSchemaDocument::from_contract::<ParetoFrontRequest>()
+        }
+        "amari.discovery/probe/optimization-pareto-front/output/v1" => {
+            ProbeSchemaDocument::from_contract::<ParetoFrontOutput>()
+        }
+        "amari.discovery/probe/rewrite-infer-rule/input/v1" => {
+            ProbeSchemaDocument::from_contract::<RewriteInferRuleRequest>()
+        }
+        "amari.discovery/probe/rewrite-infer-rule/output/v1" => {
+            ProbeSchemaDocument::from_contract::<RewriteInferRuleOutput>()
+        }
+        "amari.discovery/probe/rewrite-normalize/input/v1" => {
+            ProbeSchemaDocument::from_contract::<RewriteNormalizeRequest>()
+        }
+        "amari.discovery/probe/rewrite-normalize/output/v1" => {
+            ProbeSchemaDocument::from_contract::<RewriteNormalizeOutput>()
+        }
+        "amari.discovery/probe/rewrite-predecessors/input/v1" => {
+            ProbeSchemaDocument::from_contract::<RewritePredecessorsRequest>()
+        }
+        "amari.discovery/probe/rewrite-predecessors/output/v1" => {
+            ProbeSchemaDocument::from_contract::<RewritePredecessorsOutput>()
+        }
+        "amari.discovery/probe/surreal-rational-arithmetic/input/v1" => {
+            ProbeSchemaDocument::from_contract::<RationalSurrealArithmeticRequest>()
+        }
+        "amari.discovery/probe/surreal-rational-arithmetic/output/v1" => {
+            ProbeSchemaDocument::from_contract::<RationalSurrealArithmeticOutput>()
+        }
+        "amari.discovery/probe/surcomplex-rational-division/input/v1" => {
+            ProbeSchemaDocument::from_contract::<RationalSurcomplexDivisionRequest>()
+        }
+        "amari.discovery/probe/surcomplex-rational-division/output/v1" => {
+            ProbeSchemaDocument::from_contract::<RationalSurcomplexDivisionOutput>()
+        }
+        "amari.discovery/probe/tropical-viterbi/input/v1" => {
+            ProbeSchemaDocument::from_contract::<TropicalViterbiRequest>()
+        }
+        "amari.discovery/probe/tropical-viterbi/output/v1" => {
+            ProbeSchemaDocument::from_contract::<TropicalViterbiOutput>()
+        }
+        _ => Err(DiscoveryError::CatalogCorruption(format!(
+            "no compiled wire contract for `{schema_id}`"
+        ))),
+    }
+}
+
+#[cfg(not(feature = "standard-probes"))]
+fn compiled_schema_registrations() -> DiscoveryResult<Vec<ProbeSchemaRegistration>> {
+    Ok(Vec::new())
 }
 
 fn enforce_limit(kind: &str, observed: u64, maximum: u64) -> DiscoveryResult<()> {

--- a/amari-discovery/src/probes/network.rs
+++ b/amari-discovery/src/probes/network.rs
@@ -20,8 +20,32 @@ use crate::{DiscoveryError, DiscoveryResult, ProbeLimits, ResourceObservations, 
 const MAX_NODES: u64 = 128;
 
 /// Typed directed adjacency-matrix request for a shortest path.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/network-shortest-path/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        adjacency_node_limit = "the adjacency matrix contains at most 128 nodes",
+        adjacency_nonempty = "the adjacency matrix contains at least one node",
+        adjacency_square = "every adjacency row has one entry per node",
+        endpoint_indices_in_bounds = "source and target are valid node indices",
+        finite_nonnegative_weights = "every present edge weight is finite and nonnegative"
+    ),
+    example(
+        label = "two_node_path",
+        value = "{\"adjacency\":[[0.0,1.0],[null,0.0]],\"source\":0,\"target\":1}"
+    )
+)]
 pub struct NetworkShortestPathRequest {
     /// Square directed adjacency matrix, where `None` means no edge.
     pub adjacency: Vec<Vec<Option<f64>>>,
@@ -32,7 +56,7 @@ pub struct NetworkShortestPathRequest {
 }
 
 /// One reachable shortest path and its total edge weight.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct NetworkPath {
     /// Node indices from source through target, inclusive.
     pub nodes: Vec<usize>,
@@ -41,7 +65,29 @@ pub struct NetworkPath {
 }
 
 /// Typed output from geometric-network shortest-path evaluation.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/network-shortest-path/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        finite_total_weight = "a reachable path has a finite total weight",
+        optional_path_shape = "path is null exactly when the target is unreachable",
+        path_nodes_within_node_count = "every returned path node is a valid input node index"
+    ),
+    example(
+        label = "two_node_path",
+        value = "{\"path\":{\"nodes\":[0,1],\"total_weight\":1.0}}"
+    )
+)]
 pub struct NetworkShortestPathOutput {
     /// The shortest path, or `None` when the target is unreachable.
     pub path: Option<NetworkPath>,

--- a/amari-discovery/src/probes/optimization.rs
+++ b/amari-discovery/src/probes/optimization.rs
@@ -20,7 +20,7 @@ const MAX_POPULATION: u64 = 256;
 const MAX_DIMENSIONS: u64 = 32;
 
 /// Optimization direction for one objective dimension.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ObjectiveDirection {
     /// Prefer lower objective values.
@@ -30,8 +30,33 @@ pub enum ObjectiveDirection {
 }
 
 /// Typed request for extracting a Pareto front from objective vectors.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/optimization-pareto-front/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        dimension_limit = "at most 32 objective dimensions are accepted",
+        finite_objectives = "every objective value is finite",
+        nonempty_directions = "at least one objective direction is required",
+        nonempty_population = "at least one candidate objective vector is required",
+        population_limit = "at most 256 candidate objective vectors are accepted",
+        rectangular_objectives = "every candidate has exactly one value per objective direction"
+    ),
+    example(
+        label = "three_candidates",
+        value = "{\"objectives\":[[1.0,2.0],[2.0,1.0],[2.0,2.0]],\"directions\":[\"minimize\",\"minimize\"]}"
+    )
+)]
 pub struct ParetoFrontRequest {
     /// Objective vector for each candidate.
     pub objectives: Vec<Vec<f64>>,
@@ -40,7 +65,7 @@ pub struct ParetoFrontRequest {
 }
 
 /// One non-dominated point in the original objective convention.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ParetoPoint {
     /// Zero-based candidate index from the request.
     pub index: usize,
@@ -49,7 +74,29 @@ pub struct ParetoPoint {
 }
 
 /// Typed output from Pareto-front extraction.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/optimization-pareto-front/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        solution_indices_match_request = "every solution index refers to an input candidate",
+        solution_objectives_match_request = "solution objective vectors preserve the original input values and dimension",
+        solutions_are_nondominated = "returned solutions are mutually non-dominated under the requested directions"
+    ),
+    example(
+        label = "three_candidates",
+        value = "{\"solutions\":[{\"index\":0,\"objectives\":[1.0,2.0]},{\"index\":1,\"objectives\":[2.0,1.0]}]}"
+    )
+)]
 pub struct ParetoFrontOutput {
     /// Non-dominated points ordered by original candidate index.
     pub solutions: Vec<ParetoPoint>,

--- a/amari-discovery/src/probes/rewrite.rs
+++ b/amari-discovery/src/probes/rewrite.rs
@@ -39,7 +39,9 @@ const MAX_PREDECESSOR_FRONTIER: u64 = 1_024;
 const MAX_INFERENCE_EXAMPLES: u64 = 256;
 
 /// Serializable first-order term accepted by rewrite probes.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RewriteTerm {
     /// Pattern variable.
@@ -89,7 +91,7 @@ impl RewriteTerm {
 }
 
 /// Serializable checked first-order rewrite rule.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RewriteRule {
     /// Left-hand side pattern.
@@ -117,8 +119,35 @@ impl RewriteRule {
 }
 
 /// Typed input for bounded ordered term normalization.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-normalize/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        max_steps_limit = "max_steps is no greater than 4096",
+        max_steps_positive = "max_steps is greater than zero",
+        rules_checked = "every rule RHS variable occurs in its LHS",
+        rules_count_limit = "at most 256 ordered rules are accepted",
+        rules_non_expanding = "normalization rejects rules that expand forward term size",
+        term_bounds = "terms have depth at most 64 and at most 4096 nodes",
+        term_name_bytes_limit = "variable and symbol names contain at most 256 bytes"
+    ),
+    example(
+        label = "identity_step",
+        value = "{\"term\":{\"kind\":\"symbol\",\"name\":\"a\",\"arguments\":[]},\"rules\":[{\"lhs\":{\"kind\":\"variable\",\"name\":\"x\"},\"rhs\":{\"kind\":\"variable\",\"name\":\"x\"}}],\"max_steps\":1}"
+    )
+)]
 pub struct RewriteNormalizeRequest {
     /// Initial first-order term.
     pub term: RewriteTerm,
@@ -129,7 +158,29 @@ pub struct RewriteNormalizeRequest {
 }
 
 /// Typed fixed-point result from bounded term normalization.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-normalize/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        normal_form_within_term_bounds = "the normal form has depth at most 64 and at most 4096 nodes",
+        steps_within_request_limit = "steps never exceeds the requested max_steps bound"
+    ),
+    example(
+        label = "identity_step",
+        value = "{\"normal_form\":{\"kind\":\"symbol\",\"name\":\"a\",\"arguments\":[]},\"steps\":0}"
+    )
+)]
 pub struct RewriteNormalizeOutput {
     /// Reached normal form.
     pub normal_form: RewriteTerm,
@@ -138,8 +189,38 @@ pub struct RewriteNormalizeOutput {
 }
 
 /// Typed input for bounded inverse-rewrite predecessor search.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-predecessors/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        max_depth_limit = "max_depth is no greater than 16",
+        max_frontier_limit = "max_frontier is no greater than 1024",
+        max_frontier_positive = "max_frontier is greater than zero",
+        max_results_limit = "max_results is no greater than 1024",
+        max_results_positive = "max_results is greater than zero",
+        reverse_lhs_no_duplicate_variables = "reverse search rejects rules whose LHS duplicates variable occurrences",
+        rules_checked = "every rule RHS variable occurs in its LHS",
+        rules_count_limit = "at most 256 ordered rules are accepted",
+        term_bounds = "terms have depth at most 64 and at most 4096 nodes",
+        term_name_bytes_limit = "variable and symbol names contain at most 256 bytes"
+    ),
+    example(
+        label = "one_reverse_step",
+        value = "{\"target\":{\"kind\":\"symbol\",\"name\":\"b\",\"arguments\":[]},\"rules\":[{\"lhs\":{\"kind\":\"symbol\",\"name\":\"a\",\"arguments\":[]},\"rhs\":{\"kind\":\"symbol\",\"name\":\"b\",\"arguments\":[]}}],\"max_depth\":1,\"max_results\":8,\"max_frontier\":8}"
+    )
+)]
 pub struct RewritePredecessorsRequest {
     /// Target term whose predecessors are requested.
     pub target: RewriteTerm,
@@ -154,7 +235,30 @@ pub struct RewritePredecessorsRequest {
 }
 
 /// Deterministic bounded predecessor-search result.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-predecessors/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        predecessors_canonical_order = "predecessors are unique and canonically ordered by the wire DTO",
+        predecessors_within_result_limit = "the predecessor count never exceeds max_results",
+        truncation_truthful = "truncated is true exactly when max_results omitted at least one discovered predecessor"
+    ),
+    example(
+        label = "one_reverse_step",
+        value = "{\"predecessors\":[{\"kind\":\"symbol\",\"name\":\"a\",\"arguments\":[]}],\"truncated\":false}"
+    )
+)]
 pub struct RewritePredecessorsOutput {
     /// Unique predecessor terms in canonical DTO order.
     pub predecessors: Vec<RewriteTerm>,
@@ -163,7 +267,7 @@ pub struct RewritePredecessorsOutput {
 }
 
 /// One positive before/after rewrite example.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RewriteExample {
     /// Concrete term before rewriting.
@@ -173,15 +277,58 @@ pub struct RewriteExample {
 }
 
 /// Typed input for bounded single-rule inference.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-infer-rule/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        example_count_limit = "at most 256 positive rewrite examples are accepted",
+        examples_nonempty = "at least one positive rewrite example is required",
+        term_bounds = "terms have depth at most 64 and at most 4096 nodes",
+        term_name_bytes_limit = "variable and symbol names contain at most 256 bytes"
+    ),
+    example(
+        label = "one_example",
+        value = "{\"examples\":[{\"before\":{\"kind\":\"symbol\",\"name\":\"a\",\"arguments\":[]},\"after\":{\"kind\":\"symbol\",\"name\":\"b\",\"arguments\":[]}}]}"
+    )
+)]
 pub struct RewriteInferRuleRequest {
     /// Positive rewrite examples used for anti-unification.
     pub examples: Vec<RewriteExample>,
 }
 
 /// Exact checked rule inferred from positive examples.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/rewrite-infer-rule/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        rhs_no_duplicate_variables = "the inferred RHS does not duplicate variable occurrences",
+        rhs_variables_subset_lhs = "every inferred RHS variable occurs in its LHS",
+        rule_within_term_bounds = "the inferred rule has depth at most 64 and at most 4096 nodes"
+    )
+)]
 pub struct RewriteInferRuleOutput {
     /// Inferred checked first-order rewrite rule.
     pub rule: RewriteRule,

--- a/amari-discovery/src/probes/surreal.rs
+++ b/amari-discovery/src/probes/surreal.rs
@@ -28,7 +28,7 @@ const SURCOMPLEX_DIVISION_OPERATIONS: u64 = 12;
 const SURCOMPLEX_DIVISION_NODES: u64 = 7;
 
 /// Exact rational encoded as bounded base-ten numerator and denominator strings.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DecimalRational {
     /// Signed base-ten numerator.
@@ -38,8 +38,32 @@ pub struct DecimalRational {
 }
 
 /// Typed input for exact arithmetic over two rational surreal values.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/surreal-rational-arithmetic/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        decimal_length_limit = "numerator and denominator strings each contain 1 to 40 characters",
+        decimal_strings_are_i128 = "decimal strings are signed base-ten i128 values",
+        nonzero_denominators = "each rational denominator is nonzero",
+        nonzero_rhs = "the right operand is nonzero so exact division is defined"
+    ),
+    example(
+        label = "halves_and_thirds",
+        value = "{\"lhs\":{\"numerator\":\"1\",\"denominator\":\"2\"},\"rhs\":{\"numerator\":\"1\",\"denominator\":\"3\"}}"
+    )
+)]
 pub struct RationalSurrealArithmeticRequest {
     /// Left operand.
     pub lhs: DecimalRational,
@@ -48,7 +72,29 @@ pub struct RationalSurrealArithmeticRequest {
 }
 
 /// Exact normalized results for the four rational field operations.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/surreal-rational-arithmetic/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        nonzero_denominators = "every result denominator is nonzero",
+        normalized_exact_rationals = "every result is normalized by the exact rational-surreal implementation"
+    ),
+    example(
+        label = "halves_and_thirds",
+        value = "{\"sum\":{\"numerator\":\"5\",\"denominator\":\"6\"},\"difference\":{\"numerator\":\"1\",\"denominator\":\"6\"},\"product\":{\"numerator\":\"1\",\"denominator\":\"6\"},\"quotient\":{\"numerator\":\"3\",\"denominator\":\"2\"}}"
+    )
+)]
 pub struct RationalSurrealArithmeticOutput {
     /// `lhs + rhs`.
     pub sum: DecimalRational,
@@ -61,7 +107,7 @@ pub struct RationalSurrealArithmeticOutput {
 }
 
 /// Exact rational surcomplex value encoded as real and imaginary parts.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DecimalSurcomplex {
     /// Exact real component.
@@ -71,8 +117,32 @@ pub struct DecimalSurcomplex {
 }
 
 /// Typed input for exact rational-surcomplex division.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/surcomplex-rational-division/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        decimal_length_limit = "numerator and denominator strings each contain 1 to 40 characters",
+        decimal_strings_are_i128 = "decimal strings are signed base-ten i128 values",
+        nonzero_denominators = "each rational component denominator is nonzero",
+        nonzero_divisor = "the divisor has a nonzero real or imaginary component"
+    ),
+    example(
+        label = "identity_division",
+        value = "{\"dividend\":{\"real\":{\"numerator\":\"1\",\"denominator\":\"1\"},\"imaginary\":{\"numerator\":\"0\",\"denominator\":\"1\"}},\"divisor\":{\"real\":{\"numerator\":\"1\",\"denominator\":\"1\"},\"imaginary\":{\"numerator\":\"0\",\"denominator\":\"1\"}}}"
+    )
+)]
 pub struct RationalSurcomplexDivisionRequest {
     /// Rational-surcomplex dividend.
     pub dividend: DecimalSurcomplex,
@@ -81,7 +151,29 @@ pub struct RationalSurcomplexDivisionRequest {
 }
 
 /// Exact normalized result of rational-surcomplex division.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/surcomplex-rational-division/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        nonzero_denominators = "every quotient component denominator is nonzero",
+        normalized_exact_rationals = "quotient components are normalized by the exact rational-surcomplex implementation"
+    ),
+    example(
+        label = "identity_division",
+        value = "{\"quotient\":{\"real\":{\"numerator\":\"1\",\"denominator\":\"1\"},\"imaginary\":{\"numerator\":\"0\",\"denominator\":\"1\"}}}"
+    )
+)]
 pub struct RationalSurcomplexDivisionOutput {
     /// Exact quotient `dividend / divisor`.
     pub quotient: DecimalSurcomplex,

--- a/amari-discovery/src/probes/tropical.rs
+++ b/amari-discovery/src/probes/tropical.rs
@@ -22,8 +22,36 @@ const MAX_EMISSION_SYMBOLS: usize = 4_096;
 const MAX_OBSERVATIONS: usize = 4_096;
 
 /// Typed input for the tropical Viterbi proof-slice probe.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
 #[serde(deny_unknown_fields)]
+#[wire_contract(
+    id = "amari.discovery/probe/tropical-viterbi/input/v1",
+    role = "input",
+    compatibility = "additive_patch",
+    constraints(
+        emission_rows_match_states = "there is exactly one emission row per state",
+        emission_width_limit = "emission rows have equal nonzero width at most 4096",
+        finite_weights = "all transition and emission weights are finite",
+        nonempty_observations = "at least one observation is required",
+        observation_count_limit = "at most 4096 observations are accepted",
+        observation_indices_in_bounds = "every observation index is below the emission width",
+        square_transitions = "the transition matrix is square",
+        state_limit = "at most 64 states are accepted",
+        states_nonempty = "at least one state is required"
+    ),
+    example(
+        label = "two_state_decode",
+        value = "{\"transitions\":[[0.0,1.0],[1.0,0.0]],\"emissions\":[[0.0,1.0],[1.0,0.0]],\"observations\":[0,1]}"
+    )
+)]
 pub struct TropicalViterbiRequest {
     /// Square state-transition matrix of tropical log weights.
     pub transitions: Vec<Vec<f64>>,
@@ -34,7 +62,26 @@ pub struct TropicalViterbiRequest {
 }
 
 /// Typed output from tropical Viterbi decoding.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    amari_discovery_macros::WireContract,
+)]
+#[wire_contract(
+    id = "amari.discovery/probe/tropical-viterbi/output/v1",
+    role = "output",
+    compatibility = "additive_patch",
+    constraints(
+        finite_score = "the decoded tropical score is finite",
+        path_length_matches_observations = "the returned path has exactly one state per observation",
+        path_states_within_state_count = "every returned path state is below the input state count"
+    ),
+    example(label = "two_state_decode", value = "{\"path\":[0,1],\"score\":1.0}")
+)]
 pub struct TropicalViterbiOutput {
     /// Most likely state index at each observation.
     pub path: Vec<usize>,

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -9,11 +9,11 @@ use serde::Serialize;
 use crate::{
     commands::{
         discover::{ExampleResult, GraphResult, SearchResults},
-        probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult},
+        probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult, ProbeSchemaResolution},
     },
     CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
-    NdjsonWriter, PlanStep, ProbeBackend, ProbeIsolation, ProbeSchemaDocument, ProjectKind,
-    ProjectSnapshot, ProtocolSchema, Recommendation, SchemaCatalog,
+    NdjsonWriter, PlanStep, ProbeBackend, ProbeIsolation, ProjectKind, ProjectSnapshot,
+    ProtocolSchema, Recommendation, SchemaCatalog,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -217,9 +217,12 @@ pub(crate) fn write_probe_description_human(
 
 pub(crate) fn write_probe_schema_human(
     writer: &mut impl Write,
-    envelope: &Envelope<ProbeSchemaDocument>,
+    envelope: &Envelope<ProbeSchemaResolution>,
 ) -> DiscoveryResult<()> {
-    write!(writer, "{}", envelope.data.canonical_json()?)?;
+    writeln!(writer, "Canonical hash: {}", envelope.data.hash)?;
+    let mut document = serde_json::to_string_pretty(&envelope.data.document)?;
+    document.push('\n');
+    write!(writer, "{document}")?;
     Ok(())
 }
 

--- a/amari-discovery/src/render.rs
+++ b/amari-discovery/src/render.rs
@@ -12,8 +12,8 @@ use crate::{
         probe::{ProbeDescription, ProbeDryRun, ProbeList, ProbeRunResult},
     },
     CandidatePlan, Capabilities, CapabilityRecord, DiscoveryOutcome, DiscoveryResult, Envelope,
-    NdjsonWriter, PlanStep, ProbeBackend, ProbeIsolation, ProjectKind, ProjectSnapshot,
-    ProtocolSchema, Recommendation, SchemaCatalog,
+    NdjsonWriter, PlanStep, ProbeBackend, ProbeIsolation, ProbeSchemaDocument, ProjectKind,
+    ProjectSnapshot, ProtocolSchema, Recommendation, SchemaCatalog,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -188,6 +188,23 @@ pub(crate) fn write_probe_description_human(
         description.descriptor.output_schema
     )?;
     writeln!(writer, "Executable: {}", yes_no(description.executable))?;
+    let input_hash = description
+        .schema_hashes
+        .input_summary()
+        .map(|summary| summary.hash())
+        .unwrap_or("declared-unavailable");
+    let output_hash = description
+        .schema_hashes
+        .output_summary()
+        .map(|summary| summary.hash())
+        .unwrap_or("declared-unavailable");
+    writeln!(writer, "Input schema hash: {input_hash}")?;
+    writeln!(writer, "Output schema hash: {output_hash}")?;
+    writeln!(
+        writer,
+        "Schema document: amari probe schema {} --direction input",
+        description.descriptor.id
+    )?;
     writeln!(writer, "Process isolation: yes")?;
     writeln!(writer, "Hard timeout: {}", yes_no(description.hard_timeout))?;
     writeln!(
@@ -195,6 +212,14 @@ pub(crate) fn write_probe_description_human(
         "Crash isolation: {}",
         yes_no(description.crash_isolation)
     )?;
+    Ok(())
+}
+
+pub(crate) fn write_probe_schema_human(
+    writer: &mut impl Write,
+    envelope: &Envelope<ProbeSchemaDocument>,
+) -> DiscoveryResult<()> {
+    write!(writer, "{}", envelope.data.canonical_json()?)?;
     Ok(())
 }
 

--- a/amari-discovery/src/wire/mod.rs
+++ b/amari-discovery/src/wire/mod.rs
@@ -180,6 +180,19 @@ impl ProbeSchemaDocument {
         }
         Ok(())
     }
+    /// Builds a complete document from a compiled probe DTO contract.
+    pub fn from_contract<T: WireContract>() -> DiscoveryResult<Self> {
+        Self::new(
+            T::SCHEMA_ID,
+            T::ROLE,
+            SCHEMA_V1,
+            T::structural_schema(),
+            T::semantic_constraints(),
+            T::examples(),
+            T::COMPATIBILITY,
+        )
+    }
+
     /// Creates and validates a complete hybrid schema document.
     pub fn new(
         id: impl Into<String>,

--- a/amari-discovery/src/wire/mod.rs
+++ b/amari-discovery/src/wire/mod.rs
@@ -244,6 +244,7 @@ impl ProbeSchemaDocument {
 
     /// Returns the exported JSON value including Amari metadata.
     pub fn exported_value(&self) -> DiscoveryResult<serde_json::Value> {
+        self.validate()?;
         let mut exported = self
             .structural_schema
             .as_object()

--- a/amari-discovery/src/wire/registry.rs
+++ b/amari-discovery/src/wire/registry.rs
@@ -44,7 +44,7 @@ impl ProbeSchemaRegistration {
 }
 
 /// Compact input/output schema state for one known probe.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ProbeSchemaBinding {
     probe_id: ProbeId,
     state: ProbeSchemaContractState,

--- a/amari-discovery/tests/cli_probes.rs
+++ b/amari-discovery/tests/cli_probes.rs
@@ -107,21 +107,30 @@ fn schema_returns_complete_input_and_output_documents() {
     let output = command_json(&["probe", "schema", DUAL, "--direction", "output"]);
 
     assert_eq!(
-        input["data"],
-        serde_json::to_value(&input_document).unwrap()
+        input["data"]["document"],
+        input_document.exported_value().unwrap()
     );
     assert_eq!(
-        output["data"],
-        serde_json::to_value(&output_document).unwrap()
+        output["data"]["document"],
+        output_document.exported_value().unwrap()
     );
     assert_eq!(
-        input["data"]["id"],
+        input["data"]["document"]["$id"],
         "amari.discovery/probe/dual-polynomial-derivative/input/v1"
     );
     assert_eq!(
-        output["data"]["id"],
+        output["data"]["document"]["$id"],
         "amari.discovery/probe/dual-polynomial-derivative/output/v1"
     );
+    assert_eq!(
+        input["data"]["hash"],
+        input_document.canonical_hash().unwrap()
+    );
+    assert_eq!(
+        output["data"]["hash"],
+        output_document.canonical_hash().unwrap()
+    );
+    assert_eq!(input["data"]["hash"].as_str().unwrap().len(), 64);
     assert_eq!(
         input["data"]["hash"],
         command_json(&["probe", "schema", DUAL, "--direction", "input"])["data"]["hash"]
@@ -171,6 +180,32 @@ fn schema_rejects_invalid_direction_and_unknown_probe_as_typed_errors() {
         .as_str()
         .unwrap()
         .contains("unknown probe"));
+}
+
+#[test]
+fn readme_schema_docs() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let readme = fs::read_to_string(manifest_dir.join("README.md")).unwrap();
+    let guide = fs::read_to_string(manifest_dir.join("../docs/guide/amari-discovery.md")).unwrap();
+
+    for document in [&readme, &guide] {
+        assert!(document.contains(
+            "amari probe schema amari-probe:dual:polynomial-derivative:v1 --direction input --json"
+        ));
+        assert!(document.contains("schema_hashes"));
+        assert!(document.contains("Structural JSON Schema"));
+        assert!(document.contains("semantic Rust validation"));
+        assert!(document.contains("amari.discovery/v1"));
+    }
+
+    assert!(readme.contains("amari.discovery/probe/dual-polynomial-derivative/input/v1"));
+    assert!(readme.contains("x-amari-semantic-constraints"));
+    assert!(readme.contains("canonical SHA-256 hash"));
+    assert!(guide.contains(
+        "required field, field type, unknown-field, semantic constraint, or output meaning"
+    ));
+    assert!(guide.contains("v1") && guide.contains("v2"));
+    assert!(guide.contains("additive optional metadata"));
 }
 
 #[test]

--- a/amari-discovery/tests/cli_probes.rs
+++ b/amari-discovery/tests/cli_probes.rs
@@ -10,12 +10,17 @@ use amari_discovery::{
     CandidatePlan, Catalog, CatalogIdentity, Compatibility, Envelope, PlanCompatibility,
     PlanNormalization, PlanStep, ReplayMetadata,
 };
+#[cfg(feature = "standard-probes")]
+use amari_discovery::{
+    PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeSchemaDocument,
+};
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::{json, Value};
 use tempfile::TempDir;
 
 const VITERBI: &str = "amari-probe:tropical:viterbi:v1";
+const DUAL: &str = "amari-probe:dual:polynomial-derivative:v1";
 
 fn command_json(arguments: &[&str]) -> Value {
     let output = Command::cargo_bin("amari")
@@ -90,6 +95,84 @@ fn plan_envelope(probe_id: &str) -> Envelope<CandidatePlan> {
     )
 }
 
+#[cfg(feature = "standard-probes")]
+#[test]
+fn schema_returns_complete_input_and_output_documents() {
+    let input_document =
+        ProbeSchemaDocument::from_contract::<PolynomialDerivativeRequest>().unwrap();
+    let output_document =
+        ProbeSchemaDocument::from_contract::<PolynomialDerivativeOutput>().unwrap();
+
+    let input = command_json(&["probe", "schema", DUAL, "--direction", "input"]);
+    let output = command_json(&["probe", "schema", DUAL, "--direction", "output"]);
+
+    assert_eq!(
+        input["data"],
+        serde_json::to_value(&input_document).unwrap()
+    );
+    assert_eq!(
+        output["data"],
+        serde_json::to_value(&output_document).unwrap()
+    );
+    assert_eq!(
+        input["data"]["id"],
+        "amari.discovery/probe/dual-polynomial-derivative/input/v1"
+    );
+    assert_eq!(
+        output["data"]["id"],
+        "amari.discovery/probe/dual-polynomial-derivative/output/v1"
+    );
+    assert_eq!(
+        input["data"]["hash"],
+        command_json(&["probe", "schema", DUAL, "--direction", "input"])["data"]["hash"]
+    );
+}
+
+#[cfg(feature = "standard-probes")]
+#[test]
+fn schema_rejects_invalid_direction_and_unknown_probe_as_typed_errors() {
+    let invalid_direction = Command::cargo_bin("amari")
+        .unwrap()
+        .args(["probe", "schema", DUAL, "--direction", "sideways", "--json"])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .stderr
+        .clone();
+    let invalid_direction: Value = serde_json::from_slice(&invalid_direction).unwrap();
+    assert_eq!(invalid_direction["kind"], "invalid_input");
+    assert!(invalid_direction["message"]
+        .as_str()
+        .unwrap()
+        .contains("direction"));
+
+    let unknown_probe = Command::cargo_bin("amari")
+        .unwrap()
+        .args([
+            "probe",
+            "schema",
+            "amari-probe:dual:does-not-exist:v1",
+            "--direction",
+            "input",
+            "--json",
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .get_output()
+        .stderr
+        .clone();
+    let unknown_probe: Value = serde_json::from_slice(&unknown_probe).unwrap();
+    assert_eq!(unknown_probe["kind"], "invalid_input");
+    assert!(unknown_probe["message"]
+        .as_str()
+        .unwrap()
+        .contains("unknown probe"));
+}
+
 #[test]
 fn list_reports_every_catalog_probe_with_dynamic_execution_state() {
     let listed = command_json(&["probe", "list"]);
@@ -105,6 +188,8 @@ fn list_reports_every_catalog_probe_with_dynamic_execution_state() {
         assert_eq!(probe["known"], true);
         assert_eq!(probe["available"], state["available"]);
         assert_eq!(probe["executable"], state["executable"]);
+        assert!(probe.get("descriptor").is_none());
+        assert!(probe.get("schema_hashes").is_none());
     }
 }
 
@@ -125,6 +210,35 @@ fn describe_returns_the_catalog_contract_and_process_guarantees() {
     assert_eq!(value["data"]["isolation"], "process");
     assert_eq!(value["data"]["hard_timeout"], true);
     assert_eq!(value["data"]["crash_isolation"], true);
+
+    #[cfg(feature = "standard-probes")]
+    {
+        let input_document =
+            ProbeSchemaDocument::from_contract::<amari_discovery::TropicalViterbiRequest>()
+                .unwrap();
+        let output_document =
+            ProbeSchemaDocument::from_contract::<amari_discovery::TropicalViterbiOutput>().unwrap();
+        let hashes = &value["data"]["schema_hashes"];
+        assert_eq!(hashes["probe_id"], VITERBI);
+        assert_eq!(hashes["state"], "resolved");
+        assert_eq!(
+            hashes["input_summary"],
+            serde_json::to_value(input_document.summary().unwrap()).unwrap()
+        );
+        assert_eq!(
+            hashes["output_summary"],
+            serde_json::to_value(output_document.summary().unwrap()).unwrap()
+        );
+    }
+
+    #[cfg(not(feature = "standard-probes"))]
+    {
+        let hashes = &value["data"]["schema_hashes"];
+        assert_eq!(hashes["probe_id"], VITERBI);
+        assert_eq!(hashes["state"], "declared");
+        assert!(hashes["input_summary"].is_null());
+        assert!(hashes["output_summary"].is_null());
+    }
 }
 
 #[test]
@@ -145,7 +259,12 @@ fn list_and_describe_human_output_are_concise() {
         .success()
         .stderr(predicate::str::is_empty())
         .stdout(predicate::str::contains("Process isolation"))
-        .stdout(predicate::str::contains("Hard timeout: yes"));
+        .stdout(predicate::str::contains("Hard timeout: yes"))
+        .stdout(predicate::str::contains("Input schema hash:"))
+        .stdout(predicate::str::contains("Output schema hash:"))
+        .stdout(predicate::str::contains(
+            "amari probe schema amari-probe:tropical:viterbi:v1 --direction input",
+        ));
 }
 
 #[cfg(feature = "standard-probes")]

--- a/amari-discovery/tests/fixtures/probe-test-worker.py
+++ b/amari-discovery/tests/fixtures/probe-test-worker.py
@@ -34,6 +34,22 @@ def success_response() -> dict[str, object]:
             "probe_id": "amari-probe:tropical:viterbi:v1",
             "input_schema": "fixture/input/v1",
             "output_schema": "fixture/output/v1",
+            "schema_hashes": {
+                "probe_id": "amari-probe:tropical:viterbi:v1",
+                "state": "resolved",
+                "input_summary": {
+                    "id": "amari.discovery/probe/tropical-viterbi/input/v1",
+                    "role": "input",
+                    "compatibility": "additive_patch",
+                    "hash": "0" * 64,
+                },
+                "output_summary": {
+                    "id": "amari.discovery/probe/tropical-viterbi/output/v1",
+                    "role": "output",
+                    "compatibility": "additive_patch",
+                    "hash": "1" * 64,
+                },
+            },
             "backend": "cpu",
             "isolation": "cooperative",
             "deterministic": True,

--- a/amari-discovery/tests/probe_engine.rs
+++ b/amari-discovery/tests/probe_engine.rs
@@ -4,7 +4,10 @@
 
 #[cfg(feature = "standard-probes")]
 use amari_discovery::ProbeIsolation;
-use amari_discovery::{DiscoveryError, ProbeEngine, TropicalViterbiRequest};
+use amari_discovery::{
+    DiscoveryError, ProbeEngine, ProbeSchemaContractState, ProbeSchemaDocument,
+    TropicalViterbiOutput, TropicalViterbiRequest,
+};
 use serde_json::json;
 
 const CGT_NIM_SUM: &str = "amari-probe:cgt:nim-sum:v1";
@@ -163,6 +166,20 @@ fn execution_reports_cooperative_isolation_and_is_byte_deterministic() {
     assert_eq!(
         first.output_schema,
         "amari.discovery/probe/tropical-viterbi/output/v1"
+    );
+    let input_document = ProbeSchemaDocument::from_contract::<TropicalViterbiRequest>().unwrap();
+    let output_document = ProbeSchemaDocument::from_contract::<TropicalViterbiOutput>().unwrap();
+    assert_eq!(
+        first.schema_hashes.state(),
+        ProbeSchemaContractState::Resolved
+    );
+    assert_eq!(
+        first.schema_hashes.input_summary().unwrap(),
+        &input_document.summary().unwrap()
+    );
+    assert_eq!(
+        first.schema_hashes.output_summary().unwrap(),
+        &output_document.summary().unwrap()
     );
     assert!(first.resources.operations > 0);
     assert!(first.resources.nodes > 0);

--- a/amari-discovery/tests/probe_worker_protocol.rs
+++ b/amari-discovery/tests/probe_worker_protocol.rs
@@ -117,6 +117,10 @@ fn worker_request_has_only_typed_data_and_success_preserves_provenance() {
         )
         .unwrap();
     assert_eq!(response["execution"]["output"], direct.output);
+    assert_eq!(
+        response["execution"]["schema_hashes"],
+        serde_json::to_value(direct.schema_hashes).unwrap()
+    );
 }
 
 #[test]

--- a/amari-discovery/tests/wire_schema_registry.rs
+++ b/amari-discovery/tests/wire_schema_registry.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use amari_discovery::{
-    Catalog, ProbeEngine, ProbeId, ProbeSchemaContractState, ProbeSchemaDocument,
-    ProbeSchemaRegistration, ProbeWireSchemaRegistry, WireCompatibility, WireSchemaRole, SCHEMA_V1,
+    Catalog, CgtNimSumOutput, CgtNimSumRequest, Cl3ProductOutput, Cl3ProductRequest,
+    PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine, ProbeId,
+    ProbeSchemaContractState, ProbeSchemaDocument, ProbeSchemaRegistration,
+    ProbeWireSchemaRegistry, WireCompatibility, WireSchemaRole, SCHEMA_V1,
 };
 
 fn synthetic_document(schema_id: &str, role: WireSchemaRole) -> ProbeSchemaDocument {
@@ -39,6 +41,135 @@ fn registrations(catalog: &Catalog, executable_ids: &[ProbeId]) -> Vec<ProbeSche
                 ),
             ]
         })
+        .collect()
+}
+
+#[test]
+fn cgt_core_dual_contracts() {
+    let catalog = Catalog::embedded().unwrap();
+
+    let cgt_input = ProbeSchemaDocument::from_contract::<CgtNimSumRequest>().unwrap();
+    let cgt_output = ProbeSchemaDocument::from_contract::<CgtNimSumOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:cgt:nim-sum:v1",
+        cgt_input.clone(),
+        cgt_output.clone(),
+    );
+    assert_eq!(cgt_input.id(), "amari.discovery/probe/cgt-nim-sum/input/v1");
+    assert_eq!(
+        cgt_output.id(),
+        "amari.discovery/probe/cgt-nim-sum/output/v1"
+    );
+    assert_eq!(
+        constraint_ids(&cgt_input),
+        ["heap_count_limit", "heap_value_limit"]
+    );
+    assert_eq!(
+        constraint_ids(&cgt_output),
+        ["grundy_values_align_with_heaps", "nim_sum_is_xor"]
+    );
+    assert_eq!(
+        cgt_input.exported_value().unwrap()["additionalProperties"],
+        false
+    );
+    assert!(cgt_input.exported_value().unwrap()["properties"]["heaps"].is_object());
+
+    let core_input = ProbeSchemaDocument::from_contract::<Cl3ProductRequest>().unwrap();
+    let core_output = ProbeSchemaDocument::from_contract::<Cl3ProductOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:core:geometric-product:v1",
+        core_input.clone(),
+        core_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&core_input),
+        ["finite_numbers", "fixed_coefficient_length"]
+    );
+    assert_eq!(
+        constraint_ids(&core_output),
+        ["finite_numbers", "fixed_coefficient_length"]
+    );
+    let core_schema = core_input.exported_value().unwrap();
+    assert_eq!(core_schema["required"][0], "left");
+    assert_eq!(core_schema["required"][1], "right");
+    assert_eq!(core_schema["properties"]["left"]["minItems"], 8);
+    assert_eq!(core_schema["properties"]["left"]["maxItems"], 8);
+    assert_eq!(core_schema["properties"]["right"]["minItems"], 8);
+
+    let dual_input = ProbeSchemaDocument::from_contract::<PolynomialDerivativeRequest>().unwrap();
+    let dual_output = ProbeSchemaDocument::from_contract::<PolynomialDerivativeOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:dual:polynomial-derivative:v1",
+        dual_input.clone(),
+        dual_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&dual_input),
+        [
+            "coefficient_count_limit",
+            "finite_numbers",
+            "nonempty_coefficients"
+        ]
+    );
+    assert_eq!(constraint_ids(&dual_output), ["finite_numbers"]);
+    assert_eq!(
+        dual_input.exported_value().unwrap()["additionalProperties"],
+        false
+    );
+    assert!(dual_input.exported_value().unwrap()["properties"]["coefficients"].is_object());
+    assert!(dual_input.exported_value().unwrap()["properties"]["at"].is_object());
+}
+
+fn assert_registered_pair(
+    catalog: &Catalog,
+    probe_id: &str,
+    input: ProbeSchemaDocument,
+    output: ProbeSchemaDocument,
+) {
+    let probe_id: ProbeId = probe_id.parse().unwrap();
+    assert_eq!(input.role(), WireSchemaRole::Input);
+    assert_eq!(output.role(), WireSchemaRole::Output);
+    assert_eq!(
+        input.canonical_hash().unwrap(),
+        input.canonical_hash().unwrap()
+    );
+    assert_eq!(
+        output.canonical_hash().unwrap(),
+        output.canonical_hash().unwrap()
+    );
+    assert_eq!(
+        input.summary().unwrap().hash(),
+        input.canonical_hash().unwrap()
+    );
+    assert_eq!(
+        output.summary().unwrap().hash(),
+        output.canonical_hash().unwrap()
+    );
+    assert_eq!(input.compatibility(), WireCompatibility::AdditivePatch);
+    assert_eq!(output.compatibility(), WireCompatibility::AdditivePatch);
+
+    let registry = ProbeWireSchemaRegistry::build(
+        catalog,
+        [probe_id.clone()],
+        [
+            ProbeSchemaRegistration::new(probe_id.clone(), input),
+            ProbeSchemaRegistration::new(probe_id.clone(), output),
+        ],
+    )
+    .unwrap();
+    let binding = registry.binding(&probe_id).unwrap();
+    assert_eq!(binding.state(), ProbeSchemaContractState::Resolved);
+}
+
+fn constraint_ids(document: &ProbeSchemaDocument) -> Vec<String> {
+    document.exported_value().unwrap()["x-amari-semantic-constraints"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|constraint| constraint["id"].as_str().unwrap().to_owned())
         .collect()
 }
 

--- a/amari-discovery/tests/wire_schema_registry.rs
+++ b/amari-discovery/tests/wire_schema_registry.rs
@@ -7,7 +7,9 @@ use amari_discovery::{
     ParetoFrontOutput, ParetoFrontRequest, PolynomialDerivativeOutput, PolynomialDerivativeRequest,
     ProbeEngine, ProbeId, ProbeSchemaContractState, ProbeSchemaDocument, ProbeSchemaRegistration,
     ProbeWireSchemaRegistry, RationalSurcomplexDivisionOutput, RationalSurcomplexDivisionRequest,
-    RationalSurrealArithmeticOutput, RationalSurrealArithmeticRequest, TropicalViterbiOutput,
+    RationalSurrealArithmeticOutput, RationalSurrealArithmeticRequest, RewriteInferRuleOutput,
+    RewriteInferRuleRequest, RewriteNormalizeOutput, RewriteNormalizeRequest,
+    RewritePredecessorsOutput, RewritePredecessorsRequest, TropicalViterbiOutput,
     TropicalViterbiRequest, WireCompatibility, WireSchemaRole, SCHEMA_V1,
 };
 
@@ -341,6 +343,124 @@ fn rational_holographic_contracts() {
     assert_eq!(recall_schema["additionalProperties"], false);
     assert!(recall_schema["properties"]["entries"].is_object());
     assert!(recall_schema["properties"]["query_seed"].is_object());
+}
+
+#[test]
+fn rewrite_contracts() {
+    let catalog = Catalog::embedded().unwrap();
+
+    let normalize_input = ProbeSchemaDocument::from_contract::<RewriteNormalizeRequest>().unwrap();
+    let normalize_output = ProbeSchemaDocument::from_contract::<RewriteNormalizeOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:rewrite:normalize:v1",
+        normalize_input.clone(),
+        normalize_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&normalize_input),
+        [
+            "max_steps_limit",
+            "max_steps_positive",
+            "rules_checked",
+            "rules_count_limit",
+            "rules_non_expanding",
+            "term_bounds",
+            "term_name_bytes_limit"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&normalize_output),
+        [
+            "normal_form_within_term_bounds",
+            "steps_within_request_limit"
+        ]
+    );
+    let normalize_schema = normalize_input.exported_value().unwrap();
+    assert_eq!(normalize_schema["additionalProperties"], false);
+    assert_recursive_term_schema_is_internally_tagged_and_strict(&normalize_schema);
+    assert!(normalize_schema["properties"]["rules"].is_object());
+    assert!(normalize_schema["properties"]["max_steps"].is_object());
+
+    let infer_input = ProbeSchemaDocument::from_contract::<RewriteInferRuleRequest>().unwrap();
+    let infer_output = ProbeSchemaDocument::from_contract::<RewriteInferRuleOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:rewrite:infer-rule:v1",
+        infer_input.clone(),
+        infer_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&infer_input),
+        [
+            "example_count_limit",
+            "examples_nonempty",
+            "term_bounds",
+            "term_name_bytes_limit"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&infer_output),
+        [
+            "rhs_no_duplicate_variables",
+            "rhs_variables_subset_lhs",
+            "rule_within_term_bounds"
+        ]
+    );
+    let infer_schema = infer_input.exported_value().unwrap();
+    assert_eq!(infer_schema["additionalProperties"], false);
+    assert_recursive_term_schema_is_internally_tagged_and_strict(&infer_schema);
+
+    let predecessors_input =
+        ProbeSchemaDocument::from_contract::<RewritePredecessorsRequest>().unwrap();
+    let predecessors_output =
+        ProbeSchemaDocument::from_contract::<RewritePredecessorsOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:rewrite:predecessors:v1",
+        predecessors_input.clone(),
+        predecessors_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&predecessors_input),
+        [
+            "max_depth_limit",
+            "max_frontier_limit",
+            "max_frontier_positive",
+            "max_results_limit",
+            "max_results_positive",
+            "reverse_lhs_no_duplicate_variables",
+            "rules_checked",
+            "rules_count_limit",
+            "term_bounds",
+            "term_name_bytes_limit"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&predecessors_output),
+        [
+            "predecessors_canonical_order",
+            "predecessors_within_result_limit",
+            "truncation_truthful"
+        ]
+    );
+    let predecessors_schema = predecessors_input.exported_value().unwrap();
+    assert_eq!(predecessors_schema["additionalProperties"], false);
+    assert_recursive_term_schema_is_internally_tagged_and_strict(&predecessors_schema);
+    assert!(predecessors_schema["properties"]["max_depth"].is_object());
+    assert!(predecessors_schema["properties"]["max_results"].is_object());
+    assert!(predecessors_schema["properties"]["max_frontier"].is_object());
+}
+
+fn assert_recursive_term_schema_is_internally_tagged_and_strict(schema: &serde_json::Value) {
+    let variants = schema["$defs"]["RewriteTerm"]["oneOf"]
+        .as_array()
+        .expect("recursive RewriteTerm schema must be an internally tagged oneOf");
+    assert_eq!(variants.len(), 2);
+    for variant in variants {
+        assert_eq!(variant["additionalProperties"], false);
+        assert!(variant["properties"]["kind"].is_object());
+    }
 }
 
 fn assert_registered_pair(

--- a/amari-discovery/tests/wire_schema_registry.rs
+++ b/amari-discovery/tests/wire_schema_registry.rs
@@ -2,11 +2,13 @@
 
 use amari_discovery::{
     Catalog, CgtNimSumOutput, CgtNimSumRequest, Cl3ProductOutput, Cl3ProductRequest,
-    NetworkShortestPathOutput, NetworkShortestPathRequest, ParetoFrontOutput, ParetoFrontRequest,
-    PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine, ProbeId,
-    ProbeSchemaContractState, ProbeSchemaDocument, ProbeSchemaRegistration,
-    ProbeWireSchemaRegistry, TropicalViterbiOutput, TropicalViterbiRequest, WireCompatibility,
-    WireSchemaRole, SCHEMA_V1,
+    HolographicRecallOutput, HolographicRecallRequest, HolographicSuperpositionOutput,
+    HolographicSuperpositionRequest, NetworkShortestPathOutput, NetworkShortestPathRequest,
+    ParetoFrontOutput, ParetoFrontRequest, PolynomialDerivativeOutput, PolynomialDerivativeRequest,
+    ProbeEngine, ProbeId, ProbeSchemaContractState, ProbeSchemaDocument, ProbeSchemaRegistration,
+    ProbeWireSchemaRegistry, RationalSurcomplexDivisionOutput, RationalSurcomplexDivisionRequest,
+    RationalSurrealArithmeticOutput, RationalSurrealArithmeticRequest, TropicalViterbiOutput,
+    TropicalViterbiRequest, WireCompatibility, WireSchemaRole, SCHEMA_V1,
 };
 
 fn synthetic_document(schema_id: &str, role: WireSchemaRole) -> ProbeSchemaDocument {
@@ -228,6 +230,117 @@ fn structured_contracts() {
     assert!(tropical_schema["properties"]["transitions"].is_object());
     assert!(tropical_schema["properties"]["emissions"].is_object());
     assert!(tropical_schema["properties"]["observations"].is_object());
+}
+
+#[test]
+fn rational_holographic_contracts() {
+    let catalog = Catalog::embedded().unwrap();
+
+    let rational_input =
+        ProbeSchemaDocument::from_contract::<RationalSurrealArithmeticRequest>().unwrap();
+    let rational_output =
+        ProbeSchemaDocument::from_contract::<RationalSurrealArithmeticOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:surreal:rational-arithmetic:v1",
+        rational_input.clone(),
+        rational_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&rational_input),
+        [
+            "decimal_length_limit",
+            "decimal_strings_are_i128",
+            "nonzero_denominators",
+            "nonzero_rhs"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&rational_output),
+        ["nonzero_denominators", "normalized_exact_rationals"]
+    );
+    let rational_schema = rational_input.exported_value().unwrap();
+    assert_eq!(rational_schema["additionalProperties"], false);
+    assert!(rational_schema["properties"]["lhs"].is_object());
+    assert!(rational_schema["properties"]["rhs"].is_object());
+
+    let surcomplex_input =
+        ProbeSchemaDocument::from_contract::<RationalSurcomplexDivisionRequest>().unwrap();
+    let surcomplex_output =
+        ProbeSchemaDocument::from_contract::<RationalSurcomplexDivisionOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:surcomplex:rational-division:v1",
+        surcomplex_input.clone(),
+        surcomplex_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&surcomplex_input),
+        [
+            "decimal_length_limit",
+            "decimal_strings_are_i128",
+            "nonzero_denominators",
+            "nonzero_divisor"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&surcomplex_output),
+        ["nonzero_denominators", "normalized_exact_rationals"]
+    );
+    let surcomplex_schema = surcomplex_input.exported_value().unwrap();
+    assert_eq!(surcomplex_schema["additionalProperties"], false);
+    assert!(surcomplex_schema["properties"]["dividend"].is_object());
+    assert!(surcomplex_schema["properties"]["divisor"].is_object());
+
+    let superposition_input =
+        ProbeSchemaDocument::from_contract::<HolographicSuperpositionRequest>().unwrap();
+    let superposition_output =
+        ProbeSchemaDocument::from_contract::<HolographicSuperpositionOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:holographic:superposition:v1",
+        superposition_input.clone(),
+        superposition_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&superposition_input),
+        ["integer_seeds", "nonempty_seeds", "seed_count_limit"]
+    );
+    assert_eq!(
+        constraint_ids(&superposition_output),
+        ["finite_coefficients", "map256_dimension"]
+    );
+    assert_eq!(
+        superposition_input.exported_value().unwrap()["additionalProperties"],
+        false
+    );
+
+    let recall_input = ProbeSchemaDocument::from_contract::<HolographicRecallRequest>().unwrap();
+    let recall_output = ProbeSchemaDocument::from_contract::<HolographicRecallOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:holographic:recall:v1",
+        recall_input.clone(),
+        recall_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&recall_input),
+        ["entry_count_limit", "integer_seeds", "nonempty_entries"]
+    );
+    assert_eq!(
+        constraint_ids(&recall_output),
+        [
+            "bounded_warnings",
+            "capacity_metrics_consistent",
+            "finite_metrics",
+            "map256_dimension",
+            "nonnegative_attribution_weights"
+        ]
+    );
+    let recall_schema = recall_input.exported_value().unwrap();
+    assert_eq!(recall_schema["additionalProperties"], false);
+    assert!(recall_schema["properties"]["entries"].is_object());
+    assert!(recall_schema["properties"]["query_seed"].is_object());
 }
 
 fn assert_registered_pair(

--- a/amari-discovery/tests/wire_schema_registry.rs
+++ b/amari-discovery/tests/wire_schema_registry.rs
@@ -2,9 +2,11 @@
 
 use amari_discovery::{
     Catalog, CgtNimSumOutput, CgtNimSumRequest, Cl3ProductOutput, Cl3ProductRequest,
+    NetworkShortestPathOutput, NetworkShortestPathRequest, ParetoFrontOutput, ParetoFrontRequest,
     PolynomialDerivativeOutput, PolynomialDerivativeRequest, ProbeEngine, ProbeId,
     ProbeSchemaContractState, ProbeSchemaDocument, ProbeSchemaRegistration,
-    ProbeWireSchemaRegistry, WireCompatibility, WireSchemaRole, SCHEMA_V1,
+    ProbeWireSchemaRegistry, TropicalViterbiOutput, TropicalViterbiRequest, WireCompatibility,
+    WireSchemaRole, SCHEMA_V1,
 };
 
 fn synthetic_document(schema_id: &str, role: WireSchemaRole) -> ProbeSchemaDocument {
@@ -121,6 +123,111 @@ fn cgt_core_dual_contracts() {
     );
     assert!(dual_input.exported_value().unwrap()["properties"]["coefficients"].is_object());
     assert!(dual_input.exported_value().unwrap()["properties"]["at"].is_object());
+}
+
+#[test]
+fn structured_contracts() {
+    let catalog = Catalog::embedded().unwrap();
+
+    let network_input = ProbeSchemaDocument::from_contract::<NetworkShortestPathRequest>().unwrap();
+    let network_output = ProbeSchemaDocument::from_contract::<NetworkShortestPathOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:network:shortest-path:v1",
+        network_input.clone(),
+        network_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&network_input),
+        [
+            "adjacency_node_limit",
+            "adjacency_nonempty",
+            "adjacency_square",
+            "endpoint_indices_in_bounds",
+            "finite_nonnegative_weights"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&network_output),
+        [
+            "finite_total_weight",
+            "optional_path_shape",
+            "path_nodes_within_node_count"
+        ]
+    );
+    let network_schema = network_input.exported_value().unwrap();
+    assert_eq!(network_schema["additionalProperties"], false);
+    assert!(network_schema["properties"]["adjacency"].is_object());
+    assert!(network_schema["properties"]["source"].is_object());
+    assert!(network_schema["properties"]["target"].is_object());
+
+    let pareto_input = ProbeSchemaDocument::from_contract::<ParetoFrontRequest>().unwrap();
+    let pareto_output = ProbeSchemaDocument::from_contract::<ParetoFrontOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:optimization:pareto-front:v1",
+        pareto_input.clone(),
+        pareto_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&pareto_input),
+        [
+            "dimension_limit",
+            "finite_objectives",
+            "nonempty_directions",
+            "nonempty_population",
+            "population_limit",
+            "rectangular_objectives"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&pareto_output),
+        [
+            "solution_indices_match_request",
+            "solution_objectives_match_request",
+            "solutions_are_nondominated"
+        ]
+    );
+    let pareto_schema = pareto_input.exported_value().unwrap();
+    assert_eq!(pareto_schema["additionalProperties"], false);
+    assert!(pareto_schema["properties"]["objectives"].is_object());
+    assert!(pareto_schema["properties"]["directions"].is_object());
+
+    let tropical_input = ProbeSchemaDocument::from_contract::<TropicalViterbiRequest>().unwrap();
+    let tropical_output = ProbeSchemaDocument::from_contract::<TropicalViterbiOutput>().unwrap();
+    assert_registered_pair(
+        &catalog,
+        "amari-probe:tropical:viterbi:v1",
+        tropical_input.clone(),
+        tropical_output.clone(),
+    );
+    assert_eq!(
+        constraint_ids(&tropical_input),
+        [
+            "emission_rows_match_states",
+            "emission_width_limit",
+            "finite_weights",
+            "nonempty_observations",
+            "observation_count_limit",
+            "observation_indices_in_bounds",
+            "square_transitions",
+            "state_limit",
+            "states_nonempty"
+        ]
+    );
+    assert_eq!(
+        constraint_ids(&tropical_output),
+        [
+            "finite_score",
+            "path_length_matches_observations",
+            "path_states_within_state_count"
+        ]
+    );
+    let tropical_schema = tropical_input.exported_value().unwrap();
+    assert_eq!(tropical_schema["additionalProperties"], false);
+    assert!(tropical_schema["properties"]["transitions"].is_object());
+    assert!(tropical_schema["properties"]["emissions"].is_object());
+    assert!(tropical_schema["properties"]["observations"].is_object());
 }
 
 fn assert_registered_pair(

--- a/docs/guide/amari-discovery.md
+++ b/docs/guide/amari-discovery.md
@@ -101,6 +101,51 @@ Only registered, compiled adapters run. The public CLI routes execution through
 a restricted process worker and reports process isolation only after validating
 the worker frame, result, and provenance.
 
+### Probe wire schemas and drift
+
+`amari.discovery/v1` remains the response protocol. Every executable probe has
+a compiled Rust request and response DTO, and each DTO exports a complete wire
+schema for its existing descriptor ID. `probe describe` exposes only compact
+`schema_hashes`; `probe list` stays compact. Resolve a full document only when
+needed:
+
+```bash
+amari probe schema amari-probe:dual:polynomial-derivative:v1 --direction input --json
+amari probe schema amari-probe:dual:polynomial-derivative:v1 --direction output --json
+```
+
+The envelope's `data.document` contains the exported `$id`, JSON Schema 2020-12
+structure, and `x-amari-*` provenance, compatibility, examples, and semantic
+constraint metadata. `data.hash` is the canonical SHA-256 hash of the exact
+exported document bytes. The hash is returned beside the document rather than
+inside it, so it identifies one immutable canonical document without creating
+a self-referential schema.
+
+Structural JSON Schema and semantic Rust validation are complementary. JSON
+Schema describes required fields, primitive/container shape, nested DTOs, and
+unknown-field behavior. Semantic Rust validation remains authoritative for
+domain checks that JSON Schema should not duplicate, including finite numeric
+values, exact decimal/rational bounds, graph shape, MAP256 dimensions, rewrite
+term depth/node limits, checked rule variables, and truthful truncation
+metadata. Agents should use both the structural schema and the
+`x-amari-semantic-constraints` list before constructing a payload.
+
+Schema drift has three classes:
+
+1. **No drift:** the Rust DTO and exported document produce the same canonical
+   hash.
+2. **Additive patch drift:** additive optional metadata or a backward-compatible
+   optional field is added. The same `v1` ID may remain only if the changed
+   hash and release notes make the addition explicit.
+3. **Breaking drift:** any required field, field type, unknown-field, semantic constraint, or output meaning changes. The schema must advance from `v1` to
+   `v2` (generally, `vN` to `vN+1`) together with the owning probe descriptor.
+
+Registry tests reject descriptor/adapter mismatch, missing executable
+contracts, duplicate schema IDs, role/version mismatch, and undocumented DTO
+drift. A known but non-executable descriptor, currently
+`amari-probe:tropical:shortest-path:v1`, remains declared-only and never
+receives a fabricated compiled schema.
+
 ## Agent workflow: capabilities → inspect → recommend → plan → probe
 
 The following workflow requires `jq` and should be run from the project being


### PR DESCRIPTION
## Summary

This PR completes the approved `amari-discovery` wire-schema authority implementation plan on top of the merged foundation in #230.

It makes the Rust DTOs the wire authority for all 13 executable probes, exports complete JSON Schema documents with deterministic canonical SHA-256 hashes, resolves those documents through the CLI, reports compact schema identities through describe/execution paths, and documents the agent-facing compatibility and drift rules.

Design: #228  
Implementation plan: #229  
Foundation: #230

## Scope

- Attach `WireContract` derives and `schemars::JsonSchema` coverage to the stable request/output DTOs for:
  - numeric: CGT nim-sum, Cl(3) geometric product, dual polynomial derivative
  - structured: network shortest path, Pareto front, tropical Viterbi
  - rational/holographic: rational surreal arithmetic, rational surcomplex division, holographic superposition/recall
  - rewrite: normalize, infer-rule, predecessors, including the recursive internally tagged `RewriteTerm` DTO
- Resolve full exported schema documents with `amari probe schema <probe-id> --direction input|output`.
- Return the exported document as `data.document` and its canonical SHA-256 as `data.hash`.
- Keep `probe list` and `capabilities` compact; no full schema documents are added there.
- Add compact schema hashes to `probe describe` for executable probes.
- Preserve the declared-only state for `amari-probe:tropical:shortest-path:v1`; no fabricated compiled contract is reported.
- Report identical schema identities from the direct engine and process-isolated worker.
- Update the probe worker fixture, README, and discovery guide.
- Preserve `amari.discovery/v1`, all probe IDs/schema IDs, saved plans/results, output modes, and probe behavior.

## Compatibility and drift governance

The exported document includes the schemars structural JSON Schema plus `x-amari-*` semantic/provenance/compatibility metadata. The canonical hash commits to the exact exported document bytes.

Documented rules:

- identical hash: no contract drift;
- additive compatible change: hash change with the same schema version and compatibility metadata;
- required-field/type/unknown-field/semantic/output-meaning change: breaking and requires `vN -> vN+1`.

Structural JSON Schema is an agent-facing representation, not a replacement for Rust semantic validation. Registry corruption remains a typed catalog error; probe domain failures remain typed outcomes.

## Verification

At the final tree (`f84eaca`):

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-features --lib --bins --exclude amari-gpu -- -D warnings` — pass
- `cargo clippy -p amari-discovery -p amari-discovery-macros --all-features --lib --bins --tests -- -D warnings` — pass
- `cargo test -p amari-discovery --all-features` — pass
- `cargo test -p amari-discovery-macros --all-features` — pass, including trybuild coverage
- `cargo test --workspace --exclude amari-gpu` — pass
- `python3 scripts/verify-publish-order.py` — pass
- `python3 scripts/verify-publish-test-scope.py` — pass
- `./scripts/version-sync.sh verify 0.24.0` — pass

Explicit exception: the broader workspace **test-target** Clippy command still reports three pre-existing `amari-core/src/generic.rs` `needless_range_loop` findings unrelated to this diff. This PR does not change `amari-core` because that would be scope creep and could affect catalog hashes. The touched crates pass warning-denied test-target Clippy.

No catalog regeneration was required: the checked-in generated catalog and protocol schema artifacts remain unchanged by this branch. Version remains `0.24.0`; any `0.24.1` bump is a separate PR.

## Independent review

An independent code review of `5221187..5365eb2` returned **Ready to merge: Yes**, with no Critical findings. Its two Important maintenance points were addressed in `f84eaca`:

- `ProbeSchemaDocument::exported_value()` now revalidates before constructing the exported document;
- an unknown compiled schema ID now has a direct typed-fallthrough regression test.

## Test plan

- Contract construction and compile-time derive behavior: `amari-discovery/tests/wire_contract.rs`, `wire_schema_document.rs`, `amari-discovery-macros/tests/*`
- Every executable probe registry pair and declared-only probe behavior: `amari-discovery/tests/wire_schema_registry.rs`
- CLI schema resolution, describe hashes, list compactness, README contract: `amari-discovery/tests/cli_probes.rs`
- Direct engine and worker parity: `probe_engine.rs`, `probe_worker_protocol.rs`, `tests/fixtures/probe-test-worker.py`

## Remaining release note

This implementation PR does not authorize a release. A `0.24.1` version bump, release PR, tag/publication, and Gates A/B remain separate operations.
