### PR TITLE
chore: backmerge v0.24.1 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.1] - Unreleased
+## [0.24.1] - 2026-08-04
 
 ### Added
 

--- a/docs/releases/v0.24.1-publication-evidence.md
+++ b/docs/releases/v0.24.1-publication-evidence.md
@@ -1,0 +1,40 @@
+# Amari v0.24.1 — Publication Evidence
+
+Date: 2026-08-04. Tag: `v0.24.1` (annotated) on `b4fd692` (master, merge commit of PR #234).
+
+## Gates
+
+- **Gate A**: explicit user approval to merge PR #234 (`release/v0.24.1` @ `f2372e2` → `master`), merge commit. Merged as `b4fd692`.
+- **Gate B**: explicit user approval to tag `v0.24.1` on `b4fd692` and push, triggering `.github/workflows/publish.yml`; GitHub Release creation included in the approved actions.
+
+## Publication workflow
+
+- Run: https://github.com/Industrial-Algebra/Amari/actions/runs/30955877569
+- Validate and Test: PASS (Rust 1.97.1, fmt/clippy/tests/docs incl. the two documented all-target test-lint allowances; `amari-gpu` runtime tests excluded per exception).
+- Publish to crates.io: PASS (25m21s) — ordered publish with per-crate dry-run and index sleeps.
+- Build WASM Package: PASS.
+- Publish to npm: FAILED (auth, exit 1) — manual npm publication by Justin pending; identical disposition to v0.24.0.
+
+## Registry verification
+
+- crates.io sparse index: **27/27 crates at 0.24.1** (26 prior + new `amari-discovery-macros`):
+  amari, amari-automata, amari-calculus, amari-cgt, amari-core, amari-discovery, amari-discovery-macros, amari-dual, amari-dynamics, amari-enumerative, amari-flynn, amari-flynn-macros, amari-functional, amari-fusion, amari-gpu, amari-holographic, amari-info-geom, amari-measure, amari-network, amari-optimization, amari-probabilistic, amari-relativistic, amari-rewrite, amari-surcomplex, amari-surreal, amari-topology, amari-tropical.
+  (`amari-wasm` is npm-only by design.)
+- Consumer smoke: `cargo add amari@0.24.1 amari-discovery@0.24.1 amari-discovery-macros@0.24.1` + `cargo check` — PASS.
+- Binary smoke: `cargo install amari-discovery --version 0.24.1` — PASS. Installed `amari 0.24.1` verified:
+  - `amari probe schema amari-probe:core:geometric-product:v1 --direction input` — schema document + canonical hash `3d7f1d75…73a26`.
+  - `amari probe list` — 13 executable probes; `tropical:shortest-path` honestly reported unavailable.
+  - `amari probe run amari-probe:cgt:nim-sum:v1 --input <file>` — full envelope: schema IDs, catalog version 0.24.1, input hash, provenance. (Note: `--input` takes a file path containing JSON, per bounded-read design.)
+- npm: pending Justin's manual publish of `@justinelliottcobb/amari-wasm@0.24.1`.
+
+## GitHub Release
+
+- https://github.com/Industrial-Algebra/Amari/releases/tag/v0.24.1
+
+## Backmerge
+
+- This PR: `chore/v0.24.1-backmerge` → `develop`, merge commit (never squash).
+
+## Pre-merge verification matrix (at release head `f2372e2`)
+
+Recorded in full in the PR #234 body: fmt, `git diff --check`, version-sync verify, cargo metadata audit, workflow/crate/publish-order/test-scope/sharding verifiers, catalog + WASM surface determinism (hash `97684d902767a412e740b2e83d30ebec40e56dec61a35008766bf922f06ed5db`), discovery all-features + no-default-features tests, workspace tests excluding `amari-gpu`, scoped and publish-workflow clippy, rustdoc `-D warnings`, `cargo package` + `cargo publish --dry-run` for `amari-core` and `amari-discovery-macros` on Rust 1.97.1.


### PR DESCRIPTION
Mandatory master → develop backmerge after the v0.24.1 release (merge commit, never squash, per AGENTS.md gitflow).

## Contents
- Merge of origin/master (b4fd692, v0.24.1 release) into develop — clean, CHANGELOG date line only.
- docs/releases/v0.24.1-publication-evidence.md — Gate A/B record, workflow run, registry verification (27/27 crates.io), smoke tests, npm status.

## Release status
- Tag v0.24.1 on b4fd692; publish workflow run 30955877569: validation PASS, crates.io PASS (27 crates), WASM build PASS, npm step failed on auth (manual publish by Justin pending, same as v0.24.0).
- GitHub Release: https://github.com/Industrial-Algebra/Amari/releases/tag/v0.24.1

Merge this PR with a **merge commit** to preserve graph ancestry.