### PR TITLE
chore: prepare version 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1] - Unreleased
+
+### Added
+
+#### `amari-discovery` probe wire-schema authority
+
+- New `amari-discovery-macros` crate with a bounded `WireContract` derive for stable probe DTOs, including compile-time rejection of unsupported Serde shapes and trybuild coverage
+- Wire schema model, exported JSON Schema documents, semantic/provenance/compatibility metadata, and deterministic canonical SHA-256 hashes
+- Registry validation for input/output schema ownership, role/version matching, duplicate IDs, and declared-only non-executable probes
+- Complete input/output wire contracts for all 13 executable discovery probes across numeric, structured, rational, holographic, and rewrite domains
+- `amari probe schema <probe-id> --direction input|output` for full exported schema documents, compact schema hashes in `amari probe describe`, and matching schema identities from direct and process-isolated probe execution
+
+### Documentation
+
+- Expanded `amari-discovery/README.md` and `docs/guide/amari-discovery.md` with the structural-versus-semantic contract split, compatibility classes, drift governance, and schema resolution examples
+
+> Release acceptance requires synchronized catalogs, registry-resolved packages,
+> successful publication, post-publication installation, and the `v0.24.1` tag.
+> The comprehensive rewrite/inverse expansion remains scoped to 0.25.0.
+
+---
+
 ## [0.24.0] - 2026-07-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ members = ["amari-core", "amari-wasm", "amari-gpu", "amari-info-geom", "amari-tr
 resolver = "2"
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Amari Contributors"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -86,33 +86,33 @@ rust-version = "1.75"
 
 [workspace.dependencies]
 # Amari crates (internal dependencies)
-amari = { path = ".", version = "0.24.0" }
-amari-core = { path = "amari-core", version = "0.24.0" }
-amari-tropical = { path = "amari-tropical", version = "0.24.0" }
-amari-dual = { path = "amari-dual", version = "0.24.0" }
-amari-fusion = { path = "amari-fusion", version = "0.24.0" }
-amari-info-geom = { path = "amari-info-geom", version = "0.24.0" }
-amari-automata = { path = "amari-automata", version = "0.24.0" }
-amari-enumerative = { path = "amari-enumerative", version = "0.24.0" }
-amari-relativistic = { path = "amari-relativistic", version = "0.24.0" }
-amari-gpu = { path = "amari-gpu", version = "0.24.0" }
-amari-network = { path = "amari-network", version = "0.24.0" }
-amari-optimization = { path = "amari-optimization", version = "0.24.0" }
-amari-flynn = { path = "amari-flynn", version = "0.24.0" }
-amari-flynn-macros = { path = "amari-flynn-macros", version = "0.24.0" }
-amari-measure = { path = "amari-measure", version = "0.24.0" }
-amari-calculus = { path = "amari-calculus", version = "0.24.0" }
-amari-holographic = { path = "amari-holographic", version = "0.24.0" }
-amari-probabilistic = { path = "amari-probabilistic", version = "0.24.0" }
-amari-functional = { path = "amari-functional", version = "0.24.0" }
-amari-topology = { path = "amari-topology", version = "0.24.0" }
-amari-dynamics = { path = "amari-dynamics", version = "0.24.0" }
-amari-cgt = { path = "amari-cgt", version = "0.24.0" }
-amari-surreal = { path = "amari-surreal", version = "0.24.0" }
-amari-surcomplex = { path = "amari-surcomplex", version = "0.24.0" }
-amari-rewrite = { path = "amari-rewrite", version = "0.24.0" }
-amari-discovery-macros = { path = "amari-discovery-macros", version = "0.24.0" }
-amari-wasm = { path = "amari-wasm", version = "0.24.0" }
+amari = { path = ".", version = "0.24.1" }
+amari-core = { path = "amari-core", version = "0.24.1" }
+amari-tropical = { path = "amari-tropical", version = "0.24.1" }
+amari-dual = { path = "amari-dual", version = "0.24.1" }
+amari-fusion = { path = "amari-fusion", version = "0.24.1" }
+amari-info-geom = { path = "amari-info-geom", version = "0.24.1" }
+amari-automata = { path = "amari-automata", version = "0.24.1" }
+amari-enumerative = { path = "amari-enumerative", version = "0.24.1" }
+amari-relativistic = { path = "amari-relativistic", version = "0.24.1" }
+amari-gpu = { path = "amari-gpu", version = "0.24.1" }
+amari-network = { path = "amari-network", version = "0.24.1" }
+amari-optimization = { path = "amari-optimization", version = "0.24.1" }
+amari-flynn = { path = "amari-flynn", version = "0.24.1" }
+amari-flynn-macros = { path = "amari-flynn-macros", version = "0.24.1" }
+amari-measure = { path = "amari-measure", version = "0.24.1" }
+amari-calculus = { path = "amari-calculus", version = "0.24.1" }
+amari-holographic = { path = "amari-holographic", version = "0.24.1" }
+amari-probabilistic = { path = "amari-probabilistic", version = "0.24.1" }
+amari-functional = { path = "amari-functional", version = "0.24.1" }
+amari-topology = { path = "amari-topology", version = "0.24.1" }
+amari-dynamics = { path = "amari-dynamics", version = "0.24.1" }
+amari-cgt = { path = "amari-cgt", version = "0.24.1" }
+amari-surreal = { path = "amari-surreal", version = "0.24.1" }
+amari-surcomplex = { path = "amari-surcomplex", version = "0.24.1" }
+amari-rewrite = { path = "amari-rewrite", version = "0.24.1" }
+amari-discovery-macros = { path = "amari-discovery-macros", version = "0.24.1" }
+amari-wasm = { path = "amari-wasm", version = "0.24.1" }
 
 # External dependencies
 num-rational = "0.4"

--- a/amari-discovery/catalog/probes.toml
+++ b/amari-discovery/catalog/probes.toml
@@ -1,4 +1,4 @@
-catalog_version = "0.24.0"
+catalog_version = "0.24.1"
 
 [[probes]]
 id = "amari-probe:core:geometric-product:v1"

--- a/amari-discovery/catalog/semantic/core.toml
+++ b/amari-discovery/catalog/semantic/core.toml
@@ -1,4 +1,4 @@
-catalog_version = "0.24.0"
+catalog_version = "0.24.1"
 
 [[capabilities]]
 id = "amari:amari-core:product:geometric-product"

--- a/amari-gpu/Cargo.toml
+++ b/amari-gpu/Cargo.toml
@@ -14,10 +14,10 @@ categories = ["mathematics", "science", "algorithms"]
 # Default to no high-precision for GPU (and WASM compatibility)
 # These are specified directly instead of via workspace inheritance so
 # `default-features = false` is honored without Cargo warnings.
-amari-core = { path = "../amari-core", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
-amari-info-geom = { path = "../amari-info-geom", version = "0.24.0", default-features = false, features = ["std"] }
-amari-network = { path = "../amari-network", version = "0.24.0", default-features = false, features = ["std"] }
-amari-relativistic = { path = "../amari-relativistic", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.24.1", default-features = false, features = ["std", "phantom-types"] }
+amari-info-geom = { path = "../amari-info-geom", version = "0.24.1", default-features = false, features = ["std"] }
+amari-network = { path = "../amari-network", version = "0.24.1", default-features = false, features = ["std"] }
+amari-relativistic = { path = "../amari-relativistic", version = "0.24.1", default-features = false, features = ["std", "phantom-types"] }
 amari-measure = { workspace = true, optional = true }
 amari-calculus = { workspace = true, optional = true }
 amari-tropical = { workspace = true, optional = true }

--- a/amari-relativistic/Cargo.toml
+++ b/amari-relativistic/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["mathematics", "science", "simulation", "algorithms"]
 [dependencies]
 # Use a direct dependency instead of workspace inheritance so `default-features = false`
 # is honored (Cargo ignores it unless the workspace dependency also sets it).
-amari-core = { path = "../amari-core", version = "0.24.0", default-features = false, features = ["std", "phantom-types"] }
+amari-core = { path = "../amari-core", version = "0.24.1", default-features = false, features = ["std", "phantom-types"] }
 nalgebra = { workspace = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 num-traits = { workspace = true }

--- a/amari-wasm/examples/package.json
+++ b/amari-wasm/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-wasm-examples",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Comprehensive examples for Amari v0.24.0 WebAssembly mathematical computing library",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "all": "npm run demo && npm run geometric && npm run tropical && npm run autodiff && npm run infogeom && npm run fusion && npm run flynn && npm run gf2"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.24.0"
+    "@justinelliottcobb/amari-wasm": "^0.24.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/amari-wasm/package.json
+++ b/amari-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justinelliottcobb/amari-wasm",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "WebAssembly bindings for Amari mathematical computing library",
   "scripts": {
     "build": "wasm-pack build --target web --out-dir pkg --scope justinelliottcobb",

--- a/examples-suite/package-lock.json
+++ b/examples-suite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amari-examples-suite",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "dependencies": {
         "@justinelliottcobb/amari-wasm": "*",
         "@mantine/code-highlight": "^8.3.16",

--- a/examples-suite/package.json
+++ b/examples-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-examples-suite",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Interactive API examples for the Amari Mathematical Computing Library",
   "private": true,
   "type": "module",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-typescript-example",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Example TypeScript project using the Amari mathematical computing library",
   "main": "dist/example.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.24.0"
+    "@justinelliottcobb/amari-wasm": "^0.24.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/web/interactive-demos/package.json
+++ b/examples/web/interactive-demos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari-interactive-demos",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Interactive web demonstrations of Amari mathematical computing library",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "wasm-pack": "wasm-pack build --target web --out-dir pkg ../../../amari-wasm"
   },
   "dependencies": {
-    "@justinelliottcobb/amari-wasm": "^0.24.0",
+    "@justinelliottcobb/amari-wasm": "^0.24.1",
     "three": "^0.158.0",
     "dat.gui": "^0.7.9",
     "katex": "^0.16.8",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amari",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "High-performance Geometric Algebra/Clifford Algebra library with TypeScript bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prepares the additive `0.24.1` release line after the schema-authority implementation landed in #231.

- Bumps the workspace and all internal Amari dependency versions from `0.24.0` to `0.24.1` using `scripts/version-sync.sh`.
- Synchronizes JavaScript package metadata and Amari WASM dependency requirements.
- Synchronizes discovery semantic/probe catalog versions.
- Regenerates `amari-discovery/catalog/generated.json` so structural, semantic, and probe catalog versions all match.
- Adds the `0.24.1` changelog entry covering the probe wire-schema authority work from #230 and #231.

This is a version-preparation PR only. It does not authorize a release branch, production merge, tag, workflow dispatch, crates.io publication, npm publication, or GitHub Release.

## Verification

- `./scripts/version-sync.sh verify 0.24.1` — pass
- `python3 scripts/verify-publish-order.py` — pass
- `python3 scripts/verify-publish-test-scope.py` — pass
- `cargo fmt --all --check` — pass
- `cargo check --workspace --exclude amari-gpu --all-features` — pass
- `cargo test --workspace --exclude amari-gpu` — pass
- `cargo test -p amari-discovery-macros --all-features` — pass, including trybuild UI coverage
- `git diff --check` — pass

## Note

The first workspace test run correctly failed with `structural, semantic, and probe versions must match`: `version-sync.sh` had synchronized the semantic/probe catalogs, while the generated structural catalog still reported `0.24.0`. I regenerated `catalog/generated.json` with the checked-in deterministic generator and reran the full workspace suite successfully.
