### PR TITLE
fix: restore discovery no-default test gate

### DIFF
--- a/amari-discovery/src/probes/mod.rs
+++ b/amari-discovery/src/probes/mod.rs
@@ -45,9 +45,11 @@ pub use surreal::{
 };
 pub use tropical::{TropicalViterbiOutput, TropicalViterbiRequest};
 
+#[cfg(feature = "standard-probes")]
+use crate::ProbeSchemaDocument;
 use crate::{
     Catalog, DiscoveryError, DiscoveryResult, ProbeBackend, ProbeId, ProbeSchemaBinding,
-    ProbeSchemaDocument, ProbeSchemaRegistration, ProbeWireSchemaRegistry, ResourceObservations,
+    ProbeSchemaRegistration, ProbeWireSchemaRegistry, ResourceObservations,
 };
 
 /// Caller-selected ceilings for cooperative in-process probe execution.

--- a/amari-discovery/tests/wire_schema_registry.rs
+++ b/amari-discovery/tests/wire_schema_registry.rs
@@ -30,6 +30,7 @@ fn executable_ids() -> Vec<ProbeId> {
     ProbeEngine::new().unwrap().executable_probe_ids()
 }
 
+#[cfg(feature = "standard-probes")]
 fn registrations(catalog: &Catalog, executable_ids: &[ProbeId]) -> Vec<ProbeSchemaRegistration> {
     catalog
         .probes()
@@ -513,6 +514,7 @@ fn constraint_ids(document: &ProbeSchemaDocument) -> Vec<String> {
         .collect()
 }
 
+#[cfg(feature = "standard-probes")]
 #[test]
 fn registry_resolves_every_executable_probe_and_declares_non_executable() {
     let catalog = Catalog::embedded().unwrap();
@@ -554,6 +556,7 @@ fn registry_resolves_every_executable_probe_and_declares_non_executable() {
     assert!(registry.document(&descriptor.input_schema).is_none());
 }
 
+#[cfg(feature = "standard-probes")]
 #[test]
 fn duplicate_schema_id_is_catalog_corruption() {
     let catalog = Catalog::embedded().unwrap();
@@ -568,6 +571,7 @@ fn duplicate_schema_id_is_catalog_corruption() {
     assert_eq!(error.kind(), "catalog_corruption");
 }
 
+#[cfg(feature = "standard-probes")]
 #[test]
 fn role_and_version_mismatches_are_catalog_corruption() {
     let catalog = Catalog::embedded().unwrap();
@@ -637,6 +641,7 @@ fn registration_probe_must_own_the_document_descriptor() {
     assert_eq!(error.kind(), "catalog_corruption");
 }
 
+#[cfg(feature = "standard-probes")]
 #[test]
 fn executable_probe_requires_exactly_one_input_and_one_output() {
     let catalog = Catalog::embedded().unwrap();


### PR DESCRIPTION
## Summary

Fixes the `amari-discovery --no-default-features` test/build path exposed by the 0.24.1 release matrix.

- Gates the four wire-schema registry tests that require compiled `standard-probes` registrations behind `#[cfg(feature = "standard-probes")]`.
- Gates their shared registration helper the same way, avoiding dead-code warnings in the no-default test target.
- Gates the `ProbeSchemaDocument` import in `src/probes/mod.rs`, which is only used by the standard-probes schema-document resolver.

No probe behavior, public API, catalog artifact, protocol schema, or version metadata changes.

## Release context

The 0.24.1 release verification matrix inherited the 0.24.0 `no-default-features` gate. That gate correctly caught that four tests added with the wire-schema authority work assumed 13 executable probes even when `standard-probes` is disabled. In the no-default build, the engine intentionally reports zero executable probes and the wire-schema registry compiles to an empty registration set.

## Verification

- Reproduced failure first: `cargo test -p amari-discovery --no-default-features --test wire_schema_registry` — 4 failed / 5 passed
- `cargo test -p amari-discovery --no-default-features --test wire_schema_registry` — pass, 5/5
- `cargo check -p amari-discovery --no-default-features` — pass without the prior unused-import warning
- `cargo test -p amari-discovery --all-features --test wire_schema_registry` — pass, 9/9
- `cargo test -p amari-discovery --all-features` — pass
- `cargo test -p amari-discovery --no-default-features` — pass
- `cargo clippy -p amari-discovery -p amari-discovery-macros --all-features --lib --bins --tests -- -D warnings` — pass
- `cargo fmt --all --check` — pass
- `git diff --check` — pass
